### PR TITLE
Fix npm backend CLI bin

### DIFF
--- a/packages/node/src/scripts/backend-server.ts
+++ b/packages/node/src/scripts/backend-server.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { runBackendStdioServer } from "../backend/stdio-server.js";
 
 await runBackendStdioServer({


### PR DESCRIPTION
## Summary
- add a Node shebang to the backend stdio CLI entrypoint so npm keeps the bin during publish

## Validation
- npm run node:build
- npm run node:bundle
- npm pack --dry-run --json from packages/node
