### PR TITLE
Normalize npm backend bin metadata

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -51,7 +51,7 @@
   },
   "types": "./dist/src/index.d.ts",
   "bin": {
-    "codex-chatgpt-control-backend": "./dist/src/scripts/backend-server.js"
+    "codex-chatgpt-control-backend": "dist/src/scripts/backend-server.js"
   },
   "files": [
     "dist/src/**/*.js",


### PR DESCRIPTION
## Summary
- normalize the npm bin target path so npm does not auto-correct package metadata during publish

## Validation
- npm run node:build
- npm run node:bundle
- npm pack --dry-run --json from packages/node
- npm publish --dry-run --tag next --access public from packages/node
