### PR TITLE
[codex] export long response capture and release gates

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -37,6 +37,7 @@ jobs:
       - run: npm run bundle:live-smoke
       - run: npm run bundle:backend
       - run: npm run contract:validate
+      - run: npm run docs:drift
       - run: npm run parity:fixtures
       - run: npm run parity:suite
       - run: npm run test:backend-conformance

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -29,6 +29,7 @@ jobs:
       - run: npm run bundle:live-smoke
       - run: npm run bundle:backend
       - run: npm run contract:validate
+      - run: npm run docs:drift
       - run: npm run parity:fixtures
       - run: npm run parity:suite
       - run: npm run test:backend-conformance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: release preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install Node dependencies
+        run: npm --prefix packages/node ci
+      - name: Install Python release tools
+        run: python -m pip install --upgrade build twine
+      - run: npm run release:check-version
+      - run: npm run release:check-names
+      - run: npm run node:test
+      - run: npm run node:build
+      - run: npm run node:bundle
+      - run: npm run node:contracts
+      - run: npm run python:test
+      - run: npm run python:compile
+      - run: npm run python:pyright
+      - run: npm run python:ordinary-shell
+      - run: npm run plugin:validate
+      - run: npm run plugin:check
+      - run: npm run release:check-node-pack
+      - name: Build and check Python distributions
+        run: |
+          rm -rf packages/python/.venv dist/python
+          npm run release:build-python
+          npm run release:check-python
+
+  publish-npm:
+    name: publish npm
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - run: npm --prefix packages/node ci
+      - run: npm run release:check-version
+      - run: npm run node:build
+      - run: npm run node:bundle
+      - run: npm run release:check-node-pack
+      - name: Publish Node package to npm
+        working-directory: packages/node
+        run: npm publish --provenance --access public --tag next
+
+  publish-pypi:
+    name: publish PyPI
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --upgrade build twine
+      - run: npm run release:check-version
+      - name: Build and check Python distributions
+        run: |
+          rm -rf dist/python
+          npm run release:build-python
+          npm run release:check-python
+      - name: Publish Python package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/python

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,9 @@ npm run node:bundle
 npm run node:contracts
 npm run python:test
 npm run python:compile
+npm run release:check-version
 npm run release:check-names
+npm run release:check-node-pack
 ```
 
 For Node package work:
@@ -51,7 +53,9 @@ npm run build
 npm run bundle
 npm run bundle:backend
 npm run contract:validate
+npm run docs:drift
 npm run parity:fixtures
+npm run parity:suite
 npm run test:backend-conformance
 ```
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,9 @@ npm run build
 npm run bundle
 npm run bundle:backend
 npm run contract:validate
+npm run docs:drift
 npm run parity:fixtures
+npm run parity:suite
 ```
 
 Run deterministic Python gates after the backend bundle exists:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -9,7 +9,8 @@ status: draft
 
 ## Source Alpha
 
-1. Keep the repository public and packages unpublished.
+1. Keep the private repository as the source of truth and publish only from the
+   generated public repository.
 2. Run deterministic Node and Python parity gates.
 3. Build and validate the Codex plugin runtime:
 
@@ -89,18 +90,78 @@ contributors can review the public-facing history.
 7. Run live ChatGPT smoke tests only with explicit approval and non-sensitive
    prompts.
 
+## Trusted Publishing
+
+npm and PyPI releases are published from `.github/workflows/release.yml` using
+GitHub Actions OIDC trusted publishing. Do not store npm or PyPI API tokens in
+GitHub secrets for this workflow.
+
+The registry-side trusted publisher configuration must match the public
+repository exactly:
+
+- Repository: `adamallcock/codex-chatgpt-control`
+- Workflow filename: `release.yml`
+- Environment: `release`
+- npm package: `codex-chatgpt-control`
+- PyPI project: `codex-chatgpt-control`
+
+The `release` GitHub environment should require human approval. That keeps tag
+creation reversible until the protected publish jobs start, while still making
+the package upload itself reproducible and tokenless.
+
+## Release Tag Flow
+
+1. Merge the generated public PR after required public checks pass.
+2. Confirm versions and registry availability on public `main`:
+
+   ```bash
+   npm run release:check-version
+   npm run release:check-names
+   ```
+
+3. Create and push a `v*` tag that matches the Node package version:
+
+   ```bash
+   git tag v0.2.0-alpha.1
+   git push origin v0.2.0-alpha.1
+   ```
+
+4. Approve the `release` environment deployment in GitHub Actions.
+5. Let the workflow publish npm and PyPI independently. If one registry publish
+   succeeds and the other fails, rerun only the failed job.
+6. Verify the published packages:
+
+   ```bash
+   npm view codex-chatgpt-control version dist-tags --json
+   python - <<'PY'
+   import json, urllib.request
+   with urllib.request.urlopen("https://pypi.org/pypi/codex-chatgpt-control/json", timeout=10) as r:
+       data = json.load(r)
+   print(data["info"]["version"])
+   PY
+   ```
+
 ## npm Alpha
 
 1. Recheck registry state immediately before publishing:
 
    ```bash
+   npm run release:check-version
    npm run release:check-names
    ```
 
-2. Remove `"private": true` from `packages/node/package.json`.
-3. Run `npm pack --dry-run --json` and inspect the allowlist.
-4. Install the packed tarball in a fresh temp project.
-5. Publish with an alpha tag only after trusted publishing or login is ready.
+2. Build and inspect the package allowlist:
+
+   ```bash
+   npm --prefix packages/node ci
+   npm run node:build
+   npm run node:bundle
+   npm run release:check-node-pack
+   ```
+
+3. Publish through the release workflow with `--tag next`; do not publish local
+   shells unless the trusted-publishing path is unavailable and the release
+   owner explicitly approves a one-off fallback.
 
 ## PyPI Alpha
 
@@ -109,10 +170,19 @@ Best-practice backend story: keep the Node runtime as the authoritative browser 
 1. Recheck registry state immediately before publishing:
 
    ```bash
+   npm run release:check-version
    npm run release:check-names
    ```
 
 2. Build wheel and sdist from `packages/python`.
-3. Run `twine check`.
+3. Run `twine check`:
+
+   ```bash
+   python -m pip install --upgrade build twine
+   rm -rf dist/python
+   npm run release:build-python
+   npm run release:check-python
+   ```
+
 4. Install the wheel in a fresh virtual environment.
-5. Publish only after the backend distribution story is documented and tested.
+5. Publish through the release workflow using PyPI trusted publishing.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,6 +7,28 @@ status: draft
 
 # Troubleshooting
 
+<!-- surface-drift:blocker-kind-coverage:start -->
+## Blocker Kind Coverage
+
+This section is checked by `npm run docs:drift`. Keep it aligned with `BlockerKind`, `explainCommandBlocker(...)`, command descriptors, and public troubleshooting coverage.
+
+- `browser_bridge_unavailable`: Browser bridge unavailable (category: `environment`, severity: `blocked`, user action: no)
+- `login_required`: Login required (category: `auth`, severity: `action_required`, user action: yes)
+- `captcha`: Captcha or human verification required (category: `auth`, severity: `action_required`, user action: yes)
+- `rate_limit`: Rate limited (category: `auth`, severity: `action_required`, user action: yes)
+- `modal`: Modal is blocking the page (category: `runtime`, severity: `action_required`, user action: yes)
+- `permission`: Permission required (category: `permission`, severity: `action_required`, user action: yes)
+- `confirmation`: Confirmation required (category: `user_confirmation`, severity: `action_required`, user action: yes)
+- `selector_drift`: Selector drift (category: `ui_drift`, severity: `blocked`, user action: no)
+- `artifact_unavailable`: Artifact unavailable (category: `artifact`, severity: `warning`, user action: no)
+- `artifact_selector_drift`: Artifact selector drift (category: `ui_drift`, severity: `blocked`, user action: no)
+- `artifact_download_unavailable`: Artifact download unavailable (category: `download`, severity: `warning`, user action: no)
+- `download_unavailable`: Download unavailable (category: `download`, severity: `warning`, user action: no)
+- `upload_failed`: Upload failed (category: `upload`, severity: `action_required`, user action: yes)
+- `not_found`: Target not found (category: `not_found`, severity: `warning`, user action: no)
+- `unknown`: Unknown blocker (category: `unknown`, severity: `blocked`, user action: no)
+<!-- surface-drift:blocker-kind-coverage:end -->
+
 ## `browser_bridge_unavailable`
 
 Expected from ordinary shells. Use it as a diagnostic that the command failed safely before touching browser state.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node:test": "npm --prefix packages/node test",
     "node:build": "npm --prefix packages/node run build",
     "node:bundle": "npm --prefix packages/node run bundle && npm --prefix packages/node run bundle:backend && npm --prefix packages/node run bundle:live-smoke",
-    "node:contracts": "npm --prefix packages/node run contract:validate && npm --prefix packages/node run parity:fixtures && npm --prefix packages/node run parity:suite",
+    "node:contracts": "npm --prefix packages/node run contract:validate && npm --prefix packages/node run docs:drift && npm --prefix packages/node run parity:fixtures && npm --prefix packages/node run parity:suite",
     "python:test": "node scripts/run-python-gate.mjs test",
     "python:compile": "node scripts/run-python-gate.mjs compile",
     "python:pyright": "node scripts/run-python-gate.mjs pyright",
@@ -16,7 +16,11 @@
     "plugin:build": "node scripts/build-plugin-runtime.mjs",
     "plugin:check": "node scripts/check-plugin-runtime.mjs",
     "plugin:validate": "node scripts/validate-plugin-layout.mjs",
-    "release:check-names": "node scripts/check-release-names.mjs"
+    "release:check-version": "node scripts/check-release-version.mjs",
+    "release:check-names": "node scripts/check-release-names.mjs",
+    "release:check-node-pack": "node scripts/check-node-pack.mjs",
+    "release:build-python": "python -m build --sdist --wheel --outdir dist/python packages/python",
+    "release:check-python": "python -m twine check dist/python/*"
   },
   "license": "MIT"
 }

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -103,5 +103,7 @@ npm run build
 npm run bundle
 npm run bundle:backend
 npm run contract:validate
+npm run docs:drift
 npm run parity:fixtures
+npm run parity:suite
 ```

--- a/packages/node/contracts/v1/fixtures/read-latest-clipped.json
+++ b/packages/node/contracts/v1/fixtures/read-latest-clipped.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "chatgpt.browser_control.command_result.v1",
+  "result": {
+    "ok": true,
+    "status": "ok",
+    "data": {
+      "role": "assistant",
+      "text": "abcdefghij",
+      "format": "markdown",
+      "source": "semantic_dom",
+      "fidelity": "semantic_markdown",
+      "captureLimit": {
+        "maxChars": 10,
+        "originalChars": 26,
+        "clipped": true
+      },
+      "warnings": [
+        "Response captured text was clipped by maxChars=10 from 26 characters."
+      ],
+      "markdown": "abcdefghij"
+    },
+    "output_text": "abcdefghij",
+    "warnings": [
+      "Response captured text was clipped by maxChars=10 from 26 characters."
+    ],
+    "context": {
+      "timestamp": "2026-06-10T00:00:00.000Z",
+      "url": "https://chatgpt.com/c/fixture-clipped"
+    }
+  }
+}

--- a/packages/node/contracts/v1/fixtures/run-timeout-partial.json
+++ b/packages/node/contracts/v1/fixtures/run-timeout-partial.json
@@ -38,7 +38,7 @@
       {
         "id": "interrupt-timeout",
         "type": "timeout",
-        "status": "timeout",
+        "status": "partial",
         "message": "The assistant response did not stabilize before the configured timeout.",
         "resume": {
           "supported": true,
@@ -70,7 +70,7 @@
       {
         "id": "ask",
         "command": "messages.ask",
-        "status": "timeout",
+        "status": "partial",
         "ok": false
       }
     ],

--- a/packages/node/contracts/v1/manifest.json
+++ b/packages/node/contracts/v1/manifest.json
@@ -87,6 +87,11 @@
       "schema": "commandResult"
     },
     {
+      "case": "read_latest_clipped",
+      "file": "read-latest-clipped.json",
+      "schema": "commandResult"
+    },
+    {
       "case": "report_redaction_default",
       "file": "report-redaction-default.json",
       "schema": "commandResult"

--- a/packages/node/contracts/v1/parity-suite.json
+++ b/packages/node/contracts/v1/parity-suite.json
@@ -189,6 +189,7 @@
         "files-preflight-success.json",
         "project-sources-plan-add.json",
         "primitive-bootstrap-blocker.json",
+        "read-latest-clipped.json",
         "workflow-ask-success.json"
       ],
       "sourceFiles": [
@@ -496,10 +497,10 @@
     },
     "messages.readLatest": {
       "surface": "workflows-primitives-diagnostics",
-      "fixtures": ["command-descriptors.json", "run-basic-success.json"],
+      "fixtures": ["command-descriptors.json", "run-basic-success.json", "read-latest-clipped.json"],
       "nodeTests": ["tests/unit/messages.test.ts", "tests/unit/client.test.ts"],
-      "pythonTests": ["tests/test_primitives.py"],
-      "docs": ["references/backend-protocol.md", "references/python-parity.md"]
+      "pythonTests": ["tests/test_primitives.py", "tests/test_models_complete.py"],
+      "docs": ["references/backend-protocol.md", "references/troubleshooting.md", "references/python-parity.md"]
     },
     "messages.waitAndRead": {
       "surface": "workflows-primitives-diagnostics",
@@ -628,6 +629,12 @@
       "id": "node.contract-validate",
       "cwd": "packages/node",
       "command": "npm run contract:validate",
+      "ciRequired": true
+    },
+    {
+      "id": "node.docs-drift",
+      "cwd": "packages/node",
+      "command": "npm run docs:drift",
       "ciRequired": true
     },
     {

--- a/packages/node/contracts/v1/surface-drift-policy.json
+++ b/packages/node/contracts/v1/surface-drift-policy.json
@@ -1,0 +1,210 @@
+{
+  "schemaVersion": "chatgpt.browser_control.surface_drift_policy.v1",
+  "backendCommandDescriptorExemptions": [
+    {
+      "command": "backend.version",
+      "date": "2026-06-10",
+      "reason": "Backend metadata command used by protocol clients, not a user-facing SDK command descriptor."
+    },
+    {
+      "command": "backend.health",
+      "date": "2026-06-10",
+      "reason": "Backend metadata command used by protocol clients, not a user-facing SDK command descriptor."
+    },
+    {
+      "command": "backend.capabilities",
+      "date": "2026-06-10",
+      "reason": "Backend metadata command used by protocol clients, not a user-facing SDK command descriptor."
+    },
+    {
+      "command": "runner.plan",
+      "date": "2026-06-10",
+      "reason": "Lower-level planning command covered by the runner facade and parity suite rather than a separate public descriptor."
+    },
+    {
+      "command": "runner.stream",
+      "date": "2026-06-10",
+      "reason": "Milestone streaming transport command covered by runner docs and tests rather than a separate descriptor."
+    },
+    {
+      "command": "openThread",
+      "date": "2026-06-10",
+      "reason": "Legacy workflow alias documented through threads.open and top-level workflow facade coverage."
+    },
+    {
+      "command": "readLatest",
+      "date": "2026-06-10",
+      "reason": "Legacy workflow alias documented through messages.readLatest and response capture coverage."
+    },
+    {
+      "command": "downloadLatest",
+      "date": "2026-06-10",
+      "reason": "Legacy workflow alias documented through files.downloadLatest and download coverage."
+    },
+    {
+      "command": "reports.create",
+      "date": "2026-06-10",
+      "reason": "Report helper command is represented by createReport/redacted report descriptor and report docs."
+    },
+    {
+      "command": "reports.redact",
+      "date": "2026-06-10",
+      "reason": "Report helper command is represented by createReport/redacted report descriptor and report docs."
+    },
+    {
+      "command": "reports.summarize",
+      "date": "2026-06-10",
+      "reason": "Report helper command is represented by createReport/redacted report descriptor and report docs."
+    },
+    {
+      "command": "commands",
+      "date": "2026-06-10",
+      "reason": "Command-discovery metadata command that returns descriptors; it is not itself a public descriptor."
+    },
+    {
+      "command": "describe",
+      "date": "2026-06-10",
+      "reason": "Command-discovery metadata command that returns descriptors; it is not itself a public descriptor."
+    },
+    {
+      "command": "help",
+      "date": "2026-06-10",
+      "reason": "Command-discovery metadata command that returns help text; it is not itself a public descriptor."
+    }
+  ],
+  "descriptorBackendCommandExemptions": [
+    {
+      "descriptor": "new-ask-read",
+      "date": "2026-06-10",
+      "reason": "Named sequence macro executed through runPlan, not a backend command."
+    },
+    {
+      "descriptor": "find-open-ask-read",
+      "date": "2026-06-10",
+      "reason": "Named sequence macro executed through runPlan, not a backend command."
+    },
+    {
+      "descriptor": "find-open-copy-latest",
+      "date": "2026-06-10",
+      "reason": "Named sequence macro executed through runPlan, not a backend command."
+    },
+    {
+      "descriptor": "attach-ask-read",
+      "date": "2026-06-10",
+      "reason": "Named sequence macro executed through runPlan, not a backend command."
+    },
+    {
+      "descriptor": "ask-and-download",
+      "date": "2026-06-10",
+      "reason": "Named sequence macro executed through runPlan, not a backend command."
+    },
+    {
+      "descriptor": "two-turn",
+      "date": "2026-06-10",
+      "reason": "Named sequence macro executed through runPlan, not a backend command."
+    },
+    {
+      "descriptor": "doctor-upload",
+      "date": "2026-06-10",
+      "reason": "Named sequence macro executed through runPlan, not a backend command."
+    },
+    {
+      "descriptor": "redacted-run-report",
+      "date": "2026-06-10",
+      "reason": "Named sequence macro executed through runPlan, not a backend command."
+    }
+  ],
+  "backendDispatchExemptions": [
+    {
+      "command": "runner.stream",
+      "date": "2026-06-10",
+      "reason": "Handled by BackendSession.stream instead of dispatchBackendCommand."
+    }
+  ],
+  "pythonFacadeExemptions": [
+    {
+      "command": "backend.version",
+      "date": "2026-06-10",
+      "reason": "Python exposes the generic BackendClient.request path for backend.version; health and capabilities have dedicated facades."
+    }
+  ],
+  "generatedBlockerDocs": [
+    "references/troubleshooting.md",
+    "../../tools/public-export/root/docs/troubleshooting.md",
+    "../../docs/troubleshooting.md"
+  ],
+  "docAnchors": [
+    {
+      "id": "backend-protocol-file-preflight",
+      "paths": ["references/backend-protocol.md"],
+      "terms": ["files.preflight", "does not open ChatGPT"]
+    },
+    {
+      "id": "backend-protocol-project-sources",
+      "paths": ["references/backend-protocol.md"],
+      "terms": ["projects.sources.planAdd", "confirmMutation"]
+    },
+    {
+      "id": "python-parity-file-preflight",
+      "paths": ["references/python-parity.md"],
+      "terms": ["chatgpt.files.preflight", "FilePreflightData"]
+    },
+    {
+      "id": "python-parity-project-sources",
+      "paths": ["references/python-parity.md"],
+      "terms": ["chatgpt.projects.sources", "plan_add"]
+    },
+    {
+      "id": "node-readme-blocker-explainability",
+      "paths": ["../../tools/public-export/root/packages/node/README.md", "README.md"],
+      "terms": ["explainBlocker", "structured blockers"]
+    },
+    {
+      "id": "node-readme-file-preflight",
+      "paths": ["../../tools/public-export/root/packages/node/README.md", "README.md"],
+      "terms": ["chatgpt.files.preflight", "opening ChatGPT"]
+    },
+    {
+      "id": "node-readme-project-sources",
+      "paths": ["../../tools/public-export/root/packages/node/README.md", "README.md"],
+      "terms": ["chatgpt.projects.sources.planAdd", "confirmMutation"]
+    },
+    {
+      "id": "python-readme-blocker-explainability",
+      "paths": [
+        "$pythonRoot/README.md",
+        "../../tools/public-export/root/packages/python/README.md",
+        "../python/README.md"
+      ],
+      "terms": ["explain_blocker", "structured fields"]
+    },
+    {
+      "id": "python-readme-file-preflight",
+      "paths": [
+        "$pythonRoot/README.md",
+        "../../tools/public-export/root/packages/python/README.md",
+        "../python/README.md"
+      ],
+      "terms": ["chatgpt.files.preflight", "preflight"]
+    },
+    {
+      "id": "python-readme-project-sources",
+      "paths": [
+        "$pythonRoot/README.md",
+        "../../tools/public-export/root/packages/python/README.md",
+        "../python/README.md"
+      ],
+      "terms": ["chatgpt.projects.sources.plan_add", "confirm_mutation"]
+    },
+    {
+      "id": "skill-file-preflight",
+      "paths": ["../../tools/public-export/root/skills/codex-chatgpt-control/SKILL.md", "../../skills/codex-chatgpt-control/SKILL.md"],
+      "terms": ["chatgpt.files.preflight", "does not open ChatGPT"]
+    },
+    {
+      "id": "skill-project-sources",
+      "paths": ["../../tools/public-export/root/skills/codex-chatgpt-control/SKILL.md", "../../skills/codex-chatgpt-control/SKILL.md"],
+      "terms": ["chatgpt.projects.sources.planAdd", "confirmMutation"]
+    }
+  ]
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,6 +27,7 @@
     "bundle:backend": "esbuild src/scripts/backend-server.ts --bundle --platform=node --format=esm --outfile=dist/codex-chatgpt-control-backend.mjs",
     "bundle:live-smoke": "esbuild src/scripts/live-smoke-module.ts --bundle --platform=node --format=esm --outfile=dist/codex-chatgpt-control-live-smoke.bundle.mjs",
     "contract:validate": "node scripts/validate-contract.mjs",
+    "docs:drift": "tsx src/scripts/check-surface-drift.ts",
     "parity:fixtures": "node scripts/check-parity-fixtures.mjs",
     "parity:suite": "tsx src/scripts/check-parity-suite.ts",
     "test:backend-conformance": "vitest run tests/unit/backend-conformance.test.ts",

--- a/packages/node/references/backend-protocol.md
+++ b/packages/node/references/backend-protocol.md
@@ -67,6 +67,8 @@ Current protocol error codes are:
 
 Browser-control blockers are not protocol errors. They are normal command or runner results with `status: "blocked"`, `status: "partial"`, or `status: "needs_confirmation"` plus blocker/interruption details.
 
+`status: "partial"` is the required result for incomplete response capture. A partial result may still include `output_text` and `data.responseText`, but consumers must treat that text as incomplete until a later wait confirms completion. Common causes are wait timeout after partial assistant text, active generation controls such as `Stop answering`, stopped-generation markers such as `Stopped thinking`, or a read fallback after the wait step could not confirm completion. Intentional capture clipping uses `data.captureLimit` plus warnings; it is separate from ChatGPT generation length.
+
 ## Streaming
 
 Streaming commands emit backend event lines until `completed` or `error`.
@@ -319,7 +321,9 @@ Required gates:
 
 ```bash
 npm run contract:validate
+npm run docs:drift
 npm run parity:fixtures
+npm run parity:suite
 npm run test:backend-conformance
 ```
 

--- a/packages/node/references/localization.md
+++ b/packages/node/references/localization.md
@@ -81,6 +81,7 @@ Localized — lives in `src/dom/locale/en.ts` (English) and per-locale files, sa
 | `signedInMarkers` | signed-in detection | sidebar/shell words |
 | `transientAssistant` | streaming placeholder filter | assistant streaming text ("Thinking", etc.) |
 | `stopControl` | "still generating" detection | stop-button text |
+| `stoppedAssistant` | interrupted-response detection | stopped assistant text ("Stopped thinking", etc.) |
 | `responseActions` | response-complete fallback | action-bar text |
 | `loginBlocker` / `captchaBlocker` / `rateLimitBlocker` | blocker classification | wall/challenge/limit copy |
 

--- a/packages/node/references/python-parity.md
+++ b/packages/node/references/python-parity.md
@@ -7,6 +7,7 @@ The Python package is a parity client over the TypeScript browser-control runtim
 - Shared fixtures live in `contracts/v1/fixtures/`.
 - `npm run contract:validate` validates every fixture against JSON Schema.
 - `npm run parity:fixtures` enforces fixture shape, stream settlement, and wire-field casing.
+- `npm run docs:drift` checks backend commands, command descriptors, blocker coverage, generated troubleshooting sections, Python facade coverage, and public-export doc anchors.
 - `npm run parity:suite` validates `contracts/v1/parity-suite.json`, which ties every public backend command and fixture to TypeScript tests, Python tests, docs, and deterministic CI gates.
 - Python tests load the same manifest and round-trip every JSON fixture through Pydantic models.
 
@@ -25,6 +26,8 @@ Wire fields stay TypeScript-compatible. Python exposes idiomatic aliases:
 | `totalBytes` | `total_bytes` |
 | `projectUrl` | `project_url` |
 | `displayPath` | `display_path` |
+
+Incomplete response capture is also shared contract behavior. Python must preserve `status == "partial"`, `output_text`, warnings, and any nested `data.captureLimit` dictionaries exactly as the TypeScript backend returns them. `partial` is not a protocol error: callers should inspect `data.complete` and run another wait/read on the same thread when they need final output.
 
 Generated-image behavior stays owned by the TypeScript runtime. Python exposes
 the same backend commands through `chatgpt.artifacts.list_latest(...)`,
@@ -135,6 +138,7 @@ Run from `packages/node`:
 ```bash
 npm run bundle:backend
 npm run contract:validate
+npm run docs:drift
 npm run parity:fixtures
 npm run parity:suite
 npm run test:backend-conformance

--- a/packages/node/references/troubleshooting.md
+++ b/packages/node/references/troubleshooting.md
@@ -1,5 +1,27 @@
 # Troubleshooting
 
+<!-- surface-drift:blocker-kind-coverage:start -->
+## Blocker Kind Coverage
+
+This section is checked by `npm run docs:drift`. Keep it aligned with `BlockerKind`, `explainCommandBlocker(...)`, command descriptors, and public troubleshooting coverage.
+
+- `browser_bridge_unavailable`: Browser bridge unavailable (category: `environment`, severity: `blocked`, user action: no)
+- `login_required`: Login required (category: `auth`, severity: `action_required`, user action: yes)
+- `captcha`: Captcha or human verification required (category: `auth`, severity: `action_required`, user action: yes)
+- `rate_limit`: Rate limited (category: `auth`, severity: `action_required`, user action: yes)
+- `modal`: Modal is blocking the page (category: `runtime`, severity: `action_required`, user action: yes)
+- `permission`: Permission required (category: `permission`, severity: `action_required`, user action: yes)
+- `confirmation`: Confirmation required (category: `user_confirmation`, severity: `action_required`, user action: yes)
+- `selector_drift`: Selector drift (category: `ui_drift`, severity: `blocked`, user action: no)
+- `artifact_unavailable`: Artifact unavailable (category: `artifact`, severity: `warning`, user action: no)
+- `artifact_selector_drift`: Artifact selector drift (category: `ui_drift`, severity: `blocked`, user action: no)
+- `artifact_download_unavailable`: Artifact download unavailable (category: `download`, severity: `warning`, user action: no)
+- `download_unavailable`: Download unavailable (category: `download`, severity: `warning`, user action: no)
+- `upload_failed`: Upload failed (category: `upload`, severity: `action_required`, user action: yes)
+- `not_found`: Target not found (category: `not_found`, severity: `warning`, user action: no)
+- `unknown`: Unknown blocker (category: `unknown`, severity: `blocked`, user action: no)
+<!-- surface-drift:blocker-kind-coverage:end -->
+
 ## `browser_bridge_unavailable`
 
 The backend process does not have access to a browser bridge. This is expected when a live-smoke command runs from an ordinary shell: it proves the protocol stayed alive and surfaced a structured blocker.
@@ -75,6 +97,20 @@ Attachment paths are validated against the backend host's operating system. If a
 ## Flattened Or Unreadable Response Capture
 
 Use `readLatest({ format: "markdown" })`, `copyLatest()`, or the default SDK `read: true` path for human-readable responses. Use `format: "normalized_text"` only for exact-string assertions or polling. Check `data.source`, `data.fidelity`, and `data.warnings`: clipboard output is highest fidelity, while DOM Markdown is semantic reconstruction. If Markdown capture degrades, return the command warning and save the structured `blocks` or diagnostic `html` representation instead of silently writing flattened text as a Markdown report.
+
+## Long Responses Return `partial`
+
+Long Pro, Thinking, Deep Research, or file-backed answers can take longer than the default wait window. Treat `status: "partial"` and `data.complete: false` as an incomplete capture even when `output_text` is non-empty. Re-run `messages.wait(...)` on the same thread with a larger timeout, then call `readLatest(...)` or `copyLatest(...)` only after completion is confirmed.
+
+Recommended long-answer wait:
+
+```ts
+wait: { timeoutMs: 600000, stableMs: 8000, pollMs: 1000 }
+```
+
+Active generation may appear as a visible or accessible-name control such as `Stop answering`, `Stop generating`, or `Stop streaming`. Stopped generation may appear as `Stopped thinking`. Treat all of those as incomplete states.
+
+`maxChars` limits captured text returned by the SDK. It does not control ChatGPT generation. When set and clipping occurs, inspect result warnings and `data.captureLimit`, then rerun without `maxChars` for full capture.
 
 ## Response Branch Ambiguity
 

--- a/packages/node/src/commands/messages.ts
+++ b/packages/node/src/commands/messages.ts
@@ -1,8 +1,8 @@
 import { readPageState } from "../browser/page-state.js";
 import { resultError, resultOk } from "../errors.js";
+import { latestAssistantTurnHasResponseActions, readAssistantGenerationState, type AssistantGenerationState } from "../dom/generation-state.js";
 import { countPageMessages, isTransientAssistantText, readLatestMessage, readLatestMessageText, readLatestMessageTextSnapshot, readMessages } from "../dom/messages.js";
-import { composerTextbox, copyResponseButtons, sendButton } from "../dom/selectors.js";
-import { localeLabels } from "../dom/locale-labels.js";
+import { composerTextbox, sendButton } from "../dom/selectors.js";
 import { normalizeLineBreaks, normalizeWhitespace } from "../dom/visible-text.js";
 import type {
   AskArgs,
@@ -27,7 +27,7 @@ import { bootstrap } from "./session.js";
 export type CompletionSnapshot = {
   textStableForMs: number;
   stableMs: number;
-  hasStopButton: boolean;
+  generation: AssistantGenerationState;
   hasResponseActions: boolean;
   latestText: string;
 };
@@ -52,7 +52,8 @@ export function isResponseComplete(snapshot: CompletionSnapshot): boolean {
   return snapshot.latestText.trim().length > 0
     && !isTransientAssistantText(snapshot.latestText)
     && snapshot.textStableForMs >= snapshot.stableMs
-    && !snapshot.hasStopButton
+    && !snapshot.generation.active
+    && !snapshot.generation.stopped
     && snapshot.hasResponseActions;
 }
 
@@ -375,9 +376,27 @@ export async function waitForMessage(
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      hasStopButton: await hasStopControl(page),
-      hasResponseActions: await hasResponseActions(page)
+      generation: await readAssistantGenerationState(page),
+      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
     };
+
+    if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
+      return withCommandOutputText({
+        ok: false,
+        status: "partial",
+        data: {
+          complete: false,
+          responseText: latestText,
+          assistantTurnCount: latestAssistantCount,
+          elapsedMs: Date.now() - started
+        },
+        warnings: [
+          "ChatGPT generation appears to have been stopped or interrupted before completion.",
+          ...snapshot.generation.signals.map(signal => `Generation state signal: ${signal}`)
+        ],
+        context: await contextFromPage(page)
+      } satisfies CommandResult<WaitData>);
+    }
 
     if (targetReached && isResponseComplete(snapshot)) {
       return withCommandOutputText(resultOk(
@@ -447,6 +466,7 @@ export async function readLatest(
   const data: ReadLatestData = { role, text: latest.text, format: latest.format };
   if (latest.source !== undefined) data.source = latest.source;
   if (latest.fidelity !== undefined) data.fidelity = latest.fidelity;
+  if (latest.captureLimit !== undefined) data.captureLimit = latest.captureLimit;
   if (latest.warnings !== undefined) data.warnings = latest.warnings;
   if (latest.markdown !== undefined) data.markdown = latest.markdown;
   if (latest.visibleText !== undefined) data.visibleText = latest.visibleText;
@@ -509,11 +529,15 @@ export async function askMessage(
       waitArgs.afterAssistantTurnCount = beforeAssistantTurnCount;
     }
     waitResult = await waitForMessage(env, waitArgs);
-    if (!waitResult.ok && waitResult.status !== "partial") {
-      if (!readRequested || readRole(args.read) === "user") {
-        return forwardFailure(waitResult);
+    if (!waitResult.ok) {
+      if (waitResult.status === "partial") {
+        waitFailure = waitResult;
+      } else {
+        if (!readRequested || readRole(args.read) === "user") {
+          return forwardFailure(waitResult);
+        }
+        waitFailure = waitResult;
       }
-      waitFailure = waitResult;
     }
   }
 
@@ -526,6 +550,7 @@ export async function askMessage(
         return forwardFailure(waitFailure);
       }
       responseText = read.data?.text;
+      warnings.push(...read.warnings);
       if (waitFailure !== undefined) {
         warnings.push(
           ...waitFailure.warnings,
@@ -555,6 +580,20 @@ export async function askMessage(
   }
   if (state?.title !== undefined) {
     data.title = state.title;
+  }
+
+  if (waitFailure !== undefined) {
+    data.complete = false;
+    return withCommandOutputText({
+      ok: false,
+      status: "partial",
+      data,
+      warnings: [
+        ...warnings,
+        `Assistant response was read after ${waitFailure.status}, but completion was not confirmed.`
+      ],
+      context: await contextFromPage(page)
+    } satisfies CommandResult<AskReadData>);
   }
 
   return withCommandOutputText(resultOk(data, await contextFromPage(page), warnings));
@@ -587,7 +626,23 @@ export async function waitAndRead(
     return forwardFailure(read);
   }
 
-  return withCommandOutputText(resultOk(askReadData("", read.data?.text, wait.data?.complete), read.context, wait.warnings));
+  const data = askReadData("", read.data?.text, wait.data?.complete);
+  const warnings = [...read.warnings, ...wait.warnings];
+  if (!wait.ok && wait.status === "partial") {
+    data.complete = false;
+    return withCommandOutputText({
+      ok: false,
+      status: "partial",
+      data,
+      warnings: [
+        ...warnings,
+        "Assistant response was read after partial wait, but completion was not confirmed."
+      ],
+      context: read.context
+    } satisfies CommandResult<AskReadData>);
+  }
+
+  return withCommandOutputText(resultOk(data, read.context, warnings));
 }
 
 async function ensurePage(env: RuntimeEnv): Promise<CommandResult<unknown>> {
@@ -676,37 +731,6 @@ function renderSubmittedTurnMarkdownSyntax(text: string, preserveFenceLanguage =
     .replace(/__([^_]+)__/g, "$1")
     .replace(/\*([^*]+)\*/g, "$1")
     .replace(/_([^_]+)_/g, "$1");
-}
-
-async function hasStopControl(page: PageLike): Promise<boolean> {
-  if (typeof page.evaluate === "function") {
-    return page.evaluate((phrases: string[]) => {
-      const text = document.body?.innerText ?? "";
-      const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      return phrases.some(phrase => new RegExp(`\\b${escape(phrase)}\\b`, "i").test(text));
-    }, [...localeLabels.stopControl]).catch(() => false);
-  }
-  return false;
-}
-
-async function hasResponseActions(page: PageLike): Promise<boolean> {
-  try {
-    const copyButtons = copyResponseButtons(page);
-    const count = await copyButtons.count?.();
-    if (count !== undefined) {
-      return count > 0;
-    }
-    return await copyButtons.isVisible?.() === true;
-  } catch {
-    if (typeof page.evaluate === "function") {
-      return page.evaluate((phrases: string[]) => {
-        const text = document.body?.innerText ?? "";
-        const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        return phrases.some(phrase => new RegExp(`\\b${escape(phrase)}\\b`, "i").test(text));
-      }, [...localeLabels.responseActions]).catch(() => false);
-    }
-    return true;
-  }
 }
 
 async function readAssistantProgressSnapshot(page: PageLike): Promise<AssistantProgressSnapshot> {

--- a/packages/node/src/commands/response-actions.ts
+++ b/packages/node/src/commands/response-actions.ts
@@ -1,4 +1,5 @@
 import { readSystemClipboard, waitForClipboardChange } from "../browser/clipboard.js";
+import { readAssistantGenerationState } from "../dom/generation-state.js";
 import { formatClipboardMarkdown, normalizeResponseFormat } from "../dom/message-format.js";
 import { resultError, resultOk } from "../errors.js";
 import { readLatestMessage, readMessages, type ExtractedMessage } from "../dom/messages.js";
@@ -20,6 +21,31 @@ export async function copyResponse(
   const page = env.page!;
 
   try {
+    if (isLatestSelection(args.which)) {
+      const generation = await readAssistantGenerationState(page);
+      if (generation.active || generation.stopped) {
+        const latest = await readSelectedAssistantMessage(page, args.which, args.format ?? "markdown").catch(() => undefined);
+        const warning = generation.active
+          ? "Response is still generating; copied content may be partial."
+          : "Response appears to have been stopped before completion; copied content may be partial.";
+        const fallbackReason = generation.active
+          ? "Response is still generating; returned DOM-derived partial content."
+          : "Response appears to have been stopped before completion; returned DOM-derived partial content.";
+        const data = latest === undefined ? undefined : copiedResponseFromExtracted(latest, "dom", fallbackReason);
+        const result: CommandResult<CopiedResponse> = {
+          ok: false,
+          status: "partial",
+          warnings: [
+            warning,
+            ...generation.signals.map(signal => `Generation state signal: ${signal}`)
+          ],
+          context: await contextFromPage(page)
+        };
+        if (data !== undefined) result.data = data;
+        return withCommandOutputText(result);
+      }
+    }
+
     if (args.prefer !== "dom") {
       const before = await readClipboard(env);
       const buttons = copyResponseButtons(page);
@@ -92,6 +118,10 @@ export async function copyResponse(
   }
 }
 
+function isLatestSelection(which: CopyResponseArgs["which"]): boolean {
+  return which === undefined || which === "latest";
+}
+
 function readClipboard(env: RuntimeEnv): Promise<string | undefined> {
   return env.clipboard?.read() ?? readSystemClipboard();
 }
@@ -128,6 +158,7 @@ function copiedResponseFromExtracted(
     source
   };
   if (latest.fidelity !== undefined) data.fidelity = latest.fidelity;
+  if (latest.captureLimit !== undefined) data.captureLimit = latest.captureLimit;
   if (latest.warnings !== undefined || fallbackReason !== undefined) {
     data.warnings = [...(latest.warnings ?? []), ...(fallbackReason === undefined ? [] : [fallbackReason])];
   }
@@ -142,6 +173,7 @@ function mergeResponseMetadata(
 ): void {
   if (latest === undefined) return;
   if (latest.markdown !== undefined && data.markdown === undefined) data.markdown = latest.markdown;
+  if (latest.captureLimit !== undefined) data.captureLimit = latest.captureLimit;
   if (latest.visibleText !== undefined) data.visibleText = latest.visibleText;
   if (latest.normalizedText !== undefined) data.normalizedText = latest.normalizedText;
   if (latest.html !== undefined) data.html = latest.html;

--- a/packages/node/src/dom/generation-state.ts
+++ b/packages/node/src/dom/generation-state.ts
@@ -1,0 +1,118 @@
+import type { PageLike } from "../types.js";
+import { copyResponseButtons } from "./selectors.js";
+import { localeLabels } from "./locale-labels.js";
+
+export type AssistantGenerationState = {
+  active: boolean;
+  stopped: boolean;
+  signals: string[];
+};
+
+const EMPTY_GENERATION_STATE: AssistantGenerationState = {
+  active: false,
+  stopped: false,
+  signals: []
+};
+
+export async function readAssistantGenerationState(page: PageLike): Promise<AssistantGenerationState> {
+  if (typeof page.evaluate === "function") {
+    return page.evaluate((args: { stop: string[]; stopped: string[] }) => {
+      const normalize = (value: string | null | undefined) => (value ?? "").trim().toLowerCase();
+      const isVisible = (element: HTMLElement) => {
+        const style = window.getComputedStyle(element);
+        return style.display !== "none"
+          && style.visibility !== "hidden"
+          && style.opacity !== "0"
+          && element.getAttribute("aria-hidden") !== "true";
+      };
+      const visibleButtons = Array.from(document.querySelectorAll("button"))
+        .filter((button): button is HTMLButtonElement => isVisible(button as HTMLElement)
+          && button.disabled !== true
+          && button.getAttribute("aria-disabled") !== "true");
+      const buttonTexts = visibleButtons
+        .map(button => [
+          button.innerText,
+          button.textContent,
+          button.getAttribute("aria-label"),
+          button.getAttribute("title")
+        ].map(normalize).filter(Boolean).join(" "))
+        .filter(Boolean);
+      const bodyText = normalize(document.body?.innerText);
+      const haystacks = [bodyText, ...buttonTexts];
+      const matchingSignals = (phrases: string[]) => haystacks.flatMap(text =>
+        phrases
+          .map(phrase => phrase.toLowerCase())
+          .filter(phrase => text.includes(phrase))
+      );
+      const activeSignals = matchingSignals(args.stop);
+      const stoppedSignals = matchingSignals(args.stopped);
+      return {
+        active: activeSignals.length > 0,
+        stopped: stoppedSignals.length > 0,
+        signals: [...new Set([...activeSignals, ...stoppedSignals, ...buttonTexts.filter(text => /stop|cancel|stopped|answering|thinking/i.test(text))])].slice(0, 5)
+      };
+    }, {
+      stop: [...localeLabels.stopControl],
+      stopped: [...localeLabels.stoppedAssistant]
+    }).catch(() => EMPTY_GENERATION_STATE);
+  }
+
+  if (typeof page.content === "function") {
+    const html = await page.content().catch(() => "");
+    return generationStateFromText(html);
+  }
+
+  return EMPTY_GENERATION_STATE;
+}
+
+export async function latestAssistantTurnHasResponseActions(page: PageLike): Promise<boolean> {
+  if (typeof page.evaluate === "function") {
+    const scoped = await page.evaluate((phrases: string[]) => {
+      const turns = Array.from(document.querySelectorAll("[data-testid^='conversation-turn']"));
+      if (turns.length === 0) return undefined;
+      const latestTurn = turns.reverse().find(turn =>
+        turn.querySelector("[data-message-author-role='assistant']") !== null
+      ) as HTMLElement | undefined;
+      if (latestTurn === undefined) return false;
+      const actionText = Array.from(latestTurn.querySelectorAll("button"))
+        .map(button => [
+          button.innerText,
+          button.textContent,
+          button.getAttribute("aria-label"),
+          button.getAttribute("title")
+        ].filter(Boolean).join(" "))
+        .join(" ")
+        .toLowerCase();
+      return phrases.some(phrase => actionText.includes(phrase.toLowerCase()));
+    }, [...localeLabels.responseActions]).catch(() => undefined);
+    if (scoped !== undefined) {
+      return scoped;
+    }
+  }
+
+  try {
+    const copyButtons = copyResponseButtons(page);
+    const count = await copyButtons.count?.();
+    if (count !== undefined) {
+      return count > 0;
+    }
+    return await copyButtons.isVisible?.() === true;
+  } catch {
+    if (typeof page.content === "function") {
+      const html = await page.content().catch(() => "");
+      return localeLabels.responseActions.some(phrase => html.toLowerCase().includes(phrase.toLowerCase()));
+    }
+    return true;
+  }
+}
+
+function generationStateFromText(text: string): AssistantGenerationState {
+  const normalized = text.toLowerCase();
+  const activeSignals = localeLabels.stopControl.filter(phrase => normalized.includes(phrase.toLowerCase()));
+  const stoppedSignals = localeLabels.stoppedAssistant.filter(phrase => normalized.includes(phrase.toLowerCase()));
+  return {
+    active: activeSignals.length > 0,
+    stopped: stoppedSignals.length > 0,
+    signals: [...activeSignals, ...stoppedSignals].slice(0, 5)
+  };
+}

--- a/packages/node/src/dom/locale/en.ts
+++ b/packages/node/src/dom/locale/en.ts
@@ -46,8 +46,10 @@ export const en = {
   signedInMarkers: ["New chat", "Search chats", "Chat with ChatGPT", "Recents", "Projects"],
   /** Exact-match transient assistant placeholders filtered out of captured responses. */
   transientAssistant: ["thinking", "reasoning", "searching", "searching the web"],
-  /** Streaming "stop" control text, matched as whole words while a response generates. */
-  stopControl: ["stop generating", "stop streaming", "cancel"],
+  /** Streaming "stop" control text, matched while a response generates. */
+  stopControl: ["stop generating", "stop streaming", "stop answering", "cancel"],
+  /** Interrupted generation markers shown after the assistant stops before completion. */
+  stoppedAssistant: ["stopped thinking", "stopped answering", "generation stopped"],
   /** Response-action affordance text (fallback to the structural copy-button locator). */
   responseActions: ["Copy response", "More actions"],
 

--- a/packages/node/src/dom/locale/index.ts
+++ b/packages/node/src/dom/locale/index.ts
@@ -189,6 +189,7 @@ const nonToolKeys = [
   "signedInMarkers",
   "transientAssistant",
   "stopControl",
+  "stoppedAssistant",
   "responseActions",
   "loginBlocker",
   "captchaBlocker",
@@ -230,6 +231,7 @@ export const localeLabels: {
   signedInMarkers: string[];
   transientAssistant: string[];
   stopControl: string[];
+  stoppedAssistant: string[];
   responseActions: string[];
   loginBlocker: string[];
   captchaBlocker: string[];

--- a/packages/node/src/dom/locale/types.ts
+++ b/packages/node/src/dom/locale/types.ts
@@ -39,6 +39,7 @@ export type LocaleStrings = {
   signedInMarkers: string | readonly string[];
   transientAssistant: string | readonly string[];
   stopControl: string | readonly string[];
+  stoppedAssistant: string | readonly string[];
   responseActions: string | readonly string[];
 
   // --- Blocker classification ---

--- a/packages/node/src/dom/message-format.ts
+++ b/packages/node/src/dom/message-format.ts
@@ -2,6 +2,7 @@ import type {
   ResponseAction,
   ResponseBlock,
   ResponseBranchState,
+  ResponseCaptureLimit,
   ResponseCaptureFidelity,
   ResponseCaptureSource,
   ResponseCitation,
@@ -18,6 +19,7 @@ export type FormattedMessageContent = {
   format: NormalizedResponseFormat;
   source?: ResponseCaptureSource;
   fidelity?: ResponseCaptureFidelity;
+  captureLimit?: ResponseCaptureLimit;
   warnings?: string[];
   markdown?: string;
   visibleText?: string;
@@ -111,13 +113,25 @@ export function formatMessageHtml(
   const root = parseHtmlFragment(html);
   const meaningfulChildren = stripIgnorableNodes(root.children);
   const blocks = extractBlocks(meaningfulChildren);
-  const markdown = clamp(blocksToMarkdown(blocks), maxChars);
-  const visibleText = clamp(blocksToPlainText(blocks), maxChars);
-  const normalizedText = clamp(normalizeWhitespace(visibleText), maxChars);
+  const rawMarkdown = blocksToMarkdown(blocks);
+  const rawVisibleText = blocksToPlainText(blocks);
+  const rawNormalizedText = normalizeWhitespace(rawVisibleText);
+  const markdownCapture = applyCaptureLimit(rawMarkdown, maxChars);
+  const visibleTextCapture = applyCaptureLimit(rawVisibleText, maxChars);
+  const normalizedTextCapture = applyCaptureLimit(rawNormalizedText, maxChars);
+  const markdown = markdownCapture.text;
+  const visibleText = visibleTextCapture.text;
+  const normalizedText = normalizedTextCapture.text;
   const citations = collectCitations(meaningfulChildren);
   const codeBlocks = blocks.flatMap(block => block.type === "code" ? [codeBlockFromBlock(block)] : []);
   const tables = blocks.flatMap(block => block.type === "table" ? [tableFromBlock(block)] : []);
   const metadata = extractResponseMetadata(metadataHtml ?? html);
+  const captureLimit = captureLimitForFormat(format, {
+    markdown: markdownCapture.captureLimit,
+    visibleText: visibleTextCapture.captureLimit,
+    normalizedText: normalizedTextCapture.captureLimit,
+    html: applyCaptureLimit(html, maxChars).captureLimit
+  });
 
   const content: FormattedMessageContent = {
     text: textForFormat(format, { markdown, visibleText, normalizedText, html }),
@@ -125,7 +139,9 @@ export function formatMessageHtml(
     source: "semantic_dom",
     fidelity: fidelityForDomFormat(format)
   };
+  if (captureLimit !== undefined) content.captureLimit = captureLimit;
   const warnings = warningsForDomFormat(format);
+  if (captureLimit?.clipped === true) warnings.push(captureLimitWarning(captureLimit));
   if (warnings.length > 0) content.warnings = warnings;
 
   if (format === "markdown" || format === "all") content.markdown = markdown;
@@ -156,15 +172,27 @@ export function formatClipboardMarkdown(
   requestedFormat: ResponseFormat | undefined = "markdown"
 ): FormattedMessageContent {
   const format = normalizeResponseFormat(requestedFormat);
-  const markdown = clamp(normalizeLineBreaks(text).trim(), maxChars);
+  const rawMarkdown = normalizeLineBreaks(text).trim();
+  const rawNormalizedText = normalizeWhitespace(rawMarkdown);
+  const markdownCapture = applyCaptureLimit(rawMarkdown, maxChars);
+  const normalizedTextCapture = applyCaptureLimit(rawNormalizedText, maxChars);
+  const markdown = markdownCapture.text;
   const visibleText = markdown;
-  const normalizedText = clamp(normalizeWhitespace(markdown), maxChars);
+  const normalizedText = normalizedTextCapture.text;
+  const captureLimit = captureLimitForFormat(format, {
+    markdown: markdownCapture.captureLimit,
+    visibleText: markdownCapture.captureLimit,
+    normalizedText: normalizedTextCapture.captureLimit,
+    html: markdownCapture.captureLimit
+  });
   const content: FormattedMessageContent = {
     text: textForFormat(format, { markdown, visibleText, normalizedText, html: markdown }),
     format,
     source: "clipboard",
     fidelity: "clipboard_markdown"
   };
+  if (captureLimit !== undefined) content.captureLimit = captureLimit;
+  if (captureLimit?.clipped === true) content.warnings = [captureLimitWarning(captureLimit)];
   if (format === "markdown" || format === "all") content.markdown = markdown;
   if (format === "visible_text" || format === "all") content.visibleText = visibleText;
   if (format === "normalized_text" || format === "all") content.normalizedText = normalizedText;
@@ -193,6 +221,49 @@ function warningsForDomFormat(format: NormalizedResponseFormat): string[] {
     return [];
   }
   return ["Markdown was reconstructed from visible DOM semantics; use response.copy for clipboard Markdown when exact copy fidelity is required."];
+}
+
+function applyCaptureLimit(text: string, maxChars: number | undefined): { text: string; captureLimit?: ResponseCaptureLimit } {
+  if (maxChars === undefined) {
+    return { text };
+  }
+  const captureLimit: ResponseCaptureLimit = {
+    maxChars,
+    originalChars: text.length,
+    clipped: text.length > maxChars
+  };
+  return {
+    text: captureLimit.clipped ? text.slice(0, maxChars) : text,
+    captureLimit
+  };
+}
+
+function captureLimitForFormat(
+  format: NormalizedResponseFormat,
+  limits: {
+    markdown?: ResponseCaptureLimit | undefined;
+    visibleText?: ResponseCaptureLimit | undefined;
+    normalizedText?: ResponseCaptureLimit | undefined;
+    html?: ResponseCaptureLimit | undefined;
+  }
+): ResponseCaptureLimit | undefined {
+  switch (format) {
+    case "markdown":
+      return limits.markdown;
+    case "visible_text":
+      return limits.visibleText;
+    case "normalized_text":
+      return limits.normalizedText;
+    case "html":
+      return limits.html;
+    case "blocks":
+    case "all":
+      return limits.markdown;
+  }
+}
+
+function captureLimitWarning(captureLimit: ResponseCaptureLimit): string {
+  return `Response captured text was clipped by maxChars=${captureLimit.maxChars} from ${captureLimit.originalChars} characters.`;
 }
 
 function textForFormat(
@@ -648,11 +719,6 @@ function normalizeInline(text: string): string {
     .replace(/[ \t\r\n]+/g, " ")
     .replace(/\s+([.,;:!?])/g, "$1")
     .trim();
-}
-
-function clamp(text: string, maxChars: number | undefined): string {
-  if (maxChars === undefined || text.length <= maxChars) return text;
-  return text.slice(0, Math.max(0, maxChars));
 }
 
 function escapeMarkdownLinkText(text: string): string {

--- a/packages/node/src/dom/messages.ts
+++ b/packages/node/src/dom/messages.ts
@@ -3,6 +3,7 @@ import type {
   ResponseAction,
   ResponseBlock,
   ResponseBranchState,
+  ResponseCaptureLimit,
   ResponseCaptureFidelity,
   ResponseCaptureSource,
   ResponseCitation,
@@ -22,6 +23,7 @@ export type ExtractedMessage = {
   format: Exclude<ResponseFormat, "text">;
   source?: ResponseCaptureSource;
   fidelity?: ResponseCaptureFidelity;
+  captureLimit?: ResponseCaptureLimit;
   warnings?: string[];
   markdown?: string;
   visibleText?: string;

--- a/packages/node/src/runner/interruptions.ts
+++ b/packages/node/src/runner/interruptions.ts
@@ -47,6 +47,7 @@ function isInterruptingResult(result: CommandResult<unknown>): boolean {
   return result.blocker !== undefined
     || result.status === "needs_confirmation"
     || result.status === "unsupported"
+    || result.status === "partial"
     || result.status === "timeout";
 }
 
@@ -78,6 +79,7 @@ function interruptionType(
   }
 
   if (result.status === "needs_confirmation") return "approval_required";
+  if (result.status === "partial") return "timeout";
   if (result.status === "timeout") return "timeout";
   return "unsupported";
 }

--- a/packages/node/src/scripts/check-surface-drift.ts
+++ b/packages/node/src/scripts/check-surface-drift.ts
@@ -1,0 +1,13 @@
+import { validateSurfaceDrift } from "../testing/surface-drift.js";
+
+const report = validateSurfaceDrift();
+
+console.log([
+  "Validated docs/surface drift gate:",
+  `- ${report.commandCount} backend commands`,
+  `- ${report.descriptorCount} command descriptors`,
+  `- ${report.blockerKindCount} blocker kinds`,
+  `- ${report.pythonCommandCount} Python-covered commands`,
+  `- ${report.generatedDocsChecked} generated blocker doc sections`,
+  `- ${report.docAnchorsChecked} doc anchors`
+].join("\n"));

--- a/packages/node/src/scripts/live-smoke/scenarios.ts
+++ b/packages/node/src/scripts/live-smoke/scenarios.ts
@@ -22,6 +22,7 @@ import {
   waitAndRead,
   waitForMessage
 } from "../../index.js";
+import { readAssistantGenerationState } from "../../dom/generation-state.js";
 import type {
   AskReadData,
   CommandResult,
@@ -461,6 +462,51 @@ export const requiredScenarios: LiveSmokeScenario[] = [
 ];
 
 export const optionalScenarios: LiveSmokeScenario[] = [
+  scenario("long-response-partial-short-timeout", false, context => contextEnvFlag(context, "CHATGPT_E2E_LONG_PARTIAL"), async (context, meta) => {
+    const env = await bootNewThread(context, meta);
+    if ("status" in env) return env;
+    const result = await askMessage(env, {
+      text: [
+        "Live capture stress test. Write exactly 180 numbered items.",
+        "Each item should be a complete sentence. Continue until item 180."
+      ].join("\n"),
+      wait: { timeoutMs: 30000, stableMs: 2000, pollMs: 750 },
+      read: { format: "markdown" }
+    });
+    const output = result.output_text ?? "";
+    const details = partialCaptureDetails(result, output);
+    return !result.ok && result.status === "partial" && result.data?.complete === false
+      ? pass(meta, result, details)
+      : fail(meta, result, details);
+  }),
+  scenario("stop-control-detection", false, context => contextEnvFlag(context, "CHATGPT_E2E_STOP_CONTROL"), async (context, meta) => {
+    const env = await bootNewThread(context, meta);
+    if ("status" in env) return env;
+    const asked = await askMessage(env, {
+      text: [
+        "Live stop-control stress test. Write exactly 400 numbered items.",
+        "Each item should be a complete sentence. Continue until item 400."
+      ].join("\n"),
+      wait: false,
+      read: false
+    });
+    if (!asked.ok) return fail(meta, asked);
+    const generation = await waitForGenerationSignal(env, 30000);
+    const waited = await waitForMessage(env, { timeoutMs: 1000, stableMs: 0, pollMs: 250 });
+    await stopGenerationIfVisible(env);
+    const output = waited.output_text ?? "";
+    const details = {
+      generationActive: generation.active,
+      generationStopped: generation.stopped,
+      generationSignals: generation.signals,
+      waitStatus: waited.status,
+      outputChars: output.length,
+      outputHash: hashPreview(output)
+    };
+    return generation.active && !(waited.ok && waited.data?.complete === true)
+      ? pass(meta, waited, details)
+      : fail(meta, waited, details);
+  }),
   scenario("download-generated-file", false, context => contextEnvFlag(context, "CHATGPT_E2E_DOWNLOAD"), async (context, meta) => {
     const env = await bootNewThread(context, meta);
     if ("status" in env) return env;
@@ -685,6 +731,45 @@ function responseCommand(response: ChatGPTResponse): CommandResult<unknown> {
     warnings: [],
     context: { timestamp: new Date(response.created_at * 1000).toISOString() }
   };
+}
+
+function partialCaptureDetails(result: CommandResult<AskReadData>, output: string): Record<string, unknown> {
+  return {
+    resultStatus: result.status,
+    complete: result.data?.complete,
+    outputChars: output.length,
+    outputHash: hashPreview(output)
+  };
+}
+
+async function waitForGenerationSignal(env: RuntimeEnv, timeoutMs: number): Promise<Awaited<ReturnType<typeof readAssistantGenerationState>>> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (env.page !== undefined) {
+      const state = await readAssistantGenerationState(env.page).catch(() => ({ active: false, stopped: false, signals: [] }));
+      if (state.active || state.stopped) {
+        return state;
+      }
+    }
+    await env.page?.waitForTimeout?.(500);
+  }
+  return { active: false, stopped: false, signals: [] };
+}
+
+async function stopGenerationIfVisible(env: RuntimeEnv): Promise<void> {
+  const stop = env.page?.getByRole?.("button", { name: /Stop answering|Stop generating|Stop streaming|Cancel/i });
+  const clicked = stop?.click?.({ timeoutMs: 5000 });
+  if (clicked !== undefined) {
+    await clicked.catch(() => undefined);
+  }
+}
+
+function hashPreview(text: string): string {
+  let hash = 0;
+  for (const char of text) {
+    hash = ((hash << 5) - hash + char.charCodeAt(0)) | 0;
+  }
+  return Math.abs(hash).toString(16);
 }
 
 async function tempFile(name: string, body: string): Promise<string> {

--- a/packages/node/src/testing/surface-drift.ts
+++ b/packages/node/src/testing/surface-drift.ts
@@ -191,7 +191,7 @@ export function validateSurfaceDriftModel(model: SurfaceDriftModel): SurfaceDrif
     const text = model.docs[docPath];
     if (text === undefined) continue;
     generatedDocsChecked += 1;
-    if (extractGeneratedBlockerCoverage(text) !== expectedBlockerSection) {
+    if (normalizeLineEndings(extractGeneratedBlockerCoverage(text)) !== expectedBlockerSection) {
       errors.push(`generated blocker coverage section is stale in ${docPath}`);
     }
   }
@@ -274,6 +274,10 @@ function extractGeneratedBlockerCoverage(text: string): string | undefined {
   const end = text.indexOf(GENERATED_BLOCKERS_END);
   if (start < 0 || end < start) return undefined;
   return text.slice(start, end + GENERATED_BLOCKERS_END.length);
+}
+
+function normalizeLineEndings(text: string | undefined): string | undefined {
+  return text?.replace(/\r\n?/g, "\n");
 }
 
 function validatePolicy(model: SurfaceDriftModel, errors: string[]): void {

--- a/packages/node/src/testing/surface-drift.ts
+++ b/packages/node/src/testing/surface-drift.ts
@@ -1,0 +1,458 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { backendCommands } from "../backend/protocol.js";
+import { commandDescriptors, type CommandDescriptor } from "../commands/registry.js";
+import { explainCommandBlocker } from "../diagnostics/blockers.js";
+
+const POLICY_SCHEMA_VERSION = "chatgpt.browser_control.surface_drift_policy.v1";
+const GENERATED_BLOCKERS_START = "<!-- surface-drift:blocker-kind-coverage:start -->";
+const GENERATED_BLOCKERS_END = "<!-- surface-drift:blocker-kind-coverage:end -->";
+
+type DatedExemption = {
+  date: string;
+  reason: string;
+};
+
+type CommandExemption = DatedExemption & {
+  command: string;
+};
+
+type DescriptorExemption = DatedExemption & {
+  descriptor: string;
+};
+
+type DocAnchor = {
+  id: string;
+  paths: string[];
+  terms: string[];
+};
+
+type SurfaceDriftPolicy = {
+  schemaVersion: string;
+  backendCommandDescriptorExemptions: CommandExemption[];
+  descriptorBackendCommandExemptions: DescriptorExemption[];
+  backendDispatchExemptions: CommandExemption[];
+  pythonFacadeExemptions: CommandExemption[];
+  generatedBlockerDocs: string[];
+  docAnchors: DocAnchor[];
+};
+
+export type SurfaceCommandDescriptor = Pick<CommandDescriptor, "name" | "blockers">;
+
+export type SurfaceBlockerExplanation = {
+  kind: string;
+  title: string;
+  category: string;
+  severity: string;
+  userActionRequired: boolean;
+  nextCommands: string[];
+};
+
+export type SurfaceDriftModel = {
+  backendCommands: string[];
+  backendCapabilityCommands: string[];
+  backendDispatchCommands: string[];
+  commandDescriptors: SurfaceCommandDescriptor[];
+  commandDescriptorFixtureNames: string[];
+  paritySuiteCommands: string[];
+  pythonCommands: string[];
+  blockerKinds: string[];
+  blockerExplanationFixtureKinds: string[];
+  blockerExplanations: SurfaceBlockerExplanation[];
+  docs: Record<string, string>;
+  policy: SurfaceDriftPolicy;
+};
+
+export type SurfaceDriftReport = {
+  commandCount: number;
+  descriptorCount: number;
+  blockerKindCount: number;
+  pythonCommandCount: number;
+  generatedDocsChecked: number;
+  docAnchorsChecked: number;
+};
+
+export type SurfaceDriftValidationResult = {
+  ok: boolean;
+  errors: string[];
+  report: SurfaceDriftReport;
+};
+
+export function validateSurfaceDrift(packageRootInput: URL | string = defaultPackageRoot()): SurfaceDriftReport {
+  const result = validateSurfaceDriftModel(collectSurfaceDriftModel(packageRootInput));
+  if (!result.ok) {
+    throw new Error(`Surface drift validation failed:\n- ${result.errors.join("\n- ")}`);
+  }
+  return result.report;
+}
+
+export function collectSurfaceDriftModel(packageRootInput: URL | string = defaultPackageRoot()): SurfaceDriftModel {
+  const packageRoot = toPath(packageRootInput);
+  const contractRoot = join(packageRoot, "contracts", "v1");
+  const policy = readJson<SurfaceDriftPolicy>(join(contractRoot, "surface-drift-policy.json"));
+  const repoRoot = resolve(packageRoot, "..", "..");
+  const pythonRoot = resolvePythonRoot(packageRoot);
+  const blockerKinds = readBlockerKinds(join(packageRoot, "src", "types.ts"));
+  const descriptorFixture = readJson<{ result?: Array<{ name: string }> }>(join(contractRoot, "fixtures", "command-descriptors.json"));
+  const capabilitiesFixture = readJson<{ commands?: string[]; result?: { commands?: string[] } }>(join(contractRoot, "fixtures", "backend-capabilities.json"));
+  const blockerProfilesFixture = readJson<{ result?: { profiles?: Array<{ kind: string }> } }>(join(contractRoot, "fixtures", "blocker-explanation-profiles.json"));
+  const paritySuite = readJson<{ backendCommands?: Record<string, unknown> }>(join(contractRoot, "parity-suite.json"));
+  const docs = collectDocs(packageRoot, policy, pythonRoot);
+
+  return {
+    backendCommands: [...backendCommands],
+    backendCapabilityCommands: capabilitiesFixture.commands ?? capabilitiesFixture.result?.commands ?? [],
+    backendDispatchCommands: readBackendDispatchCommands(join(packageRoot, "src", "backend", "session.ts")),
+    commandDescriptors: commandDescriptors().map(descriptor => ({ name: descriptor.name, blockers: [...descriptor.blockers] })),
+    commandDescriptorFixtureNames: (descriptorFixture.result ?? []).map(descriptor => descriptor.name),
+    paritySuiteCommands: Object.keys(paritySuite.backendCommands ?? {}),
+    pythonCommands: pythonRoot === undefined ? [] : readPythonCommands(pythonRoot, backendCommands),
+    blockerKinds,
+    blockerExplanationFixtureKinds: (blockerProfilesFixture.result?.profiles ?? []).map(profile => profile.kind),
+    blockerExplanations: blockerKinds.map(kind => {
+      const explanation = explainCommandBlocker({ kind: kind as never, message: `Synthetic ${kind} blocker for surface drift validation.` });
+      return {
+        kind,
+        title: explanation.title,
+        category: explanation.category,
+        severity: explanation.severity,
+        userActionRequired: explanation.userActionRequired,
+        nextCommands: [...explanation.nextCommands]
+      };
+    }),
+    docs,
+    policy: normalizePolicyForLayout(policy, repoRoot)
+  };
+}
+
+export function validateSurfaceDriftModel(model: SurfaceDriftModel): SurfaceDriftValidationResult {
+  const errors: string[] = [];
+  const backendCommandsSet = new Set(model.backendCommands);
+  const descriptorNames = sortedUnique(model.commandDescriptors.map(descriptor => descriptor.name));
+  const descriptorNameSet = new Set(descriptorNames);
+  const blockerKindSet = new Set(model.blockerKinds);
+  const backendDescriptorExemptions = new Set(model.policy.backendCommandDescriptorExemptions.map(exemption => exemption.command));
+  const descriptorBackendExemptions = new Set(model.policy.descriptorBackendCommandExemptions.map(exemption => exemption.descriptor));
+  const backendDispatchExemptions = new Set(model.policy.backendDispatchExemptions.map(exemption => exemption.command));
+  const pythonFacadeExemptions = new Set(model.policy.pythonFacadeExemptions.map(exemption => exemption.command));
+
+  validatePolicy(model, errors);
+  compareSets("backend capabilities fixture commands", model.backendCapabilityCommands, model.backendCommands, errors);
+  compareSets("command descriptor fixture names", model.commandDescriptorFixtureNames, descriptorNames, errors);
+  compareSets("parity-suite backend command coverage", model.paritySuiteCommands, model.backendCommands, errors);
+  compareSets(
+    "blocker explanation profile fixture kinds",
+    model.blockerExplanationFixtureKinds,
+    model.blockerKinds,
+    errors
+  );
+
+  for (const command of model.backendCommands) {
+    if (!descriptorNameSet.has(command) && !backendDescriptorExemptions.has(command)) {
+      errors.push(`backend command ${command} is missing from command descriptors and has no exemption`);
+    }
+    if (!model.backendDispatchCommands.includes(command) && !backendDispatchExemptions.has(command)) {
+      errors.push(`backend command ${command} is missing from backend dispatch and has no exemption`);
+    }
+    if (!model.pythonCommands.includes(command) && !pythonFacadeExemptions.has(command)) {
+      errors.push(`backend command ${command} is missing from Python facade coverage and has no exemption`);
+    }
+  }
+
+  for (const descriptor of model.commandDescriptors) {
+    if (!backendCommandsSet.has(descriptor.name) && !descriptorBackendExemptions.has(descriptor.name)) {
+      errors.push(`command descriptor ${descriptor.name} is not a backend command and has no exemption`);
+    }
+    for (const blocker of descriptor.blockers) {
+      if (!blockerKindSet.has(blocker)) {
+        errors.push(`command descriptor ${descriptor.name} references unknown blocker ${blocker}`);
+      }
+    }
+  }
+
+  for (const explanation of model.blockerExplanations) {
+    if (!blockerKindSet.has(explanation.kind)) {
+      errors.push(`blocker explanation references unknown kind ${explanation.kind}`);
+    }
+    if (explanation.kind !== "unknown" && explanation.title === "Unknown blocker") {
+      errors.push(`blocker kind ${explanation.kind} falls back to the unknown blocker explanation`);
+    }
+    for (const nextCommand of explanation.nextCommands) {
+      if (!backendCommandsSet.has(nextCommand) && !descriptorNameSet.has(nextCommand)) {
+        errors.push(`blocker kind ${explanation.kind} references unknown next command ${nextCommand}`);
+      }
+    }
+  }
+
+  const expectedBlockerSection = generatedBlockerCoverageSection(model.blockerExplanations);
+  let generatedDocsChecked = 0;
+  for (const docPath of model.policy.generatedBlockerDocs) {
+    const text = model.docs[docPath];
+    if (text === undefined) continue;
+    generatedDocsChecked += 1;
+    if (extractGeneratedBlockerCoverage(text) !== expectedBlockerSection) {
+      errors.push(`generated blocker coverage section is stale in ${docPath}`);
+    }
+  }
+  if (generatedDocsChecked === 0) {
+    errors.push("no generated blocker coverage docs were found");
+  }
+
+  let docAnchorsChecked = 0;
+  for (const anchor of model.policy.docAnchors) {
+    const existingPaths = anchor.paths.filter(path => model.docs[path] !== undefined);
+    if (existingPaths.length === 0) {
+      errors.push(`doc anchor ${anchor.id} has no existing checked paths`);
+      continue;
+    }
+    for (const docPath of existingPaths) {
+      const text = model.docs[docPath];
+      if (text === undefined) continue;
+      docAnchorsChecked += anchor.terms.length;
+      for (const term of anchor.terms) {
+        if (!text.includes(term)) {
+          errors.push(`doc anchor ${anchor.id} missing ${term} in ${docPath}`);
+        }
+      }
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    report: {
+      commandCount: model.backendCommands.length,
+      descriptorCount: descriptorNames.length,
+      blockerKindCount: model.blockerKinds.length,
+      pythonCommandCount: model.pythonCommands.length,
+      generatedDocsChecked,
+      docAnchorsChecked
+    }
+  };
+}
+
+export function generatedBlockerCoverageSection(explanations: SurfaceBlockerExplanation[]): string {
+  return [
+    GENERATED_BLOCKERS_START,
+    "## Blocker Kind Coverage",
+    "",
+    "This section is checked by `npm run docs:drift`. Keep it aligned with `BlockerKind`, `explainCommandBlocker(...)`, command descriptors, and public troubleshooting coverage.",
+    "",
+    ...explanations.map(explanation => `- \`${explanation.kind}\`: ${explanation.title} (category: \`${explanation.category}\`, severity: \`${explanation.severity}\`, user action: ${explanation.userActionRequired ? "yes" : "no"})`),
+    GENERATED_BLOCKERS_END
+  ].join("\n");
+}
+
+function collectDocs(packageRoot: string, policy: SurfaceDriftPolicy, pythonRoot: string | undefined): Record<string, string> {
+  const paths = new Set<string>([
+    ...policy.generatedBlockerDocs,
+    ...policy.docAnchors.flatMap(anchor => anchor.paths)
+  ]);
+  const docs: Record<string, string> = {};
+  for (const docPath of paths) {
+    const absolutePath = resolveDocPath(packageRoot, docPath, pythonRoot);
+    if (absolutePath === undefined) continue;
+    if (existsSync(absolutePath) && statSync(absolutePath).isFile()) {
+      docs[docPath] = readFileSync(absolutePath, "utf8");
+    }
+  }
+  return docs;
+}
+
+function resolveDocPath(packageRoot: string, docPath: string, pythonRoot: string | undefined): string | undefined {
+  const pythonPrefix = "$pythonRoot/";
+  if (docPath.startsWith(pythonPrefix)) {
+    if (pythonRoot === undefined) return undefined;
+    return join(pythonRoot, docPath.slice(pythonPrefix.length));
+  }
+  return resolve(packageRoot, docPath);
+}
+
+function extractGeneratedBlockerCoverage(text: string): string | undefined {
+  const start = text.indexOf(GENERATED_BLOCKERS_START);
+  const end = text.indexOf(GENERATED_BLOCKERS_END);
+  if (start < 0 || end < start) return undefined;
+  return text.slice(start, end + GENERATED_BLOCKERS_END.length);
+}
+
+function validatePolicy(model: SurfaceDriftModel, errors: string[]): void {
+  const policy = model.policy;
+  if (policy.schemaVersion !== POLICY_SCHEMA_VERSION) {
+    errors.push(`surface-drift-policy.json has unsupported schemaVersion ${String(policy.schemaVersion)}`);
+  }
+
+  const backendCommandsSet = new Set(model.backendCommands);
+  const descriptorNames = new Set(model.commandDescriptors.map(descriptor => descriptor.name));
+  const commandExemptionGroups: Array<[string, CommandExemption[], Set<string>]> = [
+    ["backendCommandDescriptorExemptions", policy.backendCommandDescriptorExemptions, backendCommandsSet],
+    ["backendDispatchExemptions", policy.backendDispatchExemptions, backendCommandsSet],
+    ["pythonFacadeExemptions", policy.pythonFacadeExemptions, backendCommandsSet]
+  ];
+
+  for (const [group, exemptions, allowedCommands] of commandExemptionGroups) {
+    validateUniqueExemptions(group, exemptions.map(exemption => exemption.command), errors);
+    for (const exemption of exemptions) {
+      validateDatedExemption(`${group}.${exemption.command}`, exemption, errors);
+      if (!allowedCommands.has(exemption.command)) {
+        errors.push(`${group}.${exemption.command} does not reference a backend command`);
+      }
+    }
+  }
+
+  validateUniqueExemptions(
+    "descriptorBackendCommandExemptions",
+    policy.descriptorBackendCommandExemptions.map(exemption => exemption.descriptor),
+    errors
+  );
+  for (const exemption of policy.descriptorBackendCommandExemptions) {
+    validateDatedExemption(`descriptorBackendCommandExemptions.${exemption.descriptor}`, exemption, errors);
+    if (!descriptorNames.has(exemption.descriptor)) {
+      errors.push(`descriptorBackendCommandExemptions.${exemption.descriptor} does not reference a command descriptor`);
+    }
+  }
+
+  const docAnchorIds = policy.docAnchors.map(anchor => anchor.id);
+  validateUniqueExemptions("docAnchors", docAnchorIds, errors);
+  for (const anchor of policy.docAnchors) {
+    if (anchor.paths.length === 0) errors.push(`doc anchor ${anchor.id} must include at least one path`);
+    if (anchor.terms.length === 0) errors.push(`doc anchor ${anchor.id} must include at least one term`);
+  }
+}
+
+function validateDatedExemption(label: string, exemption: DatedExemption, errors: string[]): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(exemption.date)) {
+    errors.push(`${label} must include a YYYY-MM-DD date`);
+  }
+  if (exemption.reason.trim().length < 12) {
+    errors.push(`${label} must include a concrete reason`);
+  }
+}
+
+function validateUniqueExemptions(label: string, values: string[], errors: string[]): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) errors.push(`${label} contains duplicate entry ${value}`);
+    seen.add(value);
+  }
+}
+
+function compareSets(label: string, actual: string[], expected: string[], errors: string[]): void {
+  const actualSorted = sortedUnique(actual);
+  const expectedSorted = sortedUnique(expected);
+  const actualSet = new Set(actualSorted);
+  const expectedSet = new Set(expectedSorted);
+  const missing = expectedSorted.filter(item => !actualSet.has(item));
+  const extra = actualSorted.filter(item => !expectedSet.has(item));
+  if (missing.length > 0) errors.push(`${label} missing: ${missing.join(", ")}`);
+  if (extra.length > 0) errors.push(`${label} extra: ${extra.join(", ")}`);
+}
+
+function normalizePolicyForLayout(policy: SurfaceDriftPolicy, repoRoot: string): SurfaceDriftPolicy {
+  if (existsSync(join(repoRoot, "packages", "node")) && !existsSync(join(repoRoot, "tools", "public-export"))) {
+    return {
+      ...policy,
+      generatedBlockerDocs: policy.generatedBlockerDocs.filter(path => !path.includes("tools/public-export")),
+      docAnchors: policy.docAnchors.map(anchor => ({
+        ...anchor,
+        paths: anchor.paths.filter(path => !path.includes("tools/public-export"))
+      }))
+    };
+  }
+  return policy;
+}
+
+function readBlockerKinds(typesPath: string): string[] {
+  const text = readFileSync(typesPath, "utf8");
+  const match = text.match(/export type BlockerKind =([\s\S]*?);/);
+  if (match === null || match[1] === undefined) {
+    throw new Error("Unable to find BlockerKind union in src/types.ts.");
+  }
+  return [...match[1].matchAll(/"([^"]+)"/g)].map(item => {
+    const kind = item[1];
+    if (kind === undefined) throw new Error("Unable to parse BlockerKind literal.");
+    return kind;
+  });
+}
+
+function readBackendDispatchCommands(sessionPath: string): string[] {
+  const text = readFileSync(sessionPath, "utf8");
+  const match = text.match(/switch \(request\.command\) \{([\s\S]*?)\n  \}/);
+  if (match === null || match[1] === undefined) {
+    throw new Error("Unable to find backend command dispatch switch.");
+  }
+  return sortedUnique([...match[1].matchAll(/case "([^"]+)":/g)].map(item => {
+    const command = item[1];
+    if (command === undefined) throw new Error("Unable to parse backend dispatch command.");
+    return command;
+  }));
+}
+
+function readPythonCommands(pythonRoot: string, knownBackendCommands: readonly string[]): string[] {
+  const known = new Set<string>(knownBackendCommands);
+  const commands = new Set<string>();
+  for (const path of pythonFiles(pythonRoot)) {
+    const text = readFileSync(path, "utf8");
+    for (const pattern of [
+      /command_result\([^,\n]+,\s*"([^"]+)"/g,
+      /request_backend\([^,\n]+,\s*"([^"]+)"/g,
+      /async_request_backend\([^,\n]+,\s*"([^"]+)"/g,
+      /self\.request\("([^"]+)"/g,
+      /self\.stream\("([^"]+)"/g,
+      /"([^"]+)"\s*:\s*"([^"]+)"/g
+    ]) {
+      for (const match of text.matchAll(pattern)) {
+        const command = match[2] ?? match[1];
+        if (command !== undefined && known.has(command)) {
+          commands.add(command);
+        }
+      }
+    }
+  }
+  return sortedUnique([...commands]);
+}
+
+function pythonFiles(root: string): string[] {
+  const result: string[] = [];
+  const visit = (path: string): void => {
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      const entryPath = join(path, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "__pycache__" || entry.name.endsWith(".egg-info")) continue;
+        visit(entryPath);
+      } else if (entry.isFile() && entry.name.endsWith(".py")) {
+        result.push(entryPath);
+      }
+    }
+  };
+  visit(root);
+  return result;
+}
+
+function resolvePythonRoot(packageRoot: string): string | undefined {
+  const repoRoot = resolve(packageRoot, "..", "..");
+  const candidates = [
+    join(repoRoot, "packages", "python"),
+    resolve(packageRoot, "..", "python"),
+    join(repoRoot, "packages", "python"),
+    resolve(packageRoot, "..", "python")
+  ];
+  return candidates.find(path => existsSync(path) && statSync(path).isDirectory());
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function toPath(input: URL | string): string {
+  if (input instanceof URL) return fileURLToPath(input);
+  return input;
+}
+
+function defaultPackageRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+}

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -266,6 +266,12 @@ export type ResponseCaptureFidelity =
   | "blocks"
   | "all";
 
+export type ResponseCaptureLimit = {
+  maxChars: number;
+  originalChars: number;
+  clipped: boolean;
+};
+
 export type ResponseBranchState = {
   current?: number;
   total?: number;
@@ -314,6 +320,7 @@ export type ReadLatestData = {
   format: Exclude<ResponseFormat, "text">;
   source?: ResponseCaptureSource;
   fidelity?: ResponseCaptureFidelity;
+  captureLimit?: ResponseCaptureLimit;
   warnings?: string[];
   markdown?: string;
   visibleText?: string;
@@ -531,6 +538,7 @@ export type CopiedResponse = {
   source: "clipboard" | "dom";
   format: Exclude<ResponseFormat, "text">;
   fidelity?: ResponseCaptureFidelity;
+  captureLimit?: ResponseCaptureLimit;
   warnings?: string[];
   markdown?: string;
   visibleText?: string;

--- a/packages/node/tests/unit/live-smoke-harness.test.ts
+++ b/packages/node/tests/unit/live-smoke-harness.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { filterScenarios, requiredFailures, writeReport } from "../../src/scripts/live-smoke/harness.js";
+import { optionalScenarios } from "../../src/scripts/live-smoke/scenarios.js";
 import type { LiveSmokeScenario } from "../../src/scripts/live-smoke/types.js";
 import type { LiveSmokeScenarioResult } from "../../src/scripts/live-smoke/types.js";
 
@@ -38,6 +39,18 @@ describe("live smoke harness", () => {
       "copy-latest",
       "attach-one-file"
     ]);
+  });
+
+  it("registers long-response scenarios as explicit opt-in checks", () => {
+    const partial = optionalScenarios.find(item => item.name === "long-response-partial-short-timeout");
+    const stop = optionalScenarios.find(item => item.name === "stop-control-detection");
+
+    expect(partial?.required).toBe(false);
+    expect(stop?.required).toBe(false);
+    expect(partial?.enabled({ agent: {}, reportDir: "/tmp/reports", env: {} })).toBe(false);
+    expect(stop?.enabled({ agent: {}, reportDir: "/tmp/reports", env: {} })).toBe(false);
+    expect(partial?.enabled({ agent: {}, reportDir: "/tmp/reports", env: { CHATGPT_E2E_LONG_PARTIAL: "1" } })).toBe(true);
+    expect(stop?.enabled({ agent: {}, reportDir: "/tmp/reports", env: { CHATGPT_E2E_STOP_CONTROL: "1" } })).toBe(true);
   });
 
   it("redacts command content in persisted live-smoke reports", async () => {

--- a/packages/node/tests/unit/locale-labels.test.ts
+++ b/packages/node/tests/unit/locale-labels.test.ts
@@ -68,6 +68,7 @@ describe("en locale — completeness", () => {
     "signedInMarkers",
     "transientAssistant",
     "stopControl",
+    "stoppedAssistant",
     "responseActions",
     "loginBlocker",
     "captchaBlocker",

--- a/packages/node/tests/unit/messages.test.ts
+++ b/packages/node/tests/unit/messages.test.ts
@@ -235,6 +235,90 @@ describe("extractMessagesFromHtml", () => {
     expect(result.data?.responseText).toBe("Napoleon is adorable.");
   });
 
+  it("does not complete while the latest assistant turn exposes Stop answering by aria-label", async () => {
+    const page = scriptedWaitPage([
+      {
+        totalCount: 2,
+        assistantCount: 1,
+        latestAssistantTurnIndex: 2,
+        latestAssistantText: "I will now produce the list.",
+        hasStopControl: false,
+        stopButtonAria: "Stop answering",
+        hasResponseActions: true
+      },
+      {
+        totalCount: 2,
+        assistantCount: 1,
+        latestAssistantTurnIndex: 2,
+        latestAssistantText: "I will now produce the list.",
+        hasStopControl: false,
+        stopButtonAria: "Stop answering",
+        hasResponseActions: true
+      }
+    ]);
+
+    const result = await waitForMessage({ page }, {
+      afterAssistantTurnCount: 0,
+      timeoutMs: 5,
+      stableMs: 0,
+      pollMs: 1
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+    expect(result.data?.complete).toBe(false);
+  });
+
+  it("treats stopped thinking as interrupted partial output, not complete output", async () => {
+    const page = scriptedWaitPage([
+      {
+        totalCount: 2,
+        assistantCount: 1,
+        latestAssistantTurnIndex: 2,
+        latestAssistantText: "I will now produce the list.",
+        hasStopControl: false,
+        stoppedText: "Stopped thinking",
+        hasResponseActions: true
+      }
+    ]);
+
+    const result = await waitForMessage({ page }, {
+      afterAssistantTurnCount: 0,
+      timeoutMs: 5,
+      stableMs: 0,
+      pollMs: 1
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+    expect(result.warnings.join(" ")).toMatch(/stopped|interrupted/i);
+  });
+
+  it("does not use an older assistant turn copy action to complete a new generating answer", async () => {
+    const page = scriptedWaitPage([
+      {
+        totalCount: 4,
+        assistantCount: 2,
+        latestAssistantTurnIndex: 4,
+        latestAssistantText: "New answer preamble.",
+        hasStopControl: false,
+        stopButtonAria: "Stop answering",
+        hasResponseActions: true,
+        latestTurnHasResponseActions: false
+      }
+    ]);
+
+    const result = await waitForMessage({ page }, {
+      afterAssistantTurnCount: 1,
+      timeoutMs: 5,
+      stableMs: 0,
+      pollMs: 1
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+  });
+
   it("falls back to a guarded read when wait misses a submitted assistant turn", async () => {
     const page = askWaitFallbackPage("Reply exactly fallback-ok.", "fallback-ok");
 
@@ -244,10 +328,29 @@ describe("extractMessagesFromHtml", () => {
       read: { format: "normalized_text" }
     });
 
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
     expect(result.output_text).toBe("fallback-ok");
     expect(result.data?.responseText).toBe("fallback-ok");
     expect(result.data?.complete).toBe(false);
+    expect(result.warnings.join(" ")).toContain("Timed out after receiving partial assistant text.");
+    expect(result.warnings.join(" ")).toContain("completion was not confirmed");
+  });
+
+  it("surfaces a partial status when ask reads after a partial wait", async () => {
+    const page = askWaitFallbackPage("Write 500 numbered items.", "I will now produce the list.");
+
+    const result = await askMessage({ page }, {
+      text: "Write 500 numbered items.",
+      wait: { timeoutMs: 5, stableMs: 0, pollMs: 1 },
+      read: { format: "normalized_text" }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+    expect(result.output_text).toBe("I will now produce the list.");
+    expect(result.data?.complete).toBe(false);
+    expect(result.warnings.join(" ")).toContain("Timed out after receiving partial assistant text.");
     expect(result.warnings.join(" ")).toContain("completion was not confirmed");
   });
 
@@ -492,6 +595,22 @@ describe("extractMessagesFromHtml", () => {
     expect(result.data?.actions?.some(action => action.type === "sources")).toBe(true);
   });
 
+  it("warns when readLatest intentionally clips response text with maxChars", async () => {
+    const html = [
+      "<main>",
+      "<div data-message-author-role=\"assistant\"><p>abcdefghijklmnopqrstuvwxyz</p></div>",
+      "</main>"
+    ].join("");
+
+    const result = await readLatest({ page: contentPage(html) }, { format: "markdown", maxChars: 10 });
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.text).toBe("abcdefghij");
+    expect(result.warnings.join(" ")).toContain("maxChars");
+    expect(result.warnings.join(" ")).toContain("captured text was clipped");
+    expect(result.data?.warnings?.join(" ")).toContain("captured text was clipped");
+  });
+
   it("copyResponse can intentionally use DOM Markdown fallback", async () => {
     const html = readFileSync("tests/fixtures/chat-rich-response.html", "utf8");
     const result = await copyResponse({
@@ -602,6 +721,31 @@ describe("extractMessagesFromHtml", () => {
     expect(result.data?.markdown).not.toContain("## Second Response");
     expect(result.data?.branch?.label).toBe("1/2");
   });
+
+  it("does not silently copy a response while generation is active", async () => {
+    const html = [
+      "<main>",
+      "<div data-testid=\"conversation-turn-1\">",
+      "<div data-message-author-role=\"assistant\"><p>Partial preamble.</p></div>",
+      "<button aria-label=\"Stop answering\"></button>",
+      "<button aria-label=\"Copy response\"></button>",
+      "</div>",
+      "</main>"
+    ].join("");
+
+    const result = await copyResponse({
+      page: contentPage(html),
+      clipboard: {
+        read: async () => "before",
+        waitForChange: async () => "Partial preamble."
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+    expect(result.output_text).toBe("Partial preamble.");
+    expect(result.warnings.join(" ")).toContain("still generating");
+  });
 });
 
 function contentPage(html: string, onClick?: () => void): PageLike {
@@ -662,6 +806,7 @@ function askWaitFallbackPage(prompt: string, answer: string): PageLike {
       }
       if (source.includes("assistantNodes") && source.includes("latestAssistantTurnIndex")) {
         return {
+          latestText: submitted ? answer : "Earlier answer.",
           turnCount: totalCount,
           assistantTurnCount: assistantCount,
           latestAssistantTurnIndex: submitted ? 4 : 2
@@ -736,7 +881,10 @@ type WaitSnapshot = {
   latestAssistantTurnIndex?: number;
   latestAssistantText: string;
   hasStopControl: boolean;
+  stopButtonAria?: string;
+  stoppedText?: string;
   hasResponseActions: boolean;
+  latestTurnHasResponseActions?: boolean;
 };
 
 function scriptedWaitPage(snapshots: WaitSnapshot[]): PageLike {
@@ -750,6 +898,9 @@ function scriptedWaitPage(snapshots: WaitSnapshot[]): PageLike {
 
       if (Array.isArray(arg) && arg.includes("stop generating")) {
         return snapshot.hasStopControl as T;
+      }
+      if (Array.isArray(arg) && arg.includes("stopped thinking")) {
+        return (snapshot.stoppedText !== undefined) as T;
       }
       if (source.includes("latestAssistantTurnIndex")) {
         const progress: {
@@ -765,6 +916,18 @@ function scriptedWaitPage(snapshots: WaitSnapshot[]): PageLike {
         progress.latestAssistantTurnIndex = snapshot.latestAssistantTurnIndex ?? snapshot.totalCount;
         return progress as T;
       }
+      if (source.includes("data-testid^='conversation-turn'") && source.includes("latestTurn")) {
+        return (snapshot.latestTurnHasResponseActions ?? snapshot.hasResponseActions) as T;
+      }
+      if (source.includes("document.querySelectorAll(\"button\")")) {
+        const active = snapshot.hasStopControl || snapshot.stopButtonAria?.toLowerCase().includes("stop") === true;
+        const stopped = snapshot.stoppedText !== undefined;
+        const signals = [
+          snapshot.stopButtonAria,
+          snapshot.stoppedText
+        ].filter((value): value is string => value !== undefined);
+        return { active, stopped, signals } as T;
+      }
       if (source.includes("node?.innerText")) {
         return snapshot.latestAssistantText as T;
       }
@@ -774,7 +937,12 @@ function scriptedWaitPage(snapshots: WaitSnapshot[]): PageLike {
         return snapshot.totalCount as T;
       }
       if (source.includes("document.body?.innerText")) {
-        const text = snapshot.hasStopControl ? "New chat Stop generating Copy response" : "New chat Copy response";
+        const text = [
+          "New chat",
+          snapshot.hasStopControl ? "Stop generating" : undefined,
+          snapshot.stoppedText,
+          "Copy response"
+        ].filter(Boolean).join(" ");
         return text as T;
       }
 

--- a/packages/node/tests/unit/polling.test.ts
+++ b/packages/node/tests/unit/polling.test.ts
@@ -6,7 +6,7 @@ describe("isResponseComplete", () => {
     expect(isResponseComplete({
       textStableForMs: 2200,
       stableMs: 2000,
-      hasStopButton: false,
+      generation: { active: false, stopped: false, signals: [] },
       hasResponseActions: true,
       latestText: "hi"
     })).toBe(true);
@@ -16,8 +16,18 @@ describe("isResponseComplete", () => {
     expect(isResponseComplete({
       textStableForMs: 5000,
       stableMs: 2000,
-      hasStopButton: true,
+      generation: { active: true, stopped: false, signals: ["stop answering"] },
       hasResponseActions: false,
+      latestText: "hi"
+    })).toBe(false);
+  });
+
+  it("does not complete after stopped generation", () => {
+    expect(isResponseComplete({
+      textStableForMs: 5000,
+      stableMs: 2000,
+      generation: { active: false, stopped: true, signals: ["stopped thinking"] },
+      hasResponseActions: true,
       latestText: "hi"
     })).toBe(false);
   });
@@ -26,7 +36,7 @@ describe("isResponseComplete", () => {
     expect(isResponseComplete({
       textStableForMs: 500,
       stableMs: 2000,
-      hasStopButton: false,
+      generation: { active: false, stopped: false, signals: [] },
       hasResponseActions: true,
       latestText: "hi"
     })).toBe(false);
@@ -36,7 +46,7 @@ describe("isResponseComplete", () => {
     expect(isResponseComplete({
       textStableForMs: 5000,
       stableMs: 2000,
-      hasStopButton: false,
+      generation: { active: false, stopped: false, signals: [] },
       hasResponseActions: true,
       latestText: "Thinking"
     })).toBe(false);

--- a/packages/node/tests/unit/responses-adapter.test.ts
+++ b/packages/node/tests/unit/responses-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createChatGPT } from "../../src/client.js";
-import { responsesCreateArgsToRunInput, validateResponsesCreateArgs } from "../../src/runner/responses.js";
+import { toRunResult } from "../../src/runner/result.js";
+import { responseFromRunResult, responsesCreateArgsToRunInput, validateResponsesCreateArgs } from "../../src/runner/responses.js";
 
 describe("Responses adapter validation", () => {
   it("accepts browser-compatible response fields", () => {
@@ -128,5 +129,31 @@ describe("Responses adapter validation", () => {
       type: "run.blocked",
       blocker: expect.objectContaining({ code: "run_budget_exceeded" })
     });
+  });
+
+  it("maps partial runner results through the response shape", () => {
+    const chatgpt = createChatGPT();
+    const agent = chatgpt.agent({ name: "reviewer" });
+    const runResult = toRunResult(agent, {
+      ok: false,
+      status: "partial",
+      data: {
+        prompt: "Write 500 numbered items.",
+        responseText: "I will now produce the list.",
+        complete: false
+      },
+      warnings: ["Timed out after receiving partial assistant text."],
+      context: {
+        timestamp: "2026-06-10T00:00:00.000Z",
+        conversationId: "fixture-partial"
+      }
+    });
+
+    const response = responseFromRunResult(runResult, new Date("2026-06-10T00:00:00.000Z"));
+
+    expect(response.status).toBe("partial");
+    expect(response.output_text).toBe("I will now produce the list.");
+    expect(response.browser_control.resultStatus).toBe("partial");
+    expect(response.browser_control.thread?.conversationId).toBe("fixture-partial");
   });
 });

--- a/packages/node/tests/unit/runner.test.ts
+++ b/packages/node/tests/unit/runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createChatGPT } from "../../src/client.js";
+import { toRunResult } from "../../src/runner/result.js";
 import type { SequencePlan, SequenceStep } from "../../src/types.js";
 
 describe("ChatGPT runner facade", () => {
@@ -201,6 +202,35 @@ describe("ChatGPT runner facade", () => {
       "Extension availability"
     ]);
     expect(result.interruptions[0]?.fix?.steps.join(" ")).toContain("scripts/http_stdio_relay.mjs");
+  });
+
+  it("keeps partial command results as partial runner output with an interruption", () => {
+    const chatgpt = createChatGPT({ now: () => new Date("2026-06-10T00:00:00.000Z") });
+    const agent = chatgpt.agent({ name: "reviewer" });
+
+    const result = toRunResult(agent, {
+      ok: false,
+      status: "partial",
+      data: {
+        prompt: "Write 500 numbered items.",
+        responseText: "I will now produce the list.",
+        complete: false
+      },
+      warnings: ["Timed out after receiving partial assistant text."],
+      context: {
+        timestamp: "2026-06-10T00:00:00.000Z",
+        url: "https://chatgpt.com/c/fixture-partial",
+        conversationId: "fixture-partial"
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+    expect(result.output_text).toBe("I will now produce the list.");
+    expect(result.data?.outputText).toBe("I will now produce the list.");
+    expect(result.data?.thread?.conversationId).toBe("fixture-partial");
+    expect(result.interruptions[0]?.status).toBe("partial");
+    expect(result.interruptions[0]?.type).toBe("timeout");
   });
 });
 

--- a/packages/node/tests/unit/sequence.test.ts
+++ b/packages/node/tests/unit/sequence.test.ts
@@ -57,6 +57,27 @@ describe("runSequence", () => {
     expect((result.data as { responseText?: string }).responseText).toBe("hello");
   });
 
+  it("preserves partial assistant response text when a step stops early", async () => {
+    const result = await runSequenceWithExecutor({
+      name: "partial-ask-example",
+      steps: [
+        { id: "ask", command: "messages.ask", args: { text: "hi" } }
+      ]
+    }, async () => ({
+      ok: false,
+      status: "partial",
+      data: { prompt: "hi", responseText: "I will now produce the list.", complete: false },
+      warnings: ["Timed out after receiving partial assistant text."],
+      context: { timestamp: "t" }
+    }));
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+    expect(result.output_text).toBe("I will now produce the list.");
+    expect((result.data as { ask?: { responseText?: string } }).ask?.responseText).toBe("I will now produce the list.");
+    expect(result.steps?.[0]?.status).toBe("partial");
+  });
+
   it("rejects unsafe variable paths", () => {
     expect(() => resolveVariableReference("${input.__proto__.polluted}", new Map(), {})).toThrow("Unsafe");
   });

--- a/packages/node/tests/unit/surface-drift.test.ts
+++ b/packages/node/tests/unit/surface-drift.test.ts
@@ -49,7 +49,7 @@ describe("surface drift gate", () => {
     for (const docPath of model.policy.generatedBlockerDocs) {
       const text = model.docs[docPath];
       if (text !== undefined) {
-        model.docs[docPath] = text.replace(/\n/g, "\r\n");
+        model.docs[docPath] = toCrlfLineEndings(text);
       }
     }
 
@@ -74,4 +74,8 @@ function expectErrors(model: SurfaceDriftModel): string[] {
   const result = validateSurfaceDriftModel(model);
   expect(result.ok).toBe(false);
   return result.errors;
+}
+
+function toCrlfLineEndings(text: string): string {
+  return text.replace(/\r\n?/g, "\n").replace(/\n/g, "\r\n");
 }

--- a/packages/node/tests/unit/surface-drift.test.ts
+++ b/packages/node/tests/unit/surface-drift.test.ts
@@ -44,6 +44,20 @@ describe("surface drift gate", () => {
     expect(expectErrors(model)).toContain("generated blocker coverage section is stale in references/troubleshooting.md");
   });
 
+  it("accepts generated blocker docs with CRLF checkout line endings", () => {
+    const model = currentModel();
+    for (const docPath of model.policy.generatedBlockerDocs) {
+      const text = model.docs[docPath];
+      if (text !== undefined) {
+        model.docs[docPath] = text.replace(/\n/g, "\r\n");
+      }
+    }
+
+    const result = validateSurfaceDriftModel(model);
+
+    expect(result.ok).toBe(true);
+  });
+
   it("fails when a non-exempt backend command is missing from the Python facade", () => {
     const model = currentModel();
     model.pythonCommands = model.pythonCommands.filter(command => command !== "projects.sources.add");

--- a/packages/node/tests/unit/surface-drift.test.ts
+++ b/packages/node/tests/unit/surface-drift.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectSurfaceDriftModel,
+  validateSurfaceDrift,
+  validateSurfaceDriftModel,
+  type SurfaceDriftModel
+} from "../../src/testing/surface-drift.js";
+
+describe("surface drift gate", () => {
+  it("passes for the checked-in registry, protocol, fixtures, docs, and Python facade", () => {
+    const report = validateSurfaceDrift();
+
+    expect(report.commandCount).toBeGreaterThanOrEqual(45);
+    expect(report.blockerKindCount).toBeGreaterThanOrEqual(15);
+    expect(report.pythonCommandCount).toBeGreaterThanOrEqual(40);
+    expect(report.generatedDocsChecked).toBeGreaterThanOrEqual(2);
+    expect(report.docAnchorsChecked).toBeGreaterThanOrEqual(8);
+  });
+
+  it("fails when a backend command is missing from command descriptors without an exemption", () => {
+    const model = currentModel();
+    model.commandDescriptors = model.commandDescriptors.filter(descriptor => descriptor.name !== "files.preflight");
+    model.commandDescriptorFixtureNames = model.commandDescriptorFixtureNames.filter(name => name !== "files.preflight");
+
+    expect(expectErrors(model)).toContain("backend command files.preflight is missing from command descriptors and has no exemption");
+  });
+
+  it("fails when a command descriptor references an unknown blocker kind", () => {
+    const model = currentModel();
+    model.commandDescriptors = model.commandDescriptors.map(descriptor => descriptor.name === "messages.ask"
+      ? { ...descriptor, blockers: [...descriptor.blockers, "surprise_blocker"] }
+      : descriptor);
+
+    expect(expectErrors(model)).toContain("command descriptor messages.ask references unknown blocker surprise_blocker");
+  });
+
+  it("fails when generated blocker docs are stale", () => {
+    const model = currentModel();
+    const troubleshooting = model.docs["references/troubleshooting.md"];
+    expect(troubleshooting).toBeTypeOf("string");
+    if (troubleshooting === undefined) throw new Error("Expected troubleshooting docs in surface model.");
+    model.docs["references/troubleshooting.md"] = troubleshooting.replace("- `upload_failed`", "- `upload_failed_stale`");
+
+    expect(expectErrors(model)).toContain("generated blocker coverage section is stale in references/troubleshooting.md");
+  });
+
+  it("fails when a non-exempt backend command is missing from the Python facade", () => {
+    const model = currentModel();
+    model.pythonCommands = model.pythonCommands.filter(command => command !== "projects.sources.add");
+
+    expect(expectErrors(model)).toContain("backend command projects.sources.add is missing from Python facade coverage and has no exemption");
+  });
+});
+
+function currentModel(): SurfaceDriftModel {
+  return collectSurfaceDriftModel();
+}
+
+function expectErrors(model: SurfaceDriftModel): string[] {
+  const result = validateSurfaceDriftModel(model);
+  expect(result.ok).toBe(false);
+  return result.errors;
+}

--- a/packages/python/tests/test_models_complete.py
+++ b/packages/python/tests/test_models_complete.py
@@ -66,6 +66,15 @@ class CompleteModelTests(unittest.TestCase):
         self.assertEqual(result.data["prompt"], "[redacted:19 chars]")
         self.assertEqual(result.context["timestamp"], "2026-06-06T00:00:00.000Z")
 
+    def test_command_result_fixture_preserves_capture_limit_metadata(self) -> None:
+        result = CommandResult.from_wire(load_json("read-latest-clipped.json")["result"])
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.output_text, "abcdefghij")
+        self.assertEqual(result.data["captureLimit"]["maxChars"], 10)
+        self.assertTrue(result.data["captureLimit"]["clipped"])
+        self.assertIn("maxChars=10", result.warnings[0])
+
     def test_command_descriptor_fixture_parses_descriptor(self) -> None:
         descriptor = CommandDescriptor.from_wire(load_json("describe-runner-run.json"))
 

--- a/packages/python/tests/test_models_conformance.py
+++ b/packages/python/tests/test_models_conformance.py
@@ -66,6 +66,17 @@ class ModelConformanceTests(unittest.TestCase):
         self.assertEqual(result.interruptions[0]["type"], "unsupported")
         self.assertEqual(result.interruptions[0]["status"], "partial")
 
+    def test_partial_run_fixture_preserves_partial_interruption_status(self) -> None:
+        payload = load_fixture("run-timeout-partial.json")
+
+        result = ChatGPTRunResult.from_wire(payload["result"])
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.status, "partial")
+        self.assertEqual(result.output_text, "Partial assistant text captured before timeout.")
+        self.assertEqual(result.interruptions[0]["type"], "timeout")
+        self.assertEqual(result.interruptions[0]["status"], "partial")
+
     def test_response_adapter_preserves_unsupported_field_details(self) -> None:
         payload = load_fixture("responses-unsupported-temperature.json")
 

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
@@ -174,8 +174,10 @@ var en = {
   signedInMarkers: ["New chat", "Search chats", "Chat with ChatGPT", "Recents", "Projects"],
   /** Exact-match transient assistant placeholders filtered out of captured responses. */
   transientAssistant: ["thinking", "reasoning", "searching", "searching the web"],
-  /** Streaming "stop" control text, matched as whole words while a response generates. */
-  stopControl: ["stop generating", "stop streaming", "cancel"],
+  /** Streaming "stop" control text, matched while a response generates. */
+  stopControl: ["stop generating", "stop streaming", "stop answering", "cancel"],
+  /** Interrupted generation markers shown after the assistant stops before completion. */
+  stoppedAssistant: ["stopped thinking", "stopped answering", "generation stopped"],
   /** Response-action affordance text (fallback to the structural copy-button locator). */
   responseActions: ["Copy response", "More actions"],
   // --- Blocker classification (ChatGPT-localized visible text only) ---
@@ -1585,6 +1587,7 @@ var nonToolKeys = [
   "signedInMarkers",
   "transientAssistant",
   "stopControl",
+  "stoppedAssistant",
   "responseActions",
   "loginBlocker",
   "captchaBlocker",
@@ -2087,20 +2090,34 @@ function formatMessageHtml(html, requestedFormat = "markdown", maxChars, metadat
   const root = parseHtmlFragment(html);
   const meaningfulChildren = stripIgnorableNodes(root.children);
   const blocks = extractBlocks(meaningfulChildren);
-  const markdown = clamp(blocksToMarkdown(blocks), maxChars);
-  const visibleText = clamp(blocksToPlainText(blocks), maxChars);
-  const normalizedText = clamp(normalizeWhitespace(visibleText), maxChars);
+  const rawMarkdown = blocksToMarkdown(blocks);
+  const rawVisibleText = blocksToPlainText(blocks);
+  const rawNormalizedText = normalizeWhitespace(rawVisibleText);
+  const markdownCapture = applyCaptureLimit(rawMarkdown, maxChars);
+  const visibleTextCapture = applyCaptureLimit(rawVisibleText, maxChars);
+  const normalizedTextCapture = applyCaptureLimit(rawNormalizedText, maxChars);
+  const markdown = markdownCapture.text;
+  const visibleText = visibleTextCapture.text;
+  const normalizedText = normalizedTextCapture.text;
   const citations = collectCitations(meaningfulChildren);
   const codeBlocks = blocks.flatMap((block) => block.type === "code" ? [codeBlockFromBlock(block)] : []);
   const tables = blocks.flatMap((block) => block.type === "table" ? [tableFromBlock(block)] : []);
   const metadata = extractResponseMetadata(metadataHtml ?? html);
+  const captureLimit = captureLimitForFormat(format, {
+    markdown: markdownCapture.captureLimit,
+    visibleText: visibleTextCapture.captureLimit,
+    normalizedText: normalizedTextCapture.captureLimit,
+    html: applyCaptureLimit(html, maxChars).captureLimit
+  });
   const content = {
     text: textForFormat(format, { markdown, visibleText, normalizedText, html }),
     format,
     source: "semantic_dom",
     fidelity: fidelityForDomFormat(format)
   };
+  if (captureLimit !== void 0) content.captureLimit = captureLimit;
   const warnings = warningsForDomFormat(format);
+  if (captureLimit?.clipped === true) warnings.push(captureLimitWarning(captureLimit));
   if (warnings.length > 0) content.warnings = warnings;
   if (format === "markdown" || format === "all") content.markdown = markdown;
   if (format === "visible_text" || format === "all") content.visibleText = visibleText;
@@ -2124,15 +2141,27 @@ function formatMessageHtml(html, requestedFormat = "markdown", maxChars, metadat
 }
 function formatClipboardMarkdown(text, maxChars, requestedFormat = "markdown") {
   const format = normalizeResponseFormat(requestedFormat);
-  const markdown = clamp(normalizeLineBreaks(text).trim(), maxChars);
+  const rawMarkdown = normalizeLineBreaks(text).trim();
+  const rawNormalizedText = normalizeWhitespace(rawMarkdown);
+  const markdownCapture = applyCaptureLimit(rawMarkdown, maxChars);
+  const normalizedTextCapture = applyCaptureLimit(rawNormalizedText, maxChars);
+  const markdown = markdownCapture.text;
   const visibleText = markdown;
-  const normalizedText = clamp(normalizeWhitespace(markdown), maxChars);
+  const normalizedText = normalizedTextCapture.text;
+  const captureLimit = captureLimitForFormat(format, {
+    markdown: markdownCapture.captureLimit,
+    visibleText: markdownCapture.captureLimit,
+    normalizedText: normalizedTextCapture.captureLimit,
+    html: markdownCapture.captureLimit
+  });
   const content = {
     text: textForFormat(format, { markdown, visibleText, normalizedText, html: markdown }),
     format,
     source: "clipboard",
     fidelity: "clipboard_markdown"
   };
+  if (captureLimit !== void 0) content.captureLimit = captureLimit;
+  if (captureLimit?.clipped === true) content.warnings = [captureLimitWarning(captureLimit)];
   if (format === "markdown" || format === "all") content.markdown = markdown;
   if (format === "visible_text" || format === "all") content.visibleText = visibleText;
   if (format === "normalized_text" || format === "all") content.normalizedText = normalizedText;
@@ -2159,6 +2188,38 @@ function warningsForDomFormat(format) {
     return [];
   }
   return ["Markdown was reconstructed from visible DOM semantics; use response.copy for clipboard Markdown when exact copy fidelity is required."];
+}
+function applyCaptureLimit(text, maxChars) {
+  if (maxChars === void 0) {
+    return { text };
+  }
+  const captureLimit = {
+    maxChars,
+    originalChars: text.length,
+    clipped: text.length > maxChars
+  };
+  return {
+    text: captureLimit.clipped ? text.slice(0, maxChars) : text,
+    captureLimit
+  };
+}
+function captureLimitForFormat(format, limits) {
+  switch (format) {
+    case "markdown":
+      return limits.markdown;
+    case "visible_text":
+      return limits.visibleText;
+    case "normalized_text":
+      return limits.normalizedText;
+    case "html":
+      return limits.html;
+    case "blocks":
+    case "all":
+      return limits.markdown;
+  }
+}
+function captureLimitWarning(captureLimit) {
+  return `Response captured text was clipped by maxChars=${captureLimit.maxChars} from ${captureLimit.originalChars} characters.`;
 }
 function textForFormat(format, values) {
   switch (format) {
@@ -2536,10 +2597,6 @@ function languageFromClass(className) {
 }
 function normalizeInline(text) {
   return decodeBasicEntities(text).replace(/[ \t\r\n]+/g, " ").replace(/\s+([.,;:!?])/g, "$1").trim();
-}
-function clamp(text, maxChars) {
-  if (maxChars === void 0 || text.length <= maxChars) return text;
-  return text.slice(0, Math.max(0, maxChars));
 }
 function escapeMarkdownLinkText(text) {
   return text.replace(/]/g, "\\]");
@@ -5526,6 +5583,97 @@ function isNodeError2(error) {
   return error instanceof Error && "code" in error;
 }
 
+// src/dom/generation-state.ts
+var EMPTY_GENERATION_STATE = {
+  active: false,
+  stopped: false,
+  signals: []
+};
+async function readAssistantGenerationState(page) {
+  if (typeof page.evaluate === "function") {
+    return page.evaluate((args) => {
+      const normalize = (value) => (value ?? "").trim().toLowerCase();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        return style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0" && element.getAttribute("aria-hidden") !== "true";
+      };
+      const visibleButtons = Array.from(document.querySelectorAll("button")).filter((button) => isVisible(button) && button.disabled !== true && button.getAttribute("aria-disabled") !== "true");
+      const buttonTexts = visibleButtons.map((button) => [
+        button.innerText,
+        button.textContent,
+        button.getAttribute("aria-label"),
+        button.getAttribute("title")
+      ].map(normalize).filter(Boolean).join(" ")).filter(Boolean);
+      const bodyText = normalize(document.body?.innerText);
+      const haystacks = [bodyText, ...buttonTexts];
+      const matchingSignals = (phrases) => haystacks.flatMap(
+        (text) => phrases.map((phrase) => phrase.toLowerCase()).filter((phrase) => text.includes(phrase))
+      );
+      const activeSignals = matchingSignals(args.stop);
+      const stoppedSignals = matchingSignals(args.stopped);
+      return {
+        active: activeSignals.length > 0,
+        stopped: stoppedSignals.length > 0,
+        signals: [.../* @__PURE__ */ new Set([...activeSignals, ...stoppedSignals, ...buttonTexts.filter((text) => /stop|cancel|stopped|answering|thinking/i.test(text))])].slice(0, 5)
+      };
+    }, {
+      stop: [...localeLabels.stopControl],
+      stopped: [...localeLabels.stoppedAssistant]
+    }).catch(() => EMPTY_GENERATION_STATE);
+  }
+  if (typeof page.content === "function") {
+    const html = await page.content().catch(() => "");
+    return generationStateFromText(html);
+  }
+  return EMPTY_GENERATION_STATE;
+}
+async function latestAssistantTurnHasResponseActions(page) {
+  if (typeof page.evaluate === "function") {
+    const scoped = await page.evaluate((phrases) => {
+      const turns = Array.from(document.querySelectorAll("[data-testid^='conversation-turn']"));
+      if (turns.length === 0) return void 0;
+      const latestTurn = turns.reverse().find(
+        (turn) => turn.querySelector("[data-message-author-role='assistant']") !== null
+      );
+      if (latestTurn === void 0) return false;
+      const actionText = Array.from(latestTurn.querySelectorAll("button")).map((button) => [
+        button.innerText,
+        button.textContent,
+        button.getAttribute("aria-label"),
+        button.getAttribute("title")
+      ].filter(Boolean).join(" ")).join(" ").toLowerCase();
+      return phrases.some((phrase) => actionText.includes(phrase.toLowerCase()));
+    }, [...localeLabels.responseActions]).catch(() => void 0);
+    if (scoped !== void 0) {
+      return scoped;
+    }
+  }
+  try {
+    const copyButtons = copyResponseButtons(page);
+    const count = await copyButtons.count?.();
+    if (count !== void 0) {
+      return count > 0;
+    }
+    return await copyButtons.isVisible?.() === true;
+  } catch {
+    if (typeof page.content === "function") {
+      const html = await page.content().catch(() => "");
+      return localeLabels.responseActions.some((phrase) => html.toLowerCase().includes(phrase.toLowerCase()));
+    }
+    return true;
+  }
+}
+function generationStateFromText(text) {
+  const normalized = text.toLowerCase();
+  const activeSignals = localeLabels.stopControl.filter((phrase) => normalized.includes(phrase.toLowerCase()));
+  const stoppedSignals = localeLabels.stoppedAssistant.filter((phrase) => normalized.includes(phrase.toLowerCase()));
+  return {
+    active: activeSignals.length > 0,
+    stopped: stoppedSignals.length > 0,
+    signals: [...activeSignals, ...stoppedSignals].slice(0, 5)
+  };
+}
+
 // src/commands/output.ts
 function commandOutputText(data) {
   if (!isRecord2(data)) return void 0;
@@ -5554,7 +5702,7 @@ function isRecord2(value) {
 
 // src/commands/messages.ts
 function isResponseComplete(snapshot) {
-  return snapshot.latestText.trim().length > 0 && !isTransientAssistantText(snapshot.latestText) && snapshot.textStableForMs >= snapshot.stableMs && !snapshot.hasStopButton && snapshot.hasResponseActions;
+  return snapshot.latestText.trim().length > 0 && !isTransientAssistantText(snapshot.latestText) && snapshot.textStableForMs >= snapshot.stableMs && !snapshot.generation.active && !snapshot.generation.stopped && snapshot.hasResponseActions;
 }
 async function composeMessage(env, args) {
   const boot = await ensurePage3(env);
@@ -5815,9 +5963,26 @@ async function waitForMessage(env, args = {}) {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      hasStopButton: await hasStopControl2(page),
-      hasResponseActions: await hasResponseActions(page)
+      generation: await readAssistantGenerationState(page),
+      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
     };
+    if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
+      return withCommandOutputText({
+        ok: false,
+        status: "partial",
+        data: {
+          complete: false,
+          responseText: latestText,
+          assistantTurnCount: latestAssistantCount,
+          elapsedMs: Date.now() - started
+        },
+        warnings: [
+          "ChatGPT generation appears to have been stopped or interrupted before completion.",
+          ...snapshot.generation.signals.map((signal) => `Generation state signal: ${signal}`)
+        ],
+        context: await contextFromPage(page)
+      });
+    }
     if (targetReached && isResponseComplete(snapshot)) {
       return withCommandOutputText(resultOk(
         { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
@@ -5876,6 +6041,7 @@ async function readLatest(env, args = {}) {
   const data = { role, text: latest.text, format: latest.format };
   if (latest.source !== void 0) data.source = latest.source;
   if (latest.fidelity !== void 0) data.fidelity = latest.fidelity;
+  if (latest.captureLimit !== void 0) data.captureLimit = latest.captureLimit;
   if (latest.warnings !== void 0) data.warnings = latest.warnings;
   if (latest.markdown !== void 0) data.markdown = latest.markdown;
   if (latest.visibleText !== void 0) data.visibleText = latest.visibleText;
@@ -5930,11 +6096,15 @@ async function askMessage(env, args) {
       waitArgs.afterAssistantTurnCount = beforeAssistantTurnCount;
     }
     waitResult = await waitForMessage(env, waitArgs);
-    if (!waitResult.ok && waitResult.status !== "partial") {
-      if (!readRequested || readRole(args.read) === "user") {
-        return forwardFailure(waitResult);
+    if (!waitResult.ok) {
+      if (waitResult.status === "partial") {
+        waitFailure = waitResult;
+      } else {
+        if (!readRequested || readRole(args.read) === "user") {
+          return forwardFailure(waitResult);
+        }
+        waitFailure = waitResult;
       }
-      waitFailure = waitResult;
     }
   }
   let responseText = waitResult?.data?.responseText;
@@ -5946,6 +6116,7 @@ async function askMessage(env, args) {
         return forwardFailure(waitFailure);
       }
       responseText = read.data?.text;
+      warnings.push(...read.warnings);
       if (waitFailure !== void 0) {
         warnings.push(
           ...waitFailure.warnings,
@@ -5974,6 +6145,19 @@ async function askMessage(env, args) {
   if (state?.title !== void 0) {
     data.title = state.title;
   }
+  if (waitFailure !== void 0) {
+    data.complete = false;
+    return withCommandOutputText({
+      ok: false,
+      status: "partial",
+      data,
+      warnings: [
+        ...warnings,
+        `Assistant response was read after ${waitFailure.status}, but completion was not confirmed.`
+      ],
+      context: await contextFromPage(page)
+    });
+  }
   return withCommandOutputText(resultOk(data, await contextFromPage(page), warnings));
 }
 async function waitAndRead(env, args = {}) {
@@ -5998,7 +6182,22 @@ async function waitAndRead(env, args = {}) {
     }
     return forwardFailure(read);
   }
-  return withCommandOutputText(resultOk(askReadData("", read.data?.text, wait.data?.complete), read.context, wait.warnings));
+  const data = askReadData("", read.data?.text, wait.data?.complete);
+  const warnings = [...read.warnings, ...wait.warnings];
+  if (!wait.ok && wait.status === "partial") {
+    data.complete = false;
+    return withCommandOutputText({
+      ok: false,
+      status: "partial",
+      data,
+      warnings: [
+        ...warnings,
+        "Assistant response was read after partial wait, but completion was not confirmed."
+      ],
+      context: read.context
+    });
+  }
+  return withCommandOutputText(resultOk(data, read.context, warnings));
 }
 async function ensurePage3(env) {
   if (env.page !== void 0) {
@@ -6059,35 +6258,6 @@ ${language}
 ` : "\n").replace(/~~~[ \t]*([a-z0-9_+#.-]+)?/gi, (_match, language) => language && preserveFenceLanguage ? `
 ${language}
 ` : "\n").replace(/`([^`]+)`/g, "$1").replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1").replace(/\*\*([^*]+)\*\*/g, "$1").replace(/__([^_]+)__/g, "$1").replace(/\*([^*]+)\*/g, "$1").replace(/_([^_]+)_/g, "$1");
-}
-async function hasStopControl2(page) {
-  if (typeof page.evaluate === "function") {
-    return page.evaluate((phrases) => {
-      const text = document.body?.innerText ?? "";
-      const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      return phrases.some((phrase) => new RegExp(`\\b${escape(phrase)}\\b`, "i").test(text));
-    }, [...localeLabels.stopControl]).catch(() => false);
-  }
-  return false;
-}
-async function hasResponseActions(page) {
-  try {
-    const copyButtons = copyResponseButtons(page);
-    const count = await copyButtons.count?.();
-    if (count !== void 0) {
-      return count > 0;
-    }
-    return await copyButtons.isVisible?.() === true;
-  } catch {
-    if (typeof page.evaluate === "function") {
-      return page.evaluate((phrases) => {
-        const text = document.body?.innerText ?? "";
-        const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        return phrases.some((phrase) => new RegExp(`\\b${escape(phrase)}\\b`, "i").test(text));
-      }, [...localeLabels.responseActions]).catch(() => false);
-    }
-    return true;
-  }
 }
 async function readAssistantProgressSnapshot(page) {
   if (typeof page.evaluate === "function") {
@@ -6889,6 +7059,26 @@ async function copyResponse(env, args = {}) {
   }
   const page = env.page;
   try {
+    if (isLatestSelection(args.which)) {
+      const generation = await readAssistantGenerationState(page);
+      if (generation.active || generation.stopped) {
+        const latest2 = await readSelectedAssistantMessage(page, args.which, args.format ?? "markdown").catch(() => void 0);
+        const warning = generation.active ? "Response is still generating; copied content may be partial." : "Response appears to have been stopped before completion; copied content may be partial.";
+        const fallbackReason = generation.active ? "Response is still generating; returned DOM-derived partial content." : "Response appears to have been stopped before completion; returned DOM-derived partial content.";
+        const data = latest2 === void 0 ? void 0 : copiedResponseFromExtracted(latest2, "dom", fallbackReason);
+        const result = {
+          ok: false,
+          status: "partial",
+          warnings: [
+            warning,
+            ...generation.signals.map((signal) => `Generation state signal: ${signal}`)
+          ],
+          context: await contextFromPage(page)
+        };
+        if (data !== void 0) result.data = data;
+        return withCommandOutputText(result);
+      }
+    }
     if (args.prefer !== "dom") {
       const before = await readClipboard(env);
       const buttons = copyResponseButtons(page);
@@ -6951,6 +7141,9 @@ async function copyResponse(env, args = {}) {
     return resultError(error instanceof Error ? error : new Error(String(error)), await contextFromPage(page));
   }
 }
+function isLatestSelection(which) {
+  return which === void 0 || which === "latest";
+}
 function readClipboard(env) {
   return env.clipboard?.read() ?? readSystemClipboard();
 }
@@ -6974,6 +7167,7 @@ function copiedResponseFromExtracted(latest, source, fallbackReason) {
     source
   };
   if (latest.fidelity !== void 0) data.fidelity = latest.fidelity;
+  if (latest.captureLimit !== void 0) data.captureLimit = latest.captureLimit;
   if (latest.warnings !== void 0 || fallbackReason !== void 0) {
     data.warnings = [...latest.warnings ?? [], ...fallbackReason === void 0 ? [] : [fallbackReason]];
   }
@@ -6984,6 +7178,7 @@ function copiedResponseFromExtracted(latest, source, fallbackReason) {
 function mergeResponseMetadata(data, latest) {
   if (latest === void 0) return;
   if (latest.markdown !== void 0 && data.markdown === void 0) data.markdown = latest.markdown;
+  if (latest.captureLimit !== void 0) data.captureLimit = latest.captureLimit;
   if (latest.visibleText !== void 0) data.visibleText = latest.visibleText;
   if (latest.normalizedText !== void 0) data.normalizedText = latest.normalizedText;
   if (latest.html !== void 0) data.html = latest.html;
@@ -7913,7 +8108,7 @@ function interruptionFromCommandResult(result, command) {
   return interruption;
 }
 function isInterruptingResult(result) {
-  return result.blocker !== void 0 || result.status === "needs_confirmation" || result.status === "unsupported" || result.status === "timeout";
+  return result.blocker !== void 0 || result.status === "needs_confirmation" || result.status === "unsupported" || result.status === "partial" || result.status === "timeout";
 }
 function interruptionType(result, blocker) {
   switch (blocker?.kind) {
@@ -7939,6 +8134,7 @@ function interruptionType(result, blocker) {
       break;
   }
   if (result.status === "needs_confirmation") return "approval_required";
+  if (result.status === "partial") return "timeout";
   if (result.status === "timeout") return "timeout";
   return "unsupported";
 }

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
@@ -431,8 +431,10 @@ var en = {
   signedInMarkers: ["New chat", "Search chats", "Chat with ChatGPT", "Recents", "Projects"],
   /** Exact-match transient assistant placeholders filtered out of captured responses. */
   transientAssistant: ["thinking", "reasoning", "searching", "searching the web"],
-  /** Streaming "stop" control text, matched as whole words while a response generates. */
-  stopControl: ["stop generating", "stop streaming", "cancel"],
+  /** Streaming "stop" control text, matched while a response generates. */
+  stopControl: ["stop generating", "stop streaming", "stop answering", "cancel"],
+  /** Interrupted generation markers shown after the assistant stops before completion. */
+  stoppedAssistant: ["stopped thinking", "stopped answering", "generation stopped"],
   /** Response-action affordance text (fallback to the structural copy-button locator). */
   responseActions: ["Copy response", "More actions"],
   // --- Blocker classification (ChatGPT-localized visible text only) ---
@@ -1842,6 +1844,7 @@ var nonToolKeys = [
   "signedInMarkers",
   "transientAssistant",
   "stopControl",
+  "stoppedAssistant",
   "responseActions",
   "loginBlocker",
   "captchaBlocker",
@@ -2563,20 +2566,34 @@ function formatMessageHtml(html, requestedFormat = "markdown", maxChars, metadat
   const root = parseHtmlFragment(html);
   const meaningfulChildren = stripIgnorableNodes(root.children);
   const blocks = extractBlocks(meaningfulChildren);
-  const markdown = clamp(blocksToMarkdown(blocks), maxChars);
-  const visibleText = clamp(blocksToPlainText(blocks), maxChars);
-  const normalizedText = clamp(normalizeWhitespace(visibleText), maxChars);
+  const rawMarkdown = blocksToMarkdown(blocks);
+  const rawVisibleText = blocksToPlainText(blocks);
+  const rawNormalizedText = normalizeWhitespace(rawVisibleText);
+  const markdownCapture = applyCaptureLimit(rawMarkdown, maxChars);
+  const visibleTextCapture = applyCaptureLimit(rawVisibleText, maxChars);
+  const normalizedTextCapture = applyCaptureLimit(rawNormalizedText, maxChars);
+  const markdown = markdownCapture.text;
+  const visibleText = visibleTextCapture.text;
+  const normalizedText = normalizedTextCapture.text;
   const citations = collectCitations(meaningfulChildren);
   const codeBlocks = blocks.flatMap((block) => block.type === "code" ? [codeBlockFromBlock(block)] : []);
   const tables = blocks.flatMap((block) => block.type === "table" ? [tableFromBlock(block)] : []);
   const metadata = extractResponseMetadata(metadataHtml ?? html);
+  const captureLimit = captureLimitForFormat(format, {
+    markdown: markdownCapture.captureLimit,
+    visibleText: visibleTextCapture.captureLimit,
+    normalizedText: normalizedTextCapture.captureLimit,
+    html: applyCaptureLimit(html, maxChars).captureLimit
+  });
   const content = {
     text: textForFormat(format, { markdown, visibleText, normalizedText, html }),
     format,
     source: "semantic_dom",
     fidelity: fidelityForDomFormat(format)
   };
+  if (captureLimit !== void 0) content.captureLimit = captureLimit;
   const warnings = warningsForDomFormat(format);
+  if (captureLimit?.clipped === true) warnings.push(captureLimitWarning(captureLimit));
   if (warnings.length > 0) content.warnings = warnings;
   if (format === "markdown" || format === "all") content.markdown = markdown;
   if (format === "visible_text" || format === "all") content.visibleText = visibleText;
@@ -2600,15 +2617,27 @@ function formatMessageHtml(html, requestedFormat = "markdown", maxChars, metadat
 }
 function formatClipboardMarkdown(text, maxChars, requestedFormat = "markdown") {
   const format = normalizeResponseFormat(requestedFormat);
-  const markdown = clamp(normalizeLineBreaks(text).trim(), maxChars);
+  const rawMarkdown = normalizeLineBreaks(text).trim();
+  const rawNormalizedText = normalizeWhitespace(rawMarkdown);
+  const markdownCapture = applyCaptureLimit(rawMarkdown, maxChars);
+  const normalizedTextCapture = applyCaptureLimit(rawNormalizedText, maxChars);
+  const markdown = markdownCapture.text;
   const visibleText = markdown;
-  const normalizedText = clamp(normalizeWhitespace(markdown), maxChars);
+  const normalizedText = normalizedTextCapture.text;
+  const captureLimit = captureLimitForFormat(format, {
+    markdown: markdownCapture.captureLimit,
+    visibleText: markdownCapture.captureLimit,
+    normalizedText: normalizedTextCapture.captureLimit,
+    html: markdownCapture.captureLimit
+  });
   const content = {
     text: textForFormat(format, { markdown, visibleText, normalizedText, html: markdown }),
     format,
     source: "clipboard",
     fidelity: "clipboard_markdown"
   };
+  if (captureLimit !== void 0) content.captureLimit = captureLimit;
+  if (captureLimit?.clipped === true) content.warnings = [captureLimitWarning(captureLimit)];
   if (format === "markdown" || format === "all") content.markdown = markdown;
   if (format === "visible_text" || format === "all") content.visibleText = visibleText;
   if (format === "normalized_text" || format === "all") content.normalizedText = normalizedText;
@@ -2635,6 +2664,38 @@ function warningsForDomFormat(format) {
     return [];
   }
   return ["Markdown was reconstructed from visible DOM semantics; use response.copy for clipboard Markdown when exact copy fidelity is required."];
+}
+function applyCaptureLimit(text, maxChars) {
+  if (maxChars === void 0) {
+    return { text };
+  }
+  const captureLimit = {
+    maxChars,
+    originalChars: text.length,
+    clipped: text.length > maxChars
+  };
+  return {
+    text: captureLimit.clipped ? text.slice(0, maxChars) : text,
+    captureLimit
+  };
+}
+function captureLimitForFormat(format, limits) {
+  switch (format) {
+    case "markdown":
+      return limits.markdown;
+    case "visible_text":
+      return limits.visibleText;
+    case "normalized_text":
+      return limits.normalizedText;
+    case "html":
+      return limits.html;
+    case "blocks":
+    case "all":
+      return limits.markdown;
+  }
+}
+function captureLimitWarning(captureLimit) {
+  return `Response captured text was clipped by maxChars=${captureLimit.maxChars} from ${captureLimit.originalChars} characters.`;
 }
 function textForFormat(format, values) {
   switch (format) {
@@ -3012,10 +3073,6 @@ function languageFromClass(className) {
 }
 function normalizeInline(text) {
   return decodeBasicEntities(text).replace(/[ \t\r\n]+/g, " ").replace(/\s+([.,;:!?])/g, "$1").trim();
-}
-function clamp(text, maxChars) {
-  if (maxChars === void 0 || text.length <= maxChars) return text;
-  return text.slice(0, Math.max(0, maxChars));
 }
 function escapeMarkdownLinkText(text) {
   return text.replace(/]/g, "\\]");
@@ -4192,6 +4249,97 @@ async function waitForThreadHydrated(page, timeoutMs, expectedConversationId) {
   }
 }
 
+// src/dom/generation-state.ts
+var EMPTY_GENERATION_STATE = {
+  active: false,
+  stopped: false,
+  signals: []
+};
+async function readAssistantGenerationState(page) {
+  if (typeof page.evaluate === "function") {
+    return page.evaluate((args) => {
+      const normalize2 = (value) => (value ?? "").trim().toLowerCase();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        return style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0" && element.getAttribute("aria-hidden") !== "true";
+      };
+      const visibleButtons = Array.from(document.querySelectorAll("button")).filter((button) => isVisible(button) && button.disabled !== true && button.getAttribute("aria-disabled") !== "true");
+      const buttonTexts = visibleButtons.map((button) => [
+        button.innerText,
+        button.textContent,
+        button.getAttribute("aria-label"),
+        button.getAttribute("title")
+      ].map(normalize2).filter(Boolean).join(" ")).filter(Boolean);
+      const bodyText = normalize2(document.body?.innerText);
+      const haystacks = [bodyText, ...buttonTexts];
+      const matchingSignals = (phrases) => haystacks.flatMap(
+        (text) => phrases.map((phrase) => phrase.toLowerCase()).filter((phrase) => text.includes(phrase))
+      );
+      const activeSignals = matchingSignals(args.stop);
+      const stoppedSignals = matchingSignals(args.stopped);
+      return {
+        active: activeSignals.length > 0,
+        stopped: stoppedSignals.length > 0,
+        signals: [.../* @__PURE__ */ new Set([...activeSignals, ...stoppedSignals, ...buttonTexts.filter((text) => /stop|cancel|stopped|answering|thinking/i.test(text))])].slice(0, 5)
+      };
+    }, {
+      stop: [...localeLabels.stopControl],
+      stopped: [...localeLabels.stoppedAssistant]
+    }).catch(() => EMPTY_GENERATION_STATE);
+  }
+  if (typeof page.content === "function") {
+    const html = await page.content().catch(() => "");
+    return generationStateFromText(html);
+  }
+  return EMPTY_GENERATION_STATE;
+}
+async function latestAssistantTurnHasResponseActions(page) {
+  if (typeof page.evaluate === "function") {
+    const scoped = await page.evaluate((phrases) => {
+      const turns = Array.from(document.querySelectorAll("[data-testid^='conversation-turn']"));
+      if (turns.length === 0) return void 0;
+      const latestTurn = turns.reverse().find(
+        (turn) => turn.querySelector("[data-message-author-role='assistant']") !== null
+      );
+      if (latestTurn === void 0) return false;
+      const actionText = Array.from(latestTurn.querySelectorAll("button")).map((button) => [
+        button.innerText,
+        button.textContent,
+        button.getAttribute("aria-label"),
+        button.getAttribute("title")
+      ].filter(Boolean).join(" ")).join(" ").toLowerCase();
+      return phrases.some((phrase) => actionText.includes(phrase.toLowerCase()));
+    }, [...localeLabels.responseActions]).catch(() => void 0);
+    if (scoped !== void 0) {
+      return scoped;
+    }
+  }
+  try {
+    const copyButtons = copyResponseButtons(page);
+    const count = await copyButtons.count?.();
+    if (count !== void 0) {
+      return count > 0;
+    }
+    return await copyButtons.isVisible?.() === true;
+  } catch {
+    if (typeof page.content === "function") {
+      const html = await page.content().catch(() => "");
+      return localeLabels.responseActions.some((phrase) => html.toLowerCase().includes(phrase.toLowerCase()));
+    }
+    return true;
+  }
+}
+function generationStateFromText(text) {
+  const normalized = text.toLowerCase();
+  const activeSignals = localeLabels.stopControl.filter((phrase) => normalized.includes(phrase.toLowerCase()));
+  const stoppedSignals = localeLabels.stoppedAssistant.filter((phrase) => normalized.includes(phrase.toLowerCase()));
+  return {
+    active: activeSignals.length > 0,
+    stopped: stoppedSignals.length > 0,
+    signals: [...activeSignals, ...stoppedSignals].slice(0, 5)
+  };
+}
+
 // src/commands/output.ts
 function commandOutputText(data) {
   if (!isRecord(data)) return void 0;
@@ -4220,7 +4368,7 @@ function isRecord(value) {
 
 // src/commands/messages.ts
 function isResponseComplete(snapshot) {
-  return snapshot.latestText.trim().length > 0 && !isTransientAssistantText(snapshot.latestText) && snapshot.textStableForMs >= snapshot.stableMs && !snapshot.hasStopButton && snapshot.hasResponseActions;
+  return snapshot.latestText.trim().length > 0 && !isTransientAssistantText(snapshot.latestText) && snapshot.textStableForMs >= snapshot.stableMs && !snapshot.generation.active && !snapshot.generation.stopped && snapshot.hasResponseActions;
 }
 async function composeMessage(env, args) {
   const boot2 = await ensurePage2(env);
@@ -4481,9 +4629,26 @@ async function waitForMessage(env, args = {}) {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      hasStopButton: await hasStopControl(page),
-      hasResponseActions: await hasResponseActions(page)
+      generation: await readAssistantGenerationState(page),
+      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
     };
+    if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
+      return withCommandOutputText({
+        ok: false,
+        status: "partial",
+        data: {
+          complete: false,
+          responseText: latestText,
+          assistantTurnCount: latestAssistantCount,
+          elapsedMs: Date.now() - started
+        },
+        warnings: [
+          "ChatGPT generation appears to have been stopped or interrupted before completion.",
+          ...snapshot.generation.signals.map((signal) => `Generation state signal: ${signal}`)
+        ],
+        context: await contextFromPage(page)
+      });
+    }
     if (targetReached && isResponseComplete(snapshot)) {
       return withCommandOutputText(resultOk(
         { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
@@ -4542,6 +4707,7 @@ async function readLatest(env, args = {}) {
   const data = { role, text: latest.text, format: latest.format };
   if (latest.source !== void 0) data.source = latest.source;
   if (latest.fidelity !== void 0) data.fidelity = latest.fidelity;
+  if (latest.captureLimit !== void 0) data.captureLimit = latest.captureLimit;
   if (latest.warnings !== void 0) data.warnings = latest.warnings;
   if (latest.markdown !== void 0) data.markdown = latest.markdown;
   if (latest.visibleText !== void 0) data.visibleText = latest.visibleText;
@@ -4596,11 +4762,15 @@ async function askMessage(env, args) {
       waitArgs.afterAssistantTurnCount = beforeAssistantTurnCount;
     }
     waitResult = await waitForMessage(env, waitArgs);
-    if (!waitResult.ok && waitResult.status !== "partial") {
-      if (!readRequested || readRole(args.read) === "user") {
-        return forwardFailure(waitResult);
+    if (!waitResult.ok) {
+      if (waitResult.status === "partial") {
+        waitFailure = waitResult;
+      } else {
+        if (!readRequested || readRole(args.read) === "user") {
+          return forwardFailure(waitResult);
+        }
+        waitFailure = waitResult;
       }
-      waitFailure = waitResult;
     }
   }
   let responseText = waitResult?.data?.responseText;
@@ -4612,6 +4782,7 @@ async function askMessage(env, args) {
         return forwardFailure(waitFailure);
       }
       responseText = read.data?.text;
+      warnings.push(...read.warnings);
       if (waitFailure !== void 0) {
         warnings.push(
           ...waitFailure.warnings,
@@ -4640,6 +4811,19 @@ async function askMessage(env, args) {
   if (state?.title !== void 0) {
     data.title = state.title;
   }
+  if (waitFailure !== void 0) {
+    data.complete = false;
+    return withCommandOutputText({
+      ok: false,
+      status: "partial",
+      data,
+      warnings: [
+        ...warnings,
+        `Assistant response was read after ${waitFailure.status}, but completion was not confirmed.`
+      ],
+      context: await contextFromPage(page)
+    });
+  }
   return withCommandOutputText(resultOk(data, await contextFromPage(page), warnings));
 }
 async function waitAndRead(env, args = {}) {
@@ -4664,7 +4848,22 @@ async function waitAndRead(env, args = {}) {
     }
     return forwardFailure(read);
   }
-  return withCommandOutputText(resultOk(askReadData("", read.data?.text, wait.data?.complete), read.context, wait.warnings));
+  const data = askReadData("", read.data?.text, wait.data?.complete);
+  const warnings = [...read.warnings, ...wait.warnings];
+  if (!wait.ok && wait.status === "partial") {
+    data.complete = false;
+    return withCommandOutputText({
+      ok: false,
+      status: "partial",
+      data,
+      warnings: [
+        ...warnings,
+        "Assistant response was read after partial wait, but completion was not confirmed."
+      ],
+      context: read.context
+    });
+  }
+  return withCommandOutputText(resultOk(data, read.context, warnings));
 }
 async function ensurePage2(env) {
   if (env.page !== void 0) {
@@ -4725,35 +4924,6 @@ ${language}
 ` : "\n").replace(/~~~[ \t]*([a-z0-9_+#.-]+)?/gi, (_match, language) => language && preserveFenceLanguage ? `
 ${language}
 ` : "\n").replace(/`([^`]+)`/g, "$1").replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1").replace(/\*\*([^*]+)\*\*/g, "$1").replace(/__([^_]+)__/g, "$1").replace(/\*([^*]+)\*/g, "$1").replace(/_([^_]+)_/g, "$1");
-}
-async function hasStopControl(page) {
-  if (typeof page.evaluate === "function") {
-    return page.evaluate((phrases) => {
-      const text = document.body?.innerText ?? "";
-      const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      return phrases.some((phrase) => new RegExp(`\\b${escape(phrase)}\\b`, "i").test(text));
-    }, [...localeLabels.stopControl]).catch(() => false);
-  }
-  return false;
-}
-async function hasResponseActions(page) {
-  try {
-    const copyButtons = copyResponseButtons(page);
-    const count = await copyButtons.count?.();
-    if (count !== void 0) {
-      return count > 0;
-    }
-    return await copyButtons.isVisible?.() === true;
-  } catch {
-    if (typeof page.evaluate === "function") {
-      return page.evaluate((phrases) => {
-        const text = document.body?.innerText ?? "";
-        const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        return phrases.some((phrase) => new RegExp(`\\b${escape(phrase)}\\b`, "i").test(text));
-      }, [...localeLabels.responseActions]).catch(() => false);
-    }
-    return true;
-  }
 }
 async function readAssistantProgressSnapshot(page) {
   if (typeof page.evaluate === "function") {
@@ -4966,7 +5136,7 @@ async function waitForArtifact(env, args = {}) {
       lastChangedAt = Date.now();
     }
     const targetReached = latestArtifacts.length > afterArtifactCount && latest2 !== void 0 && (args.requireDownload !== true || latest2.downloadAvailable);
-    if (targetReached && Date.now() - lastChangedAt >= stableMs && !await hasStopControl2(page, timeoutMs)) {
+    if (targetReached && Date.now() - lastChangedAt >= stableMs && !await hasStopControl(page, timeoutMs)) {
       return resultOk(
         {
           complete: true,
@@ -5298,7 +5468,7 @@ async function ensurePage3(env) {
   }
   return bootstrap(env, { preferExistingTab: true });
 }
-async function hasStopControl2(page, timeoutMs) {
+async function hasStopControl(page, timeoutMs) {
   if (typeof page.evaluate !== "function") return false;
   return withTimeout2(
     page.evaluate((phrases) => {
@@ -6547,6 +6717,26 @@ async function copyResponse(env, args = {}) {
   }
   const page = env.page;
   try {
+    if (isLatestSelection(args.which)) {
+      const generation = await readAssistantGenerationState(page);
+      if (generation.active || generation.stopped) {
+        const latest2 = await readSelectedAssistantMessage(page, args.which, args.format ?? "markdown").catch(() => void 0);
+        const warning = generation.active ? "Response is still generating; copied content may be partial." : "Response appears to have been stopped before completion; copied content may be partial.";
+        const fallbackReason = generation.active ? "Response is still generating; returned DOM-derived partial content." : "Response appears to have been stopped before completion; returned DOM-derived partial content.";
+        const data = latest2 === void 0 ? void 0 : copiedResponseFromExtracted(latest2, "dom", fallbackReason);
+        const result = {
+          ok: false,
+          status: "partial",
+          warnings: [
+            warning,
+            ...generation.signals.map((signal) => `Generation state signal: ${signal}`)
+          ],
+          context: await contextFromPage(page)
+        };
+        if (data !== void 0) result.data = data;
+        return withCommandOutputText(result);
+      }
+    }
     if (args.prefer !== "dom") {
       const before = await readClipboard(env);
       const buttons = copyResponseButtons(page);
@@ -6609,6 +6799,9 @@ async function copyResponse(env, args = {}) {
     return resultError(error instanceof Error ? error : new Error(String(error)), await contextFromPage(page));
   }
 }
+function isLatestSelection(which) {
+  return which === void 0 || which === "latest";
+}
 function readClipboard(env) {
   return env.clipboard?.read() ?? readSystemClipboard();
 }
@@ -6632,6 +6825,7 @@ function copiedResponseFromExtracted(latest, source, fallbackReason) {
     source
   };
   if (latest.fidelity !== void 0) data.fidelity = latest.fidelity;
+  if (latest.captureLimit !== void 0) data.captureLimit = latest.captureLimit;
   if (latest.warnings !== void 0 || fallbackReason !== void 0) {
     data.warnings = [...latest.warnings ?? [], ...fallbackReason === void 0 ? [] : [fallbackReason]];
   }
@@ -6642,6 +6836,7 @@ function copiedResponseFromExtracted(latest, source, fallbackReason) {
 function mergeResponseMetadata(data, latest) {
   if (latest === void 0) return;
   if (latest.markdown !== void 0 && data.markdown === void 0) data.markdown = latest.markdown;
+  if (latest.captureLimit !== void 0) data.captureLimit = latest.captureLimit;
   if (latest.visibleText !== void 0) data.visibleText = latest.visibleText;
   if (latest.normalizedText !== void 0) data.normalizedText = latest.normalizedText;
   if (latest.html !== void 0) data.html = latest.html;
@@ -8122,7 +8317,7 @@ function interruptionFromCommandResult(result, command) {
   return interruption;
 }
 function isInterruptingResult(result) {
-  return result.blocker !== void 0 || result.status === "needs_confirmation" || result.status === "unsupported" || result.status === "timeout";
+  return result.blocker !== void 0 || result.status === "needs_confirmation" || result.status === "unsupported" || result.status === "partial" || result.status === "timeout";
 }
 function interruptionType(result, blocker) {
   switch (blocker?.kind) {
@@ -8148,6 +8343,7 @@ function interruptionType(result, blocker) {
       break;
   }
   if (result.status === "needs_confirmation") return "approval_required";
+  if (result.status === "partial") return "timeout";
   if (result.status === "timeout") return "timeout";
   return "unsupported";
 }
@@ -9581,6 +9777,47 @@ var requiredScenarios = [
   })
 ];
 var optionalScenarios = [
+  scenario("long-response-partial-short-timeout", false, (context) => contextEnvFlag(context, "CHATGPT_E2E_LONG_PARTIAL"), async (context, meta) => {
+    const env = await bootNewThread(context, meta);
+    if ("status" in env) return env;
+    const result = await askMessage(env, {
+      text: [
+        "Live capture stress test. Write exactly 180 numbered items.",
+        "Each item should be a complete sentence. Continue until item 180."
+      ].join("\n"),
+      wait: { timeoutMs: 3e4, stableMs: 2e3, pollMs: 750 },
+      read: { format: "markdown" }
+    });
+    const output = result.output_text ?? "";
+    const details = partialCaptureDetails(result, output);
+    return !result.ok && result.status === "partial" && result.data?.complete === false ? pass(meta, result, details) : fail(meta, result, details);
+  }),
+  scenario("stop-control-detection", false, (context) => contextEnvFlag(context, "CHATGPT_E2E_STOP_CONTROL"), async (context, meta) => {
+    const env = await bootNewThread(context, meta);
+    if ("status" in env) return env;
+    const asked = await askMessage(env, {
+      text: [
+        "Live stop-control stress test. Write exactly 400 numbered items.",
+        "Each item should be a complete sentence. Continue until item 400."
+      ].join("\n"),
+      wait: false,
+      read: false
+    });
+    if (!asked.ok) return fail(meta, asked);
+    const generation = await waitForGenerationSignal(env, 3e4);
+    const waited = await waitForMessage(env, { timeoutMs: 1e3, stableMs: 0, pollMs: 250 });
+    await stopGenerationIfVisible(env);
+    const output = waited.output_text ?? "";
+    const details = {
+      generationActive: generation.active,
+      generationStopped: generation.stopped,
+      generationSignals: generation.signals,
+      waitStatus: waited.status,
+      outputChars: output.length,
+      outputHash: hashPreview(output)
+    };
+    return generation.active && !(waited.ok && waited.data?.complete === true) ? pass(meta, waited, details) : fail(meta, waited, details);
+  }),
   scenario("download-generated-file", false, (context) => contextEnvFlag(context, "CHATGPT_E2E_DOWNLOAD"), async (context, meta) => {
     const env = await bootNewThread(context, meta);
     if ("status" in env) return env;
@@ -9757,6 +9994,41 @@ function responseCommand(response) {
     warnings: [],
     context: { timestamp: new Date(response.created_at * 1e3).toISOString() }
   };
+}
+function partialCaptureDetails(result, output) {
+  return {
+    resultStatus: result.status,
+    complete: result.data?.complete,
+    outputChars: output.length,
+    outputHash: hashPreview(output)
+  };
+}
+async function waitForGenerationSignal(env, timeoutMs) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (env.page !== void 0) {
+      const state = await readAssistantGenerationState(env.page).catch(() => ({ active: false, stopped: false, signals: [] }));
+      if (state.active || state.stopped) {
+        return state;
+      }
+    }
+    await env.page?.waitForTimeout?.(500);
+  }
+  return { active: false, stopped: false, signals: [] };
+}
+async function stopGenerationIfVisible(env) {
+  const stop = env.page?.getByRole?.("button", { name: /Stop answering|Stop generating|Stop streaming|Cancel/i });
+  const clicked = stop?.click?.({ timeoutMs: 5e3 });
+  if (clicked !== void 0) {
+    await clicked.catch(() => void 0);
+  }
+}
+function hashPreview(text) {
+  let hash = 0;
+  for (const char of text) {
+    hash = (hash << 5) - hash + char.charCodeAt(0) | 0;
+  }
+  return Math.abs(hash).toString(16);
 }
 async function tempFile(name, body) {
   const dir = await mkdtemp(join5(tmpdir(), "chatgpt-live-smoke-"));

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
@@ -264,8 +264,10 @@ var en = {
   signedInMarkers: ["New chat", "Search chats", "Chat with ChatGPT", "Recents", "Projects"],
   /** Exact-match transient assistant placeholders filtered out of captured responses. */
   transientAssistant: ["thinking", "reasoning", "searching", "searching the web"],
-  /** Streaming "stop" control text, matched as whole words while a response generates. */
-  stopControl: ["stop generating", "stop streaming", "cancel"],
+  /** Streaming "stop" control text, matched while a response generates. */
+  stopControl: ["stop generating", "stop streaming", "stop answering", "cancel"],
+  /** Interrupted generation markers shown after the assistant stops before completion. */
+  stoppedAssistant: ["stopped thinking", "stopped answering", "generation stopped"],
   /** Response-action affordance text (fallback to the structural copy-button locator). */
   responseActions: ["Copy response", "More actions"],
   // --- Blocker classification (ChatGPT-localized visible text only) ---
@@ -1675,6 +1677,7 @@ var nonToolKeys = [
   "signedInMarkers",
   "transientAssistant",
   "stopControl",
+  "stoppedAssistant",
   "responseActions",
   "loginBlocker",
   "captchaBlocker",
@@ -2396,20 +2399,34 @@ function formatMessageHtml(html, requestedFormat = "markdown", maxChars, metadat
   const root = parseHtmlFragment(html);
   const meaningfulChildren = stripIgnorableNodes(root.children);
   const blocks = extractBlocks(meaningfulChildren);
-  const markdown = clamp(blocksToMarkdown(blocks), maxChars);
-  const visibleText = clamp(blocksToPlainText(blocks), maxChars);
-  const normalizedText = clamp(normalizeWhitespace(visibleText), maxChars);
+  const rawMarkdown = blocksToMarkdown(blocks);
+  const rawVisibleText = blocksToPlainText(blocks);
+  const rawNormalizedText = normalizeWhitespace(rawVisibleText);
+  const markdownCapture = applyCaptureLimit(rawMarkdown, maxChars);
+  const visibleTextCapture = applyCaptureLimit(rawVisibleText, maxChars);
+  const normalizedTextCapture = applyCaptureLimit(rawNormalizedText, maxChars);
+  const markdown = markdownCapture.text;
+  const visibleText = visibleTextCapture.text;
+  const normalizedText = normalizedTextCapture.text;
   const citations = collectCitations(meaningfulChildren);
   const codeBlocks = blocks.flatMap((block) => block.type === "code" ? [codeBlockFromBlock(block)] : []);
   const tables = blocks.flatMap((block) => block.type === "table" ? [tableFromBlock(block)] : []);
   const metadata = extractResponseMetadata(metadataHtml ?? html);
+  const captureLimit = captureLimitForFormat(format, {
+    markdown: markdownCapture.captureLimit,
+    visibleText: visibleTextCapture.captureLimit,
+    normalizedText: normalizedTextCapture.captureLimit,
+    html: applyCaptureLimit(html, maxChars).captureLimit
+  });
   const content = {
     text: textForFormat(format, { markdown, visibleText, normalizedText, html }),
     format,
     source: "semantic_dom",
     fidelity: fidelityForDomFormat(format)
   };
+  if (captureLimit !== void 0) content.captureLimit = captureLimit;
   const warnings = warningsForDomFormat(format);
+  if (captureLimit?.clipped === true) warnings.push(captureLimitWarning(captureLimit));
   if (warnings.length > 0) content.warnings = warnings;
   if (format === "markdown" || format === "all") content.markdown = markdown;
   if (format === "visible_text" || format === "all") content.visibleText = visibleText;
@@ -2433,15 +2450,27 @@ function formatMessageHtml(html, requestedFormat = "markdown", maxChars, metadat
 }
 function formatClipboardMarkdown(text, maxChars, requestedFormat = "markdown") {
   const format = normalizeResponseFormat(requestedFormat);
-  const markdown = clamp(normalizeLineBreaks(text).trim(), maxChars);
+  const rawMarkdown = normalizeLineBreaks(text).trim();
+  const rawNormalizedText = normalizeWhitespace(rawMarkdown);
+  const markdownCapture = applyCaptureLimit(rawMarkdown, maxChars);
+  const normalizedTextCapture = applyCaptureLimit(rawNormalizedText, maxChars);
+  const markdown = markdownCapture.text;
   const visibleText = markdown;
-  const normalizedText = clamp(normalizeWhitespace(markdown), maxChars);
+  const normalizedText = normalizedTextCapture.text;
+  const captureLimit = captureLimitForFormat(format, {
+    markdown: markdownCapture.captureLimit,
+    visibleText: markdownCapture.captureLimit,
+    normalizedText: normalizedTextCapture.captureLimit,
+    html: markdownCapture.captureLimit
+  });
   const content = {
     text: textForFormat(format, { markdown, visibleText, normalizedText, html: markdown }),
     format,
     source: "clipboard",
     fidelity: "clipboard_markdown"
   };
+  if (captureLimit !== void 0) content.captureLimit = captureLimit;
+  if (captureLimit?.clipped === true) content.warnings = [captureLimitWarning(captureLimit)];
   if (format === "markdown" || format === "all") content.markdown = markdown;
   if (format === "visible_text" || format === "all") content.visibleText = visibleText;
   if (format === "normalized_text" || format === "all") content.normalizedText = normalizedText;
@@ -2468,6 +2497,38 @@ function warningsForDomFormat(format) {
     return [];
   }
   return ["Markdown was reconstructed from visible DOM semantics; use response.copy for clipboard Markdown when exact copy fidelity is required."];
+}
+function applyCaptureLimit(text, maxChars) {
+  if (maxChars === void 0) {
+    return { text };
+  }
+  const captureLimit = {
+    maxChars,
+    originalChars: text.length,
+    clipped: text.length > maxChars
+  };
+  return {
+    text: captureLimit.clipped ? text.slice(0, maxChars) : text,
+    captureLimit
+  };
+}
+function captureLimitForFormat(format, limits) {
+  switch (format) {
+    case "markdown":
+      return limits.markdown;
+    case "visible_text":
+      return limits.visibleText;
+    case "normalized_text":
+      return limits.normalizedText;
+    case "html":
+      return limits.html;
+    case "blocks":
+    case "all":
+      return limits.markdown;
+  }
+}
+function captureLimitWarning(captureLimit) {
+  return `Response captured text was clipped by maxChars=${captureLimit.maxChars} from ${captureLimit.originalChars} characters.`;
 }
 function textForFormat(format, values) {
   switch (format) {
@@ -2845,10 +2906,6 @@ function languageFromClass(className) {
 }
 function normalizeInline(text) {
   return decodeBasicEntities(text).replace(/[ \t\r\n]+/g, " ").replace(/\s+([.,;:!?])/g, "$1").trim();
-}
-function clamp(text, maxChars) {
-  if (maxChars === void 0 || text.length <= maxChars) return text;
-  return text.slice(0, Math.max(0, maxChars));
 }
 function escapeMarkdownLinkText(text) {
   return text.replace(/]/g, "\\]");
@@ -4137,6 +4194,97 @@ async function waitForThreadHydrated(page, timeoutMs, expectedConversationId) {
   }
 }
 
+// src/dom/generation-state.ts
+var EMPTY_GENERATION_STATE = {
+  active: false,
+  stopped: false,
+  signals: []
+};
+async function readAssistantGenerationState(page) {
+  if (typeof page.evaluate === "function") {
+    return page.evaluate((args) => {
+      const normalize = (value) => (value ?? "").trim().toLowerCase();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        return style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0" && element.getAttribute("aria-hidden") !== "true";
+      };
+      const visibleButtons = Array.from(document.querySelectorAll("button")).filter((button) => isVisible(button) && button.disabled !== true && button.getAttribute("aria-disabled") !== "true");
+      const buttonTexts = visibleButtons.map((button) => [
+        button.innerText,
+        button.textContent,
+        button.getAttribute("aria-label"),
+        button.getAttribute("title")
+      ].map(normalize).filter(Boolean).join(" ")).filter(Boolean);
+      const bodyText = normalize(document.body?.innerText);
+      const haystacks = [bodyText, ...buttonTexts];
+      const matchingSignals = (phrases) => haystacks.flatMap(
+        (text) => phrases.map((phrase) => phrase.toLowerCase()).filter((phrase) => text.includes(phrase))
+      );
+      const activeSignals = matchingSignals(args.stop);
+      const stoppedSignals = matchingSignals(args.stopped);
+      return {
+        active: activeSignals.length > 0,
+        stopped: stoppedSignals.length > 0,
+        signals: [.../* @__PURE__ */ new Set([...activeSignals, ...stoppedSignals, ...buttonTexts.filter((text) => /stop|cancel|stopped|answering|thinking/i.test(text))])].slice(0, 5)
+      };
+    }, {
+      stop: [...localeLabels.stopControl],
+      stopped: [...localeLabels.stoppedAssistant]
+    }).catch(() => EMPTY_GENERATION_STATE);
+  }
+  if (typeof page.content === "function") {
+    const html = await page.content().catch(() => "");
+    return generationStateFromText(html);
+  }
+  return EMPTY_GENERATION_STATE;
+}
+async function latestAssistantTurnHasResponseActions(page) {
+  if (typeof page.evaluate === "function") {
+    const scoped = await page.evaluate((phrases) => {
+      const turns = Array.from(document.querySelectorAll("[data-testid^='conversation-turn']"));
+      if (turns.length === 0) return void 0;
+      const latestTurn = turns.reverse().find(
+        (turn) => turn.querySelector("[data-message-author-role='assistant']") !== null
+      );
+      if (latestTurn === void 0) return false;
+      const actionText = Array.from(latestTurn.querySelectorAll("button")).map((button) => [
+        button.innerText,
+        button.textContent,
+        button.getAttribute("aria-label"),
+        button.getAttribute("title")
+      ].filter(Boolean).join(" ")).join(" ").toLowerCase();
+      return phrases.some((phrase) => actionText.includes(phrase.toLowerCase()));
+    }, [...localeLabels.responseActions]).catch(() => void 0);
+    if (scoped !== void 0) {
+      return scoped;
+    }
+  }
+  try {
+    const copyButtons = copyResponseButtons(page);
+    const count = await copyButtons.count?.();
+    if (count !== void 0) {
+      return count > 0;
+    }
+    return await copyButtons.isVisible?.() === true;
+  } catch {
+    if (typeof page.content === "function") {
+      const html = await page.content().catch(() => "");
+      return localeLabels.responseActions.some((phrase) => html.toLowerCase().includes(phrase.toLowerCase()));
+    }
+    return true;
+  }
+}
+function generationStateFromText(text) {
+  const normalized = text.toLowerCase();
+  const activeSignals = localeLabels.stopControl.filter((phrase) => normalized.includes(phrase.toLowerCase()));
+  const stoppedSignals = localeLabels.stoppedAssistant.filter((phrase) => normalized.includes(phrase.toLowerCase()));
+  return {
+    active: activeSignals.length > 0,
+    stopped: stoppedSignals.length > 0,
+    signals: [...activeSignals, ...stoppedSignals].slice(0, 5)
+  };
+}
+
 // src/commands/output.ts
 function commandOutputText(data) {
   if (!isRecord(data)) return void 0;
@@ -4165,7 +4313,7 @@ function isRecord(value) {
 
 // src/commands/messages.ts
 function isResponseComplete(snapshot) {
-  return snapshot.latestText.trim().length > 0 && !isTransientAssistantText(snapshot.latestText) && snapshot.textStableForMs >= snapshot.stableMs && !snapshot.hasStopButton && snapshot.hasResponseActions;
+  return snapshot.latestText.trim().length > 0 && !isTransientAssistantText(snapshot.latestText) && snapshot.textStableForMs >= snapshot.stableMs && !snapshot.generation.active && !snapshot.generation.stopped && snapshot.hasResponseActions;
 }
 async function composeMessage(env, args) {
   const boot = await ensurePage2(env);
@@ -4426,9 +4574,26 @@ async function waitForMessage(env, args = {}) {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      hasStopButton: await hasStopControl(page),
-      hasResponseActions: await hasResponseActions(page)
+      generation: await readAssistantGenerationState(page),
+      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
     };
+    if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
+      return withCommandOutputText({
+        ok: false,
+        status: "partial",
+        data: {
+          complete: false,
+          responseText: latestText,
+          assistantTurnCount: latestAssistantCount,
+          elapsedMs: Date.now() - started
+        },
+        warnings: [
+          "ChatGPT generation appears to have been stopped or interrupted before completion.",
+          ...snapshot.generation.signals.map((signal) => `Generation state signal: ${signal}`)
+        ],
+        context: await contextFromPage(page)
+      });
+    }
     if (targetReached && isResponseComplete(snapshot)) {
       return withCommandOutputText(resultOk(
         { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
@@ -4487,6 +4652,7 @@ async function readLatest(env, args = {}) {
   const data = { role, text: latest.text, format: latest.format };
   if (latest.source !== void 0) data.source = latest.source;
   if (latest.fidelity !== void 0) data.fidelity = latest.fidelity;
+  if (latest.captureLimit !== void 0) data.captureLimit = latest.captureLimit;
   if (latest.warnings !== void 0) data.warnings = latest.warnings;
   if (latest.markdown !== void 0) data.markdown = latest.markdown;
   if (latest.visibleText !== void 0) data.visibleText = latest.visibleText;
@@ -4541,11 +4707,15 @@ async function askMessage(env, args) {
       waitArgs.afterAssistantTurnCount = beforeAssistantTurnCount;
     }
     waitResult = await waitForMessage(env, waitArgs);
-    if (!waitResult.ok && waitResult.status !== "partial") {
-      if (!readRequested || readRole(args.read) === "user") {
-        return forwardFailure(waitResult);
+    if (!waitResult.ok) {
+      if (waitResult.status === "partial") {
+        waitFailure = waitResult;
+      } else {
+        if (!readRequested || readRole(args.read) === "user") {
+          return forwardFailure(waitResult);
+        }
+        waitFailure = waitResult;
       }
-      waitFailure = waitResult;
     }
   }
   let responseText = waitResult?.data?.responseText;
@@ -4557,6 +4727,7 @@ async function askMessage(env, args) {
         return forwardFailure(waitFailure);
       }
       responseText = read.data?.text;
+      warnings.push(...read.warnings);
       if (waitFailure !== void 0) {
         warnings.push(
           ...waitFailure.warnings,
@@ -4585,6 +4756,19 @@ async function askMessage(env, args) {
   if (state?.title !== void 0) {
     data.title = state.title;
   }
+  if (waitFailure !== void 0) {
+    data.complete = false;
+    return withCommandOutputText({
+      ok: false,
+      status: "partial",
+      data,
+      warnings: [
+        ...warnings,
+        `Assistant response was read after ${waitFailure.status}, but completion was not confirmed.`
+      ],
+      context: await contextFromPage(page)
+    });
+  }
   return withCommandOutputText(resultOk(data, await contextFromPage(page), warnings));
 }
 async function waitAndRead(env, args = {}) {
@@ -4609,7 +4793,22 @@ async function waitAndRead(env, args = {}) {
     }
     return forwardFailure(read);
   }
-  return withCommandOutputText(resultOk(askReadData("", read.data?.text, wait.data?.complete), read.context, wait.warnings));
+  const data = askReadData("", read.data?.text, wait.data?.complete);
+  const warnings = [...read.warnings, ...wait.warnings];
+  if (!wait.ok && wait.status === "partial") {
+    data.complete = false;
+    return withCommandOutputText({
+      ok: false,
+      status: "partial",
+      data,
+      warnings: [
+        ...warnings,
+        "Assistant response was read after partial wait, but completion was not confirmed."
+      ],
+      context: read.context
+    });
+  }
+  return withCommandOutputText(resultOk(data, read.context, warnings));
 }
 async function ensurePage2(env) {
   if (env.page !== void 0) {
@@ -4670,35 +4869,6 @@ ${language}
 ` : "\n").replace(/~~~[ \t]*([a-z0-9_+#.-]+)?/gi, (_match, language) => language && preserveFenceLanguage ? `
 ${language}
 ` : "\n").replace(/`([^`]+)`/g, "$1").replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1").replace(/\*\*([^*]+)\*\*/g, "$1").replace(/__([^_]+)__/g, "$1").replace(/\*([^*]+)\*/g, "$1").replace(/_([^_]+)_/g, "$1");
-}
-async function hasStopControl(page) {
-  if (typeof page.evaluate === "function") {
-    return page.evaluate((phrases) => {
-      const text = document.body?.innerText ?? "";
-      const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      return phrases.some((phrase) => new RegExp(`\\b${escape(phrase)}\\b`, "i").test(text));
-    }, [...localeLabels.stopControl]).catch(() => false);
-  }
-  return false;
-}
-async function hasResponseActions(page) {
-  try {
-    const copyButtons = copyResponseButtons(page);
-    const count = await copyButtons.count?.();
-    if (count !== void 0) {
-      return count > 0;
-    }
-    return await copyButtons.isVisible?.() === true;
-  } catch {
-    if (typeof page.evaluate === "function") {
-      return page.evaluate((phrases) => {
-        const text = document.body?.innerText ?? "";
-        const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        return phrases.some((phrase) => new RegExp(`\\b${escape(phrase)}\\b`, "i").test(text));
-      }, [...localeLabels.responseActions]).catch(() => false);
-    }
-    return true;
-  }
 }
 async function readAssistantProgressSnapshot(page) {
   if (typeof page.evaluate === "function") {
@@ -4911,7 +5081,7 @@ async function waitForArtifact(env, args = {}) {
       lastChangedAt = Date.now();
     }
     const targetReached = latestArtifacts.length > afterArtifactCount && latest2 !== void 0 && (args.requireDownload !== true || latest2.downloadAvailable);
-    if (targetReached && Date.now() - lastChangedAt >= stableMs && !await hasStopControl2(page, timeoutMs)) {
+    if (targetReached && Date.now() - lastChangedAt >= stableMs && !await hasStopControl(page, timeoutMs)) {
       return resultOk(
         {
           complete: true,
@@ -5243,7 +5413,7 @@ async function ensurePage3(env) {
   }
   return bootstrap(env, { preferExistingTab: true });
 }
-async function hasStopControl2(page, timeoutMs) {
+async function hasStopControl(page, timeoutMs) {
   if (typeof page.evaluate !== "function") return false;
   return withTimeout(
     page.evaluate((phrases) => {
@@ -6503,6 +6673,26 @@ async function copyResponse(env, args = {}) {
   }
   const page = env.page;
   try {
+    if (isLatestSelection(args.which)) {
+      const generation = await readAssistantGenerationState(page);
+      if (generation.active || generation.stopped) {
+        const latest2 = await readSelectedAssistantMessage(page, args.which, args.format ?? "markdown").catch(() => void 0);
+        const warning = generation.active ? "Response is still generating; copied content may be partial." : "Response appears to have been stopped before completion; copied content may be partial.";
+        const fallbackReason = generation.active ? "Response is still generating; returned DOM-derived partial content." : "Response appears to have been stopped before completion; returned DOM-derived partial content.";
+        const data = latest2 === void 0 ? void 0 : copiedResponseFromExtracted(latest2, "dom", fallbackReason);
+        const result = {
+          ok: false,
+          status: "partial",
+          warnings: [
+            warning,
+            ...generation.signals.map((signal) => `Generation state signal: ${signal}`)
+          ],
+          context: await contextFromPage(page)
+        };
+        if (data !== void 0) result.data = data;
+        return withCommandOutputText(result);
+      }
+    }
     if (args.prefer !== "dom") {
       const before = await readClipboard(env);
       const buttons = copyResponseButtons(page);
@@ -6565,6 +6755,9 @@ async function copyResponse(env, args = {}) {
     return resultError(error instanceof Error ? error : new Error(String(error)), await contextFromPage(page));
   }
 }
+function isLatestSelection(which) {
+  return which === void 0 || which === "latest";
+}
 function readClipboard(env) {
   return env.clipboard?.read() ?? readSystemClipboard();
 }
@@ -6588,6 +6781,7 @@ function copiedResponseFromExtracted(latest, source, fallbackReason) {
     source
   };
   if (latest.fidelity !== void 0) data.fidelity = latest.fidelity;
+  if (latest.captureLimit !== void 0) data.captureLimit = latest.captureLimit;
   if (latest.warnings !== void 0 || fallbackReason !== void 0) {
     data.warnings = [...latest.warnings ?? [], ...fallbackReason === void 0 ? [] : [fallbackReason]];
   }
@@ -6598,6 +6792,7 @@ function copiedResponseFromExtracted(latest, source, fallbackReason) {
 function mergeResponseMetadata(data, latest) {
   if (latest === void 0) return;
   if (latest.markdown !== void 0 && data.markdown === void 0) data.markdown = latest.markdown;
+  if (latest.captureLimit !== void 0) data.captureLimit = latest.captureLimit;
   if (latest.visibleText !== void 0) data.visibleText = latest.visibleText;
   if (latest.normalizedText !== void 0) data.normalizedText = latest.normalizedText;
   if (latest.html !== void 0) data.html = latest.html;
@@ -8182,7 +8377,7 @@ function interruptionFromCommandResult(result, command) {
   return interruption;
 }
 function isInterruptingResult(result) {
-  return result.blocker !== void 0 || result.status === "needs_confirmation" || result.status === "unsupported" || result.status === "timeout";
+  return result.blocker !== void 0 || result.status === "needs_confirmation" || result.status === "unsupported" || result.status === "partial" || result.status === "timeout";
 }
 function interruptionType(result, blocker) {
   switch (blocker?.kind) {
@@ -8208,6 +8403,7 @@ function interruptionType(result, blocker) {
       break;
   }
   if (result.status === "needs_confirmation") return "approval_required";
+  if (result.status === "partial") return "timeout";
   if (result.status === "timeout") return "timeout";
   return "unsupported";
 }

--- a/scripts/check-node-pack.mjs
+++ b/scripts/check-node-pack.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+const REQUIRED_FILES = [
+  "package.json",
+  "README.md",
+  "LICENSE",
+  "CHANGELOG.md",
+  "dist/src/index.js",
+  "dist/src/index.d.ts",
+  "dist/codex-chatgpt-control.bundle.mjs",
+  "dist/codex-chatgpt-control-backend.mjs",
+  "contracts/v1/manifest.json"
+];
+
+const FORBIDDEN_PATTERNS = [
+  /^node_modules\//,
+  /^reports\//,
+  /^tests\//,
+  /^src\/.*\.ts$/,
+  /\.map$/,
+  /\.env(?:\.|$)/,
+  /live-smoke\/.*\.json$/,
+  /__pycache__/
+];
+
+function main() {
+  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: new URL("../packages/node", import.meta.url),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+
+  const packs = JSON.parse(output);
+  const pack = packs[0];
+  if (!pack) throw new Error("npm pack did not return a package summary");
+
+  const files = pack.files.map(file => file.path).sort();
+  const missing = REQUIRED_FILES.filter(file => !files.includes(file));
+  const forbidden = files.filter(file => FORBIDDEN_PATTERNS.some(pattern => pattern.test(file)));
+
+  const summary = {
+    name: pack.name,
+    version: pack.version,
+    filename: pack.filename,
+    files: files.length,
+    unpackedSize: pack.unpackedSize,
+    missing,
+    forbidden
+  };
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (missing.length > 0 || forbidden.length > 0) {
+    process.exit(1);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+const NODE_PACKAGE = "codex-chatgpt-control";
+const PYTHON_PACKAGE = "codex-chatgpt-control";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--tag") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("--tag requires a value");
+      args.tag = value;
+      i += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/check-release-version.mjs [--tag v0.2.0-alpha.1]
+
+Validates that the release tag, root package version, Node package version, and
+Python package version describe the same release.
+`);
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(new URL(path, import.meta.url), "utf8"));
+}
+
+async function readPythonMetadata() {
+  const pyproject = await readFile(new URL("../packages/python/pyproject.toml", import.meta.url), "utf8");
+  const name = pyproject.match(/^name\s*=\s*"([^"]+)"/m)?.[1];
+  const version = pyproject.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+  if (!name || !version) throw new Error("Unable to read Python package name/version from packages/python/pyproject.toml");
+  return { name, version };
+}
+
+function tagFromEnvironment() {
+  if (process.env.RELEASE_TAG) return process.env.RELEASE_TAG;
+  if (process.env.GITHUB_REF_TYPE === "tag" && process.env.GITHUB_REF_NAME) return process.env.GITHUB_REF_NAME;
+  if (process.env.GITHUB_REF?.startsWith("refs/tags/")) return process.env.GITHUB_REF.slice("refs/tags/".length);
+  return undefined;
+}
+
+function normalizeTag(tag) {
+  return tag.replace(/^refs\/tags\//, "").replace(/^v/, "");
+}
+
+function expectedPythonVersion(nodeVersion) {
+  const stable = nodeVersion.match(/^(\d+\.\d+\.\d+)$/);
+  if (stable) return stable[1];
+
+  const prerelease = nodeVersion.match(/^(\d+\.\d+\.\d+)-(alpha|beta|rc)\.(\d+)$/);
+  if (!prerelease) {
+    throw new Error(`Unsupported release version format: ${nodeVersion}`);
+  }
+
+  const [, base, channel, number] = prerelease;
+  const pythonChannel = channel === "alpha" ? "a" : channel === "beta" ? "b" : "rc";
+  return `${base}${pythonChannel}${number}`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const rootPackage = await readJson("../package.json");
+  const nodePackage = await readJson("../packages/node/package.json");
+  const pythonPackage = await readPythonMetadata();
+
+  const tag = args.tag ?? tagFromEnvironment();
+  const normalizedTag = tag ? normalizeTag(tag) : undefined;
+  const expectedPython = expectedPythonVersion(nodePackage.version);
+
+  const errors = [];
+  if (rootPackage.version !== nodePackage.version) {
+    errors.push(`Root package version ${rootPackage.version} does not match Node package version ${nodePackage.version}`);
+  }
+  if (nodePackage.name !== NODE_PACKAGE) {
+    errors.push(`Node package name ${nodePackage.name} does not match ${NODE_PACKAGE}`);
+  }
+  if (pythonPackage.name !== PYTHON_PACKAGE) {
+    errors.push(`Python package name ${pythonPackage.name} does not match ${PYTHON_PACKAGE}`);
+  }
+  if (pythonPackage.version !== expectedPython) {
+    errors.push(`Python package version ${pythonPackage.version} does not match expected ${expectedPython} for Node ${nodePackage.version}`);
+  }
+  if (normalizedTag && normalizedTag !== nodePackage.version) {
+    errors.push(`Release tag ${tag} resolves to ${normalizedTag}, but Node package version is ${nodePackage.version}`);
+  }
+
+  const summary = {
+    tag: tag ?? null,
+    normalizedTag: normalizedTag ?? null,
+    rootVersion: rootPackage.version,
+    node: {
+      package: nodePackage.name,
+      version: nodePackage.version
+    },
+    python: {
+      package: pythonPackage.name,
+      version: pythonPackage.version,
+      expectedVersion: expectedPython
+    }
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (errors.length > 0) {
+    for (const error of errors) console.error(error);
+    process.exit(1);
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- exports long-response partial-capture hardening from the private source tree
- exports the docs/surface drift gate and regenerated plugin runtime bundles
- adds a tag-triggered trusted-publishing workflow for npm and PyPI without pushing a release tag

## Validation

- private: npm --prefix work/chatgpt-browser-control run build
- private: npm --prefix work/chatgpt-browser-control run contract:validate
- private: npm --prefix work/chatgpt-browser-control run parity:fixtures
- private: npm --prefix work/chatgpt-browser-control run parity:suite
- private: npm --prefix work/chatgpt-browser-control run docs:drift
- private: npm --prefix work/chatgpt-browser-control run test:backend-conformance
- private: npm --prefix work/chatgpt-browser-control test
- private: Python unittest/compileall/pyright/ordinary-shell smoke in isolated venv
- private: plugin runtime build/check
- private: node tools/public-export/export-public.mjs --check
- public: npm run node:test
- public: npm run node:build
- public: npm run node:contracts
- public: npm run node:bundle
- public: npm run plugin:build && npm run plugin:check
- public: npm run release:check-version -- --tag v0.2.0-alpha.1
- public: npm run release:check-names
- public: npm run release:check-node-pack
- public: npm run python:test
- public: npm run python:compile
- public: npm run python:pyright
- public: npm run python:ordinary-shell
- public: npm run release:build-python && npm run release:check-python

## Release Note

No `v*` release tag was pushed. This PR can merge without publishing to npm or PyPI; package publication remains gated on a future tag plus the protected `release` environment approval.