### PR TITLE
Prepare 0.2.0 alpha release

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -2,17 +2,7 @@ name: codex-chatgpt-control-parity
 
 on:
   push:
-    paths:
-      - ".github/workflows/parity.yml"
-      - "package.json"
-      - "packages/node/**"
-      - "packages/python/**"
   pull_request:
-    paths:
-      - ".github/workflows/parity.yml"
-      - "package.json"
-      - "packages/node/**"
-      - "packages/python/**"
 
 jobs:
   node-backend-contracts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0-alpha.1
+
+- Adds cross-platform Windows and macOS path handling, subprocess gates, and public CI coverage.
+- Adds broader localized ChatGPT label detection through the shared locale registry.
+- Adds untrusted-output envelopes, integrity sidecars, and expanded diagnostics contracts.
+
 ## 0.1.0-alpha.1
 
 - Initial public source preparation for `codex-chatgpt-control`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -115,4 +115,4 @@ Best-practice backend story: keep the Node runtime as the authoritative browser 
 2. Build wheel and sdist from `packages/python`.
 3. Run `twine check`.
 4. Install the wheel in a fresh virtual environment.
-5. Publish `0.1.0a1` only after the backend distribution story is documented and tested.
+5. Publish only after the backend distribution story is documented and tested.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-chatgpt-control-repo",
-  "version": "0.1.0-alpha.1",
+  "version": "0.2.0-alpha.1",
   "private": true,
   "description": "Public source repo for the unofficial codex-chatgpt-control SDK.",
   "type": "module",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0-alpha.1
+
+- Adds Windows-safe host path validation and cross-platform backend gates.
+- Adds localized ChatGPT selector support through the locale-label registry.
+- Adds untrusted-output safety envelopes and integrity sidecar verification helpers.
+
 ## 0.1.0-alpha.1
 
 - Initial public alpha package metadata and source layout.

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-chatgpt-control",
-  "version": "0.1.0-alpha.1",
+  "version": "0.2.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-chatgpt-control",
-      "version": "0.1.0-alpha.1",
+      "version": "0.2.0-alpha.1",
       "devDependencies": {
         "@types/node": "^24.13.1",
         "ajv": "^8.17.1",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-chatgpt-control",
-  "version": "0.1.0-alpha.1",
+  "version": "0.2.0-alpha.1",
   "description": "Unofficial SDK for Codex agents controlling visible ChatGPT web sessions.",
   "type": "module",
   "license": "MIT",

--- a/packages/python/CHANGELOG.md
+++ b/packages/python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0a1
+
+- Adds Windows parity coverage for backend command splitting, subprocess handling, and integrity verification.
+- Adds Python access to untrusted-output envelopes and integrity sidecar verification.
+- Keeps the Python package aligned with the Node backend protocol used by the localized selector and diagnostics updates.
+
 ## 0.1.0a1
 
 - Initial Python parity client metadata for the public source repo.

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-chatgpt-control"
-version = "0.1.0a1"
+version = "0.2.0a1"
 description = "Python SDK for Codex agents controlling visible ChatGPT web sessions through a local backend."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/python/tests/test_untrusted_output.py
+++ b/packages/python/tests/test_untrusted_output.py
@@ -56,7 +56,7 @@ class UntrustedOutputTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             target = root / "report.json"
-            target.write_text("original\n", encoding="utf-8")
+            target.write_bytes(b"original\n")
             sidecar = root / "report.json.meta.json"
             sidecar.write_text(json.dumps({
                 "schemaVersion": "chatgpt.browser_control.integrity.v1",
@@ -70,7 +70,7 @@ class UntrustedOutputTests(unittest.TestCase):
             }), encoding="utf-8")
 
             self.assertEqual(verify_integrity_sidecar(sidecar)["ok"], True)
-            target.write_text("tampered\n", encoding="utf-8")
+            target.write_bytes(b"tampered\n")
 
             result = verify_integrity_sidecar(sidecar)
             self.assertEqual(result["ok"], False)


### PR DESCRIPTION
## Summary
- run public parity on every PR/push so required checks are always present
- fix the Python integrity-sidecar test so Windows newline translation does not cause a false failure
- bump release metadata to npm 0.2.0-alpha.1 / PyPI 0.2.0a1 and document the release notes

## Source
Generated from private source commit 3df2639 via the managed public exporter.

## Validation
- node /Users/adamallcock/Documents/Coding/llm-chatgpt/tools/public-export/export-public.mjs --check
- npm run node:build
- npm run node:contracts
- npm run python:test
- npm run python:compile
- npm run python:pyright
- npm run release:check-names
- npm run node:test
- npm run node:bundle
- npm run plugin:validate
- npm run plugin:check
- npm run python:ordinary-shell