### PR TITLE
[codex] Support localized ChatGPT composer selectors

### DIFF
--- a/packages/node/src/dom/selectors.ts
+++ b/packages/node/src/dom/selectors.ts
@@ -20,14 +20,14 @@ export function composerTextbox(page: PageLike): LocatorLike {
   if (typeof page.getByRole !== "function") {
     return requiredLocator(page, "[contenteditable='true'], textarea");
   }
-  return page.getByRole("textbox", { name: "Chat with ChatGPT" });
+  return firstRoleLocator(page, "textbox", ["Chat with ChatGPT", "与 ChatGPT 聊天"]);
 }
 
 export function sendButton(page: PageLike): LocatorLike {
   if (typeof page.getByRole !== "function") {
     return requiredLocator(page, "button[aria-label*='Send']");
   }
-  return page.getByRole("button", { name: "Send prompt" });
+  return firstRoleLocator(page, "button", ["Send prompt", "发送提示"]);
 }
 
 export function searchChatsButton(page: PageLike): LocatorLike {
@@ -82,4 +82,64 @@ export function requiredLocator(page: PageLike, selector: string): LocatorLike {
     throw new Error(`Page does not support locator("${selector}")`);
   }
   return page.locator(selector);
+}
+
+function firstRoleLocator(page: PageLike, role: string, names: string[]): LocatorLike {
+  const locators = names.map(name => page.getByRole!(role, { name }));
+  return {
+    click: options => withFirstLocator(locators, locator => locator.click?.(options)),
+    fill: (value, options) => withFirstLocator(locators, locator => locator.fill?.(value, options)),
+    textContent: options => withFirstLocator(locators, locator => locator.textContent?.(options)),
+    innerText: options => withFirstLocator(locators, locator => locator.innerText?.(options)),
+    innerHTML: options => withFirstLocator(locators, locator => locator.innerHTML?.(options)),
+    count: async () => {
+      let total = 0;
+      for (const locator of locators) {
+        total += await locator.count?.().catch(() => 0) ?? 0;
+      }
+      return total;
+    },
+    first: () => firstRoleLocator(page, role, names).nth?.(0) ?? locators[0]!,
+    last: () => locators.at(-1)?.last?.() ?? locators.at(-1)!,
+    nth: index => locators[index]?.nth?.(index) ?? locators[index] ?? locators[0]!,
+    isVisible: options => withFirstLocator(locators, locator => locator.isVisible?.(options)),
+    evaluate: fn => withFirstLocator(locators, locator => locator.evaluate?.(fn)),
+    locator: selector => withFirstLocatorSync(locators, locator => locator.locator?.(selector)),
+    filter: options => withFirstLocatorSync(locators, locator => locator.filter?.(options)),
+    getByRole: (nestedRole, options) => withFirstLocatorSync(locators, locator => locator.getByRole?.(nestedRole, options)),
+    getByText: (text, options) => withFirstLocatorSync(locators, locator => locator.getByText?.(text, options)),
+    setInputFiles: paths => withFirstLocator(locators, locator => locator.setInputFiles?.(paths))
+  };
+}
+
+async function withFirstLocator<T>(
+  locators: LocatorLike[],
+  action: (locator: LocatorLike) => Promise<T> | undefined
+): Promise<T> {
+  const locator = await resolveFirstLocator(locators);
+  const result = action(locator);
+  if (result === undefined) {
+    throw new Error("Matched locator does not support the requested action.");
+  }
+  return result;
+}
+
+function withFirstLocatorSync(
+  locators: LocatorLike[],
+  action: (locator: LocatorLike) => LocatorLike | undefined
+): LocatorLike {
+  for (const locator of locators) {
+    const result = action(locator);
+    if (result !== undefined) return result;
+  }
+  return locators[0]!;
+}
+
+async function resolveFirstLocator(locators: LocatorLike[]): Promise<LocatorLike> {
+  for (const locator of locators) {
+    if (locator.count === undefined) return locator;
+    const count = await locator.count().catch(() => 0);
+    if (count > 0) return locator;
+  }
+  return locators[0]!;
 }

--- a/packages/node/tests/unit/messages.test.ts
+++ b/packages/node/tests/unit/messages.test.ts
@@ -251,6 +251,22 @@ describe("extractMessagesFromHtml", () => {
     expect(result.warnings.join(" ")).toContain("completion was not confirmed");
   });
 
+  it("composes and submits with localized ChatGPT composer labels", async () => {
+    const page = askWaitFallbackPage("Reply exactly fallback-ok.", "fallback-ok", {
+      textboxName: "与 ChatGPT 聊天",
+      sendButtonName: "发送提示"
+    });
+
+    const result = await askMessage({ page }, {
+      text: "Reply exactly fallback-ok.",
+      wait: { timeoutMs: 5, stableMs: 0, pollMs: 1 },
+      read: { format: "normalized_text" }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output_text).toBe("fallback-ok");
+  });
+
   it("extracts assistant Markdown by default without flattening structure", () => {
     const html = readFileSync("tests/fixtures/chat-rich-response.html", "utf8");
     const messages = extractMessagesFromHtml(html);
@@ -493,9 +509,15 @@ function contentPage(html: string, onClick?: () => void): PageLike {
   };
 }
 
-function askWaitFallbackPage(prompt: string, answer: string): PageLike {
+function askWaitFallbackPage(
+  prompt: string,
+  answer: string,
+  labels: { textboxName?: string; sendButtonName?: string } = {}
+): PageLike {
   let composerText = "";
   let submitted = false;
+  const textboxName = labels.textboxName ?? "Chat with ChatGPT";
+  const sendButtonName = labels.sendButtonName ?? "Send prompt";
   const textbox: LocatorLike = {
     click: async () => {},
     fill: async text => {
@@ -564,8 +586,8 @@ function askWaitFallbackPage(prompt: string, answer: string): PageLike {
     },
     getByRole: (role, options) => {
       const name = String(options?.name ?? "");
-      if (role === "textbox") return textbox;
-      if (role === "button" && /Send prompt/.test(name)) return send;
+      if (role === "textbox" && name === textboxName) return textbox;
+      if (role === "button" && name === sendButtonName) return send;
       if (role === "button" && /Copy response/.test(name)) return noResponseActions;
       return noResponseActions;
     },


### PR DESCRIPTION
## Summary

Adds localized ChatGPT composer selector fallbacks for Chinese UI labels so browser-control workflows can compose and submit prompts when ChatGPT exposes `与 ChatGPT 聊天` and `发送提示` instead of the English labels.

## Root Cause

The Node runtime only targeted the English accessible names `Chat with ChatGPT` and `Send prompt`. In a Chinese ChatGPT session, the bridge could bootstrap and create a new thread, but `messages.ask` failed because the textbox selector did not match.

## Changes

- Add role-locator fallback support for multiple accessible names.
- Use English and Chinese labels for the composer textbox and send button.
- Add a unit test covering localized composer and submit labels.

## Validation

- `npm test -- tests/unit/messages.test.ts`
- `npm test`
- Live smoke through Codex browser bridge: `runner.run` with `reply with the word hi` returned `output_text: hi`.
