### PR TITLE
Fix cross-platform absolute attach path validation

### DIFF
--- a/packages/node/src/commands/files.ts
+++ b/packages/node/src/commands/files.ts
@@ -1,5 +1,5 @@
 import { access, readFile, stat } from "node:fs/promises";
-import { basename, resolve } from "node:path";
+import { basename, posix, resolve, win32 } from "node:path";
 import { constants } from "node:fs";
 import { waitForDownloadFromClick } from "../browser/downloads.js";
 import { resultError, resultOk } from "../errors.js";
@@ -26,7 +26,7 @@ export async function validateAttachPaths(paths: string[]): Promise<AttachedFile
   const files: AttachedFile[] = [];
 
   for (const path of paths) {
-    if (!path.startsWith("/")) {
+    if (!isSupportedAbsolutePath(path)) {
       throw new Error(`File attachment path must be absolute: ${path}`);
     }
 
@@ -45,6 +45,10 @@ export async function validateAttachPaths(paths: string[]): Promise<AttachedFile
   }
 
   return files;
+}
+
+function isSupportedAbsolutePath(path: string): boolean {
+  return posix.isAbsolute(path) || win32.isAbsolute(path);
 }
 
 export async function attachFiles(

--- a/packages/node/tests/unit/files.test.ts
+++ b/packages/node/tests/unit/files.test.ts
@@ -6,8 +6,27 @@ import { attachFiles, downloadLatestFile, validateAttachPaths } from "../../src/
 import type { LocatorLike, PageLike } from "../../src/types.js";
 
 describe("validateAttachPaths", () => {
-  it("rejects relative paths", async () => {
+  it("rejects POSIX relative paths", async () => {
     await expect(validateAttachPaths(["notes.txt"])).rejects.toThrow(/absolute/);
+    await expect(validateAttachPaths(["notes/file.md"])).rejects.toThrow(/absolute/);
+  });
+
+  it("rejects Windows drive-relative paths", async () => {
+    await expect(validateAttachPaths(["C:Users\\notes.md"])).rejects.toThrow(/absolute/);
+  });
+
+  it("rejects empty paths", async () => {
+    await expect(validateAttachPaths([""])).rejects.toThrow(/absolute/);
+  });
+
+  it("accepts POSIX absolute paths for filesystem validation", async () => {
+    await expectPathPassesAbsoluteValidation("/home/codex/missing-file.md");
+    await expectPathPassesAbsoluteValidation("/mnt/d/WSL/missing-file.md");
+  });
+
+  it("accepts Windows drive absolute paths for filesystem validation", async () => {
+    await expectPathPassesAbsoluteValidation("C:\\Users\\codex\\missing-file.md");
+    await expectPathPassesAbsoluteValidation("D:\\WSL\\Codex\\missing-file.md");
   });
 
   it("returns file metadata for readable files", async () => {
@@ -20,6 +39,15 @@ describe("validateAttachPaths", () => {
     ]);
   });
 });
+
+async function expectPathPassesAbsoluteValidation(path: string): Promise<void> {
+  try {
+    await validateAttachPaths([path]);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toMatch(/must be absolute/);
+  }
+}
 
 describe("attachFiles", () => {
   it("uses ChatGPT's Add photos & files chooser when the file input is hidden", async () => {


### PR DESCRIPTION
## Summary

This PR fixes cross-platform absolute attach path validation by accepting both POSIX and Windows absolute paths.

* Use both `posix.isAbsolute(path)` and `win32.isAbsolute(path)` for attach path validation.
* Preserve rejection of relative paths.
* Add/update coverage for POSIX absolute paths, Windows drive absolute paths, relative paths, and empty inputs.

## Problem

`validateAttachPaths` previously relied on a POSIX-style absolute path check. This works for paths such as `/home/...` and `/mnt/d/...`, but Windows native absolute paths such as `C:\Users\...\file.md` or `D:\WSL\...\file.md` could be rejected before filesystem validation, especially when running under a non-Windows Node environment.

## Root cause

The validation treated absolute paths as POSIX-style paths only. As a result, Windows drive absolute paths were not recognized as absolute paths in cross-platform scenarios.

## Fix

The validation now accepts both:

* `posix.isAbsolute(path)`
* `win32.isAbsolute(path)`

This allows valid absolute paths from both platforms to proceed to filesystem validation while still rejecting relative or malformed inputs.

## Tests

Validated locally:

* `npm test` — PASS, 27 files / 178 tests
* `npm run build` — PASS

Test coverage includes:

* POSIX absolute paths
* Windows drive absolute paths
* POSIX relative paths
* Windows relative paths
* Empty inputs

## Notes

This PR only addresses attach path validation.

It does not change browser bridge behavior, live-smoke behavior, Skill installation, ChatGPT session control, or any host runtime assumptions.
