### PR TITLE
[codex] Make long ChatGPT Pro consults recoverable across timeout layers

### DIFF
--- a/packages/node/src/commands/messages.ts
+++ b/packages/node/src/commands/messages.ts
@@ -1,6 +1,6 @@
 import { readPageState } from "../browser/page-state.js";
 import { resultError, resultOk } from "../errors.js";
-import { latestAssistantTurnHasResponseActions, readAssistantGenerationState, type AssistantGenerationState } from "../dom/generation-state.js";
+import { EMPTY_GENERATION_STATE, latestAssistantTurnHasResponseActions, readAssistantGenerationState, type AssistantGenerationState } from "../dom/generation-state.js";
 import { countPageMessages, isTransientAssistantText, readLatestMessage, readLatestMessageText, readLatestMessageTextSnapshot, readMessages } from "../dom/messages.js";
 import { composerTextbox, sendButton } from "../dom/selectors.js";
 import { normalizeLineBreaks, normalizeWhitespace } from "../dom/visible-text.js";
@@ -23,6 +23,7 @@ import type {
 import { contextFromPage } from "./context.js";
 import { withCommandOutputText } from "./output.js";
 import { bootstrap } from "./session.js";
+import { localGuardTimeout, withTimeout } from "./timeouts.js";
 
 export type CompletionSnapshot = {
   textStableForMs: number;
@@ -347,10 +348,18 @@ export async function waitForMessage(
   const started = Date.now();
   let lastTargetText = "";
   let lastChangedAt = Date.now();
-  let latestAssistantCount = await countPageMessages(page, "assistant").catch(() => 0);
+  let latestAssistantCount = await withTimeout(
+    countPageMessages(page, "assistant"),
+    localGuardTimeout(timeoutMs, 10000),
+    "Timed out while counting assistant messages."
+  ).catch(() => 0);
 
   while (Date.now() - started < timeoutMs) {
-    const state = await readPageState(page).catch(() => undefined);
+    const state = await withTimeout(
+      readPageState(page),
+      localGuardTimeout(timeoutMs, 10000),
+      "Timed out while reading ChatGPT page state."
+    ).catch(() => undefined);
     if (state?.blocker !== undefined && state.blocker.kind !== "modal") {
       return {
         ok: false,
@@ -361,7 +370,11 @@ export async function waitForMessage(
       };
     }
 
-    const progress = await readAssistantProgressSnapshot(page)
+    const progress = await withTimeout(
+      readAssistantProgressSnapshot(page),
+      localGuardTimeout(timeoutMs, 10000),
+      "Timed out while reading assistant progress."
+    )
       .catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
     latestAssistantCount = progress.assistantTurnCount;
     const targetReached = waitTargetReached(args, progress);
@@ -376,8 +389,16 @@ export async function waitForMessage(
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      generation: await readAssistantGenerationState(page),
-      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
+      generation: await withTimeout(
+        readAssistantGenerationState(page),
+        localGuardTimeout(timeoutMs, 10000),
+        "Timed out while reading assistant generation state."
+      ).catch(() => EMPTY_GENERATION_STATE),
+      hasResponseActions: await withTimeout(
+        latestAssistantTurnHasResponseActions(page),
+        5000,
+        "Timed out while checking response actions."
+      ).catch(() => false)
     };
 
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
@@ -764,7 +785,11 @@ async function fallbackAssistantProgressSnapshot(
   page: PageLike,
   previousAssistantTurnCount: number
 ): Promise<AssistantProgressSnapshot> {
-  const messages = await readMessages(page, { format: "normalized_text" }).catch(() => undefined);
+  const messages = await withTimeout(
+    readMessages(page, { format: "normalized_text" }),
+    5000,
+    "Timed out while reading messages."
+  ).catch(() => undefined);
   if (messages !== undefined) {
     let latestAssistantTurnIndex = -1;
     for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -785,10 +810,22 @@ async function fallbackAssistantProgressSnapshot(
   }
 
   const snapshot: AssistantProgressSnapshot = {
-    assistantTurnCount: await countPageMessages(page, "assistant").catch(() => previousAssistantTurnCount)
+    assistantTurnCount: await withTimeout(
+      countPageMessages(page, "assistant"),
+      5000,
+      "Timed out while counting assistant messages."
+    ).catch(() => previousAssistantTurnCount)
   };
-  const latestText = await readLatestMessageText(page, "assistant").catch(() => undefined);
-  const turnCount = await countPageMessages(page).catch(() => undefined);
+  const latestText = await withTimeout(
+    readLatestMessageText(page, "assistant"),
+    5000,
+    "Timed out while reading latest assistant text."
+  ).catch(() => undefined);
+  const turnCount = await withTimeout(
+    countPageMessages(page),
+    5000,
+    "Timed out while counting messages."
+  ).catch(() => undefined);
   if (latestText !== undefined) snapshot.latestText = latestText;
   if (turnCount !== undefined) snapshot.turnCount = turnCount;
   return snapshot;

--- a/packages/node/src/commands/modes.ts
+++ b/packages/node/src/commands/modes.ts
@@ -1,5 +1,5 @@
 import { resultError, resultOk } from "../errors.js";
-import { enumerateVisibleMenuItems, findUniqueMenuItem, type MenuItem } from "../dom/menus.js";
+import { enumerateVisibleMenuItems, findUniqueMenuItem, visibleLabelMatches, type MenuItem } from "../dom/menus.js";
 import { localeLabels } from "../dom/locale-labels.js";
 import { normalizeLabel, normalizeWhitespace } from "../dom/visible-text.js";
 import type { CommandResult, LocatorLike, PageLike, RuntimeEnv, SelectToolArgs, SetModeArgs } from "../types.js";
@@ -43,6 +43,9 @@ export async function setMode(
     }
     await page.waitForTimeout?.(250);
     const candidates = await enumerateVisibleMenuItems(page);
+    if (candidates.length > 0 && !looksLikeModeMenu(candidates.map(candidate => candidate.label))) {
+      return selectorDrift(page, "Opened menu does not look like a model/mode menu.", candidates.map(candidate => candidate.label));
+    }
     const selected: string[] = [];
 
     for (const item of requested) {
@@ -361,17 +364,6 @@ function findUniqueVisibleLabel(labels: string[], wanted: string): string | unde
 
   const fuzzy = labels.filter(label => visibleLabelMatches(normalizeLabel(label), normalized));
   return fuzzy.length === 1 ? fuzzy[0] : undefined;
-}
-
-function visibleLabelMatches(label: string, wanted: string): boolean {
-  if (wanted.length <= 3) {
-    return new RegExp(`(^|[^a-z0-9])${escapeRegExp(wanted)}([^a-z0-9]|$)`, "i").test(label);
-  }
-  return label.includes(wanted);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function escapeAttributeValue(value: string): string {

--- a/packages/node/src/commands/threads.ts
+++ b/packages/node/src/commands/threads.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types.js";
 import { contextFromPage } from "./context.js";
 import { bootstrap } from "./session.js";
+import { withTimeout } from "./timeouts.js";
 
 const CHATGPT_HOME = "https://chatgpt.com/";
 
@@ -129,13 +130,21 @@ export async function openThread(
       };
     }
 
-    if (target.href !== undefined && target.href.startsWith("/")) {
-      await page.goto?.(new URL(target.href, CHATGPT_HOME).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 30000 });
-    } else {
-      await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 30000 });
+    const targetConversationId = parseConversationId(target.url);
+    const currentUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+    const currentConversationId = typeof currentUrl === "string" ? parseConversationId(currentUrl) : undefined;
+    const alreadyOnTarget = targetConversationId !== undefined
+      && currentConversationId === targetConversationId;
+
+    if (!alreadyOnTarget) {
+      if (target.href !== undefined && target.href.startsWith("/")) {
+        await page.goto?.(new URL(target.href, CHATGPT_HOME).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 30000 });
+      } else {
+        await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 30000 });
+      }
     }
 
-    await waitForThreadHydrated(page, args.timeoutMs ?? 30000, parseConversationId(target.url));
+    await waitForThreadHydrated(page, args.timeoutMs ?? 30000, targetConversationId);
     const state = await readPageState(page);
     return resultOk(
       openThreadData(state.url, state.conversationId, state.title ?? target.title),
@@ -354,9 +363,9 @@ async function waitForThreadHydrated(
   await page.waitForTimeout?.(1000);
   while (Date.now() - started < timeoutMs) {
     const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
-    const urlMatches = expectedConversationId === undefined || url.includes(expectedConversationId);
-    const count = await countPageMessages(page).catch(() => 0);
-    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => undefined);
+    const urlMatches = expectedConversationId === undefined || parseConversationId(url) === expectedConversationId;
+    const count = await withTimeout(countPageMessages(page), 5000, "Timed out while counting thread messages.").catch(() => 0);
+    const latestAssistantText = await withTimeout(readLatestMessageText(page, "assistant"), 5000, "Timed out while reading latest assistant text.").catch(() => undefined);
     const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
     if (urlMatches && ((latestAssistantText?.trim().length ?? 0) > 0 || (count > 0 && title.length > 0 && title !== "ChatGPT"))) {
       await page.waitForTimeout?.(250);

--- a/packages/node/src/dom/generation-state.ts
+++ b/packages/node/src/dom/generation-state.ts
@@ -8,7 +8,7 @@ export type AssistantGenerationState = {
   signals: string[];
 };
 
-const EMPTY_GENERATION_STATE: AssistantGenerationState = {
+export const EMPTY_GENERATION_STATE: AssistantGenerationState = {
   active: false,
   stopped: false,
   signals: []

--- a/packages/node/src/dom/menus.ts
+++ b/packages/node/src/dom/menus.ts
@@ -82,6 +82,17 @@ export function findUniqueMenuItem(items: MenuItem[], wanted: string): MenuItem 
     return exact[0];
   }
 
-  const fuzzy = items.filter(item => item.normalized.includes(normalized));
+  const fuzzy = items.filter(item => visibleLabelMatches(item.normalized, normalized));
   return fuzzy.length === 1 ? fuzzy[0] : undefined;
+}
+
+export function visibleLabelMatches(label: string, wanted: string): boolean {
+  if (wanted.length <= 3) {
+    return new RegExp(`(^|[^a-z0-9])${escapeRegExp(wanted)}([^a-z0-9]|$)`, "i").test(label);
+  }
+  return label.includes(wanted);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/node/tests/unit/menus.test.ts
+++ b/packages/node/tests/unit/menus.test.ts
@@ -14,4 +14,16 @@ describe("menu helpers", () => {
     const items = extractMenuItemsFromText("Web search\nDeep research\nCreate image");
     expect(findUniqueMenuItem(items, "deep")?.label).toBe("Deep research");
   });
+
+  it("does not match short labels inside unrelated words", () => {
+    const items = extractMenuItemsFromText("Share\nRename\nMove to project");
+
+    expect(findUniqueMenuItem(items, "Pro")).toBeUndefined();
+  });
+
+  it("still matches short mode labels as visible label tokens", () => {
+    const items = extractMenuItemsFromText("Instant\nMedium\nHigh\nExtra High\nPro Extended");
+
+    expect(findUniqueMenuItem(items, "Pro")?.label).toBe("Pro Extended");
+  });
 });

--- a/packages/node/tests/unit/messages.test.ts
+++ b/packages/node/tests/unit/messages.test.ts
@@ -162,6 +162,49 @@ describe("extractMessagesFromHtml", () => {
     expect(result.data?.assistantTurnCount).toBe(2);
   });
 
+  it("uses the guarded fallback when assistant progress DOM reads hang", async () => {
+    let progressAttempts = 0;
+    const page: PageLike = {
+      evaluate: async <T, A = unknown>(fn: (arg: A) => T | Promise<T>, arg?: A): Promise<T> => {
+        const source = String(fn);
+        if (source.includes("document.querySelectorAll(selector).length")) {
+          return (arg === "assistant" ? 1 : 2) as T;
+        }
+        if (source.includes("document.body?.innerText")) {
+          return "New chat Chat with ChatGPT" as T;
+        }
+        if (source.includes("assistantNodes") && source.includes("latestAssistantTurnIndex")) {
+          progressAttempts += 1;
+          return await new Promise<T>(() => {});
+        }
+        if (source.includes("metadataHtml")) {
+          return [{ role: "assistant", html: "guarded fallback", metadataHtml: "guarded fallback" }] as T;
+        }
+        if (source.includes("visibleButtons")) {
+          return { active: false, stopped: false, signals: [] } as T;
+        }
+        if (source.includes("const turns = Array.from")) {
+          return true as T;
+        }
+        throw new Error(`Unexpected evaluate call: ${source}`);
+      },
+      waitForTimeout: async () => {},
+      title: async () => "ChatGPT",
+      url: () => "https://chatgpt.com/c/abc-123"
+    };
+
+    const result = await waitForMessage({ page }, {
+      afterAssistantTurnCount: 0,
+      timeoutMs: 80,
+      stableMs: 0,
+      pollMs: 1
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output_text).toBe("guarded fallback");
+    expect(progressAttempts).toBeGreaterThan(0);
+  });
+
   it("requires the latest assistant turn to be after the requested total turn baseline", async () => {
     const page = scriptedWaitPage([
       {

--- a/packages/node/tests/unit/modes.test.ts
+++ b/packages/node/tests/unit/modes.test.ts
@@ -83,6 +83,23 @@ describe("mode and tool selection blockers", () => {
     });
   });
 
+  it("rejects a non-mode menu opened while selecting Pro", async () => {
+    const page = modeButtonMenuPage(
+      [{ text: "High" }],
+      ["Share", "Rename", "Move to project"]
+    );
+
+    const result = await setMode({ page }, { model: "Pro" });
+
+    expect(result.ok).toBe(false);
+    expect(result.blocker).toMatchObject({
+      kind: "selector_drift",
+      code: "visible_candidate_not_found",
+      message: "Opened menu does not look like a model/mode menu.",
+      candidates: [{ label: "Share" }, { label: "Rename" }, { label: "Move to project" }]
+    });
+  });
+
   it("opens the new intelligence picker from the current High button and selects Pro", async () => {
     const page = intelligencePickerPage({ current: "High" });
 

--- a/packages/node/tests/unit/threads.test.ts
+++ b/packages/node/tests/unit/threads.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { openThread } from "../../src/commands/threads.js";
+import type { PageLike } from "../../src/types.js";
+
+describe("thread commands", () => {
+  it("does not reload when already on the target conversation", async () => {
+    const targetUrl = "https://chatgpt.com/c/abc-123";
+    const gotoCalls: string[] = [];
+    const page: PageLike = {
+      url: () => targetUrl,
+      goto: async url => {
+        gotoCalls.push(url);
+      },
+      title: async () => "Existing thread",
+      content: async () => [
+        "<main>",
+        "<div data-message-author-role=\"user\">hello</div>",
+        "<div data-message-author-role=\"assistant\">hi</div>",
+        "</main>"
+      ].join(""),
+      waitForTimeout: async () => {}
+    };
+
+    const result = await openThread({ page }, { conversationId: "abc-123", timeoutMs: 10 });
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.conversationId).toBe("abc-123");
+    expect(gotoCalls).toEqual([]);
+  });
+
+  it("navigates when the current tab is on a different conversation", async () => {
+    const gotoCalls: string[] = [];
+    let currentUrl = "https://chatgpt.com/c/other";
+    const page: PageLike = {
+      url: () => currentUrl,
+      goto: async url => {
+        gotoCalls.push(url);
+        currentUrl = url;
+      },
+      title: async () => "Target thread",
+      content: async () => [
+        "<main>",
+        "<div data-message-author-role=\"assistant\">target answer</div>",
+        "</main>"
+      ].join(""),
+      waitForTimeout: async () => {}
+    };
+
+    const result = await openThread({ page }, { conversationId: "abc-123", timeoutMs: 10 });
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.conversationId).toBe("abc-123");
+    expect(gotoCalls).toEqual(["https://chatgpt.com/c/abc-123"]);
+  });
+});

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
@@ -6002,9 +6002,17 @@ async function waitForMessage(env, args = {}) {
   const started = Date.now();
   let lastTargetText = "";
   let lastChangedAt = Date.now();
-  let latestAssistantCount = await countPageMessages(page, "assistant").catch(() => 0);
+  let latestAssistantCount = await withTimeout(
+    countPageMessages(page, "assistant"),
+    localGuardTimeout(timeoutMs, 1e4),
+    "Timed out while counting assistant messages."
+  ).catch(() => 0);
   while (Date.now() - started < timeoutMs) {
-    const state = await readPageState(page).catch(() => void 0);
+    const state = await withTimeout(
+      readPageState(page),
+      localGuardTimeout(timeoutMs, 1e4),
+      "Timed out while reading ChatGPT page state."
+    ).catch(() => void 0);
     if (state?.blocker !== void 0 && state.blocker.kind !== "modal") {
       return {
         ok: false,
@@ -6014,7 +6022,11 @@ async function waitForMessage(env, args = {}) {
         context: await contextFromPage(page)
       };
     }
-    const progress = await readAssistantProgressSnapshot(page).catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
+    const progress = await withTimeout(
+      readAssistantProgressSnapshot(page),
+      localGuardTimeout(timeoutMs, 1e4),
+      "Timed out while reading assistant progress."
+    ).catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
     latestAssistantCount = progress.assistantTurnCount;
     const targetReached = waitTargetReached(args, progress);
     const latestText = targetReached ? normalizeWhitespace(progress.latestText ?? "") : "";
@@ -6026,8 +6038,16 @@ async function waitForMessage(env, args = {}) {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      generation: await readAssistantGenerationState(page),
-      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
+      generation: await withTimeout(
+        readAssistantGenerationState(page),
+        localGuardTimeout(timeoutMs, 1e4),
+        "Timed out while reading assistant generation state."
+      ).catch(() => EMPTY_GENERATION_STATE),
+      hasResponseActions: await withTimeout(
+        latestAssistantTurnHasResponseActions(page),
+        5e3,
+        "Timed out while checking response actions."
+      ).catch(() => false)
     };
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
       return withCommandOutputText({
@@ -6342,7 +6362,11 @@ async function readAssistantProgressSnapshot(page) {
   return fallbackAssistantProgressSnapshot(page, 0);
 }
 async function fallbackAssistantProgressSnapshot(page, previousAssistantTurnCount) {
-  const messages = await readMessages(page, { format: "normalized_text" }).catch(() => void 0);
+  const messages = await withTimeout(
+    readMessages(page, { format: "normalized_text" }),
+    5e3,
+    "Timed out while reading messages."
+  ).catch(() => void 0);
   if (messages !== void 0) {
     let latestAssistantTurnIndex = -1;
     for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -6362,10 +6386,22 @@ async function fallbackAssistantProgressSnapshot(page, previousAssistantTurnCoun
     return snapshot2;
   }
   const snapshot = {
-    assistantTurnCount: await countPageMessages(page, "assistant").catch(() => previousAssistantTurnCount)
+    assistantTurnCount: await withTimeout(
+      countPageMessages(page, "assistant"),
+      5e3,
+      "Timed out while counting assistant messages."
+    ).catch(() => previousAssistantTurnCount)
   };
-  const latestText = await readLatestMessageText(page, "assistant").catch(() => void 0);
-  const turnCount = await countPageMessages(page).catch(() => void 0);
+  const latestText = await withTimeout(
+    readLatestMessageText(page, "assistant"),
+    5e3,
+    "Timed out while reading latest assistant text."
+  ).catch(() => void 0);
+  const turnCount = await withTimeout(
+    countPageMessages(page),
+    5e3,
+    "Timed out while counting messages."
+  ).catch(() => void 0);
   if (latestText !== void 0) snapshot.latestText = latestText;
   if (turnCount !== void 0) snapshot.turnCount = turnCount;
   return snapshot;
@@ -6481,8 +6517,17 @@ function findUniqueMenuItem(items, wanted) {
   if (exact.length === 1) {
     return exact[0];
   }
-  const fuzzy = items.filter((item) => item.normalized.includes(normalized));
+  const fuzzy = items.filter((item) => visibleLabelMatches(item.normalized, normalized));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
+}
+function visibleLabelMatches(label, wanted) {
+  if (wanted.length <= 3) {
+    return new RegExp(`(^|[^a-z0-9])${escapeRegExp2(wanted)}([^a-z0-9]|$)`, "i").test(label);
+  }
+  return label.includes(wanted);
+}
+function escapeRegExp2(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // src/commands/modes.ts
@@ -6517,6 +6562,9 @@ async function setMode(env, args) {
     }
     await page.waitForTimeout?.(250);
     const candidates = await enumerateVisibleMenuItems(page);
+    if (candidates.length > 0 && !looksLikeModeMenu(candidates.map((candidate) => candidate.label))) {
+      return selectorDrift(page, "Opened menu does not look like a model/mode menu.", candidates.map((candidate) => candidate.label));
+    }
     const selected = [];
     for (const item of requested) {
       const match = findModeMenuItem(candidates, item);
@@ -6769,15 +6817,6 @@ function findUniqueVisibleLabel(labels, wanted) {
   }
   const fuzzy = labels.filter((label) => visibleLabelMatches(normalizeLabel(label), normalized));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
-}
-function visibleLabelMatches(label, wanted) {
-  if (wanted.length <= 3) {
-    return new RegExp(`(^|[^a-z0-9])${escapeRegExp2(wanted)}([^a-z0-9]|$)`, "i").test(label);
-  }
-  return label.includes(wanted);
-}
-function escapeRegExp2(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 function escapeAttributeValue(value) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
@@ -7879,12 +7918,18 @@ async function openThread(env, args, previousResults) {
         context: await contextFromPage(page)
       };
     }
-    if (target.href !== void 0 && target.href.startsWith("/")) {
-      await page.goto?.(new URL(target.href, CHATGPT_HOME2).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
-    } else {
-      await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+    const targetConversationId = parseConversationId(target.url);
+    const currentUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+    const currentConversationId = typeof currentUrl === "string" ? parseConversationId(currentUrl) : void 0;
+    const alreadyOnTarget = targetConversationId !== void 0 && currentConversationId === targetConversationId;
+    if (!alreadyOnTarget) {
+      if (target.href !== void 0 && target.href.startsWith("/")) {
+        await page.goto?.(new URL(target.href, CHATGPT_HOME2).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+      } else {
+        await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+      }
     }
-    await waitForThreadHydrated(page, args.timeoutMs ?? 3e4, parseConversationId(target.url));
+    await waitForThreadHydrated(page, args.timeoutMs ?? 3e4, targetConversationId);
     const state = await readPageState(page);
     return resultOk(
       openThreadData(state.url, state.conversationId, state.title ?? target.title),
@@ -8057,9 +8102,9 @@ async function waitForThreadHydrated(page, timeoutMs, expectedConversationId) {
   await page.waitForTimeout?.(1e3);
   while (Date.now() - started < timeoutMs) {
     const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
-    const urlMatches2 = expectedConversationId === void 0 || url.includes(expectedConversationId);
-    const count = await countPageMessages(page).catch(() => 0);
-    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => void 0);
+    const urlMatches2 = expectedConversationId === void 0 || parseConversationId(url) === expectedConversationId;
+    const count = await withTimeout(countPageMessages(page), 5e3, "Timed out while counting thread messages.").catch(() => 0);
+    const latestAssistantText = await withTimeout(readLatestMessageText(page, "assistant"), 5e3, "Timed out while reading latest assistant text.").catch(() => void 0);
     const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
     if (urlMatches2 && ((latestAssistantText?.trim().length ?? 0) > 0 || count > 0 && title.length > 0 && title !== "ChatGPT")) {
       await page.waitForTimeout?.(250);

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
@@ -4122,12 +4122,18 @@ async function openThread(env, args, previousResults) {
         context: await contextFromPage(page)
       };
     }
-    if (target.href !== void 0 && target.href.startsWith("/")) {
-      await page.goto?.(new URL(target.href, CHATGPT_HOME2).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
-    } else {
-      await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+    const targetConversationId = parseConversationId(target.url);
+    const currentUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+    const currentConversationId = typeof currentUrl === "string" ? parseConversationId(currentUrl) : void 0;
+    const alreadyOnTarget = targetConversationId !== void 0 && currentConversationId === targetConversationId;
+    if (!alreadyOnTarget) {
+      if (target.href !== void 0 && target.href.startsWith("/")) {
+        await page.goto?.(new URL(target.href, CHATGPT_HOME2).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+      } else {
+        await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+      }
     }
-    await waitForThreadHydrated(page, args.timeoutMs ?? 3e4, parseConversationId(target.url));
+    await waitForThreadHydrated(page, args.timeoutMs ?? 3e4, targetConversationId);
     const state = await readPageState(page);
     return resultOk(
       openThreadData(state.url, state.conversationId, state.title ?? target.title),
@@ -4300,9 +4306,9 @@ async function waitForThreadHydrated(page, timeoutMs, expectedConversationId) {
   await page.waitForTimeout?.(1e3);
   while (Date.now() - started < timeoutMs) {
     const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
-    const urlMatches2 = expectedConversationId === void 0 || url.includes(expectedConversationId);
-    const count = await countPageMessages(page).catch(() => 0);
-    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => void 0);
+    const urlMatches2 = expectedConversationId === void 0 || parseConversationId(url) === expectedConversationId;
+    const count = await withTimeout2(countPageMessages(page), 5e3, "Timed out while counting thread messages.").catch(() => 0);
+    const latestAssistantText = await withTimeout2(readLatestMessageText(page, "assistant"), 5e3, "Timed out while reading latest assistant text.").catch(() => void 0);
     const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
     if (urlMatches2 && ((latestAssistantText?.trim().length ?? 0) > 0 || count > 0 && title.length > 0 && title !== "ChatGPT")) {
       await page.waitForTimeout?.(250);
@@ -4668,9 +4674,17 @@ async function waitForMessage(env, args = {}) {
   const started = Date.now();
   let lastTargetText = "";
   let lastChangedAt = Date.now();
-  let latestAssistantCount = await countPageMessages(page, "assistant").catch(() => 0);
+  let latestAssistantCount = await withTimeout2(
+    countPageMessages(page, "assistant"),
+    localGuardTimeout(timeoutMs, 1e4),
+    "Timed out while counting assistant messages."
+  ).catch(() => 0);
   while (Date.now() - started < timeoutMs) {
-    const state = await readPageState(page).catch(() => void 0);
+    const state = await withTimeout2(
+      readPageState(page),
+      localGuardTimeout(timeoutMs, 1e4),
+      "Timed out while reading ChatGPT page state."
+    ).catch(() => void 0);
     if (state?.blocker !== void 0 && state.blocker.kind !== "modal") {
       return {
         ok: false,
@@ -4680,7 +4694,11 @@ async function waitForMessage(env, args = {}) {
         context: await contextFromPage(page)
       };
     }
-    const progress = await readAssistantProgressSnapshot(page).catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
+    const progress = await withTimeout2(
+      readAssistantProgressSnapshot(page),
+      localGuardTimeout(timeoutMs, 1e4),
+      "Timed out while reading assistant progress."
+    ).catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
     latestAssistantCount = progress.assistantTurnCount;
     const targetReached = waitTargetReached(args, progress);
     const latestText = targetReached ? normalizeWhitespace(progress.latestText ?? "") : "";
@@ -4692,8 +4710,16 @@ async function waitForMessage(env, args = {}) {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      generation: await readAssistantGenerationState(page),
-      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
+      generation: await withTimeout2(
+        readAssistantGenerationState(page),
+        localGuardTimeout(timeoutMs, 1e4),
+        "Timed out while reading assistant generation state."
+      ).catch(() => EMPTY_GENERATION_STATE),
+      hasResponseActions: await withTimeout2(
+        latestAssistantTurnHasResponseActions(page),
+        5e3,
+        "Timed out while checking response actions."
+      ).catch(() => false)
     };
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
       return withCommandOutputText({
@@ -5008,7 +5034,11 @@ async function readAssistantProgressSnapshot(page) {
   return fallbackAssistantProgressSnapshot(page, 0);
 }
 async function fallbackAssistantProgressSnapshot(page, previousAssistantTurnCount) {
-  const messages = await readMessages(page, { format: "normalized_text" }).catch(() => void 0);
+  const messages = await withTimeout2(
+    readMessages(page, { format: "normalized_text" }),
+    5e3,
+    "Timed out while reading messages."
+  ).catch(() => void 0);
   if (messages !== void 0) {
     let latestAssistantTurnIndex = -1;
     for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -5028,10 +5058,22 @@ async function fallbackAssistantProgressSnapshot(page, previousAssistantTurnCoun
     return snapshot2;
   }
   const snapshot = {
-    assistantTurnCount: await countPageMessages(page, "assistant").catch(() => previousAssistantTurnCount)
+    assistantTurnCount: await withTimeout2(
+      countPageMessages(page, "assistant"),
+      5e3,
+      "Timed out while counting assistant messages."
+    ).catch(() => previousAssistantTurnCount)
   };
-  const latestText = await readLatestMessageText(page, "assistant").catch(() => void 0);
-  const turnCount = await countPageMessages(page).catch(() => void 0);
+  const latestText = await withTimeout2(
+    readLatestMessageText(page, "assistant"),
+    5e3,
+    "Timed out while reading latest assistant text."
+  ).catch(() => void 0);
+  const turnCount = await withTimeout2(
+    countPageMessages(page),
+    5e3,
+    "Timed out while counting messages."
+  ).catch(() => void 0);
   if (latestText !== void 0) snapshot.latestText = latestText;
   if (turnCount !== void 0) snapshot.turnCount = turnCount;
   return snapshot;
@@ -6962,8 +7004,17 @@ function findUniqueMenuItem(items, wanted) {
   if (exact.length === 1) {
     return exact[0];
   }
-  const fuzzy = items.filter((item) => item.normalized.includes(normalized));
+  const fuzzy = items.filter((item) => visibleLabelMatches(item.normalized, normalized));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
+}
+function visibleLabelMatches(label, wanted) {
+  if (wanted.length <= 3) {
+    return new RegExp(`(^|[^a-z0-9])${escapeRegExp2(wanted)}([^a-z0-9]|$)`, "i").test(label);
+  }
+  return label.includes(wanted);
+}
+function escapeRegExp2(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // src/commands/modes.ts
@@ -6998,6 +7049,9 @@ async function setMode(env, args) {
     }
     await page.waitForTimeout?.(250);
     const candidates = await enumerateVisibleMenuItems(page);
+    if (candidates.length > 0 && !looksLikeModeMenu(candidates.map((candidate) => candidate.label))) {
+      return selectorDrift(page, "Opened menu does not look like a model/mode menu.", candidates.map((candidate) => candidate.label));
+    }
     const selected = [];
     for (const item of requested) {
       const match = findModeMenuItem(candidates, item);
@@ -7250,15 +7304,6 @@ function findUniqueVisibleLabel(labels, wanted) {
   }
   const fuzzy = labels.filter((label) => visibleLabelMatches(normalizeLabel(label), normalized));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
-}
-function visibleLabelMatches(label, wanted) {
-  if (wanted.length <= 3) {
-    return new RegExp(`(^|[^a-z0-9])${escapeRegExp2(wanted)}([^a-z0-9]|$)`, "i").test(label);
-  }
-  return label.includes(wanted);
-}
-function escapeRegExp2(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 function escapeAttributeValue(value) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
@@ -4067,12 +4067,18 @@ async function openThread(env, args, previousResults) {
         context: await contextFromPage(page)
       };
     }
-    if (target.href !== void 0 && target.href.startsWith("/")) {
-      await page.goto?.(new URL(target.href, CHATGPT_HOME2).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
-    } else {
-      await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+    const targetConversationId = parseConversationId(target.url);
+    const currentUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+    const currentConversationId = typeof currentUrl === "string" ? parseConversationId(currentUrl) : void 0;
+    const alreadyOnTarget = targetConversationId !== void 0 && currentConversationId === targetConversationId;
+    if (!alreadyOnTarget) {
+      if (target.href !== void 0 && target.href.startsWith("/")) {
+        await page.goto?.(new URL(target.href, CHATGPT_HOME2).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+      } else {
+        await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+      }
     }
-    await waitForThreadHydrated(page, args.timeoutMs ?? 3e4, parseConversationId(target.url));
+    await waitForThreadHydrated(page, args.timeoutMs ?? 3e4, targetConversationId);
     const state = await readPageState(page);
     return resultOk(
       openThreadData(state.url, state.conversationId, state.title ?? target.title),
@@ -4245,9 +4251,9 @@ async function waitForThreadHydrated(page, timeoutMs, expectedConversationId) {
   await page.waitForTimeout?.(1e3);
   while (Date.now() - started < timeoutMs) {
     const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
-    const urlMatches2 = expectedConversationId === void 0 || url.includes(expectedConversationId);
-    const count = await countPageMessages(page).catch(() => 0);
-    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => void 0);
+    const urlMatches2 = expectedConversationId === void 0 || parseConversationId(url) === expectedConversationId;
+    const count = await withTimeout(countPageMessages(page), 5e3, "Timed out while counting thread messages.").catch(() => 0);
+    const latestAssistantText = await withTimeout(readLatestMessageText(page, "assistant"), 5e3, "Timed out while reading latest assistant text.").catch(() => void 0);
     const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
     if (urlMatches2 && ((latestAssistantText?.trim().length ?? 0) > 0 || count > 0 && title.length > 0 && title !== "ChatGPT")) {
       await page.waitForTimeout?.(250);
@@ -4613,9 +4619,17 @@ async function waitForMessage(env, args = {}) {
   const started = Date.now();
   let lastTargetText = "";
   let lastChangedAt = Date.now();
-  let latestAssistantCount = await countPageMessages(page, "assistant").catch(() => 0);
+  let latestAssistantCount = await withTimeout(
+    countPageMessages(page, "assistant"),
+    localGuardTimeout(timeoutMs, 1e4),
+    "Timed out while counting assistant messages."
+  ).catch(() => 0);
   while (Date.now() - started < timeoutMs) {
-    const state = await readPageState(page).catch(() => void 0);
+    const state = await withTimeout(
+      readPageState(page),
+      localGuardTimeout(timeoutMs, 1e4),
+      "Timed out while reading ChatGPT page state."
+    ).catch(() => void 0);
     if (state?.blocker !== void 0 && state.blocker.kind !== "modal") {
       return {
         ok: false,
@@ -4625,7 +4639,11 @@ async function waitForMessage(env, args = {}) {
         context: await contextFromPage(page)
       };
     }
-    const progress = await readAssistantProgressSnapshot(page).catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
+    const progress = await withTimeout(
+      readAssistantProgressSnapshot(page),
+      localGuardTimeout(timeoutMs, 1e4),
+      "Timed out while reading assistant progress."
+    ).catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
     latestAssistantCount = progress.assistantTurnCount;
     const targetReached = waitTargetReached(args, progress);
     const latestText = targetReached ? normalizeWhitespace(progress.latestText ?? "") : "";
@@ -4637,8 +4655,16 @@ async function waitForMessage(env, args = {}) {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      generation: await readAssistantGenerationState(page),
-      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
+      generation: await withTimeout(
+        readAssistantGenerationState(page),
+        localGuardTimeout(timeoutMs, 1e4),
+        "Timed out while reading assistant generation state."
+      ).catch(() => EMPTY_GENERATION_STATE),
+      hasResponseActions: await withTimeout(
+        latestAssistantTurnHasResponseActions(page),
+        5e3,
+        "Timed out while checking response actions."
+      ).catch(() => false)
     };
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
       return withCommandOutputText({
@@ -4953,7 +4979,11 @@ async function readAssistantProgressSnapshot(page) {
   return fallbackAssistantProgressSnapshot(page, 0);
 }
 async function fallbackAssistantProgressSnapshot(page, previousAssistantTurnCount) {
-  const messages = await readMessages(page, { format: "normalized_text" }).catch(() => void 0);
+  const messages = await withTimeout(
+    readMessages(page, { format: "normalized_text" }),
+    5e3,
+    "Timed out while reading messages."
+  ).catch(() => void 0);
   if (messages !== void 0) {
     let latestAssistantTurnIndex = -1;
     for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -4973,10 +5003,22 @@ async function fallbackAssistantProgressSnapshot(page, previousAssistantTurnCoun
     return snapshot2;
   }
   const snapshot = {
-    assistantTurnCount: await countPageMessages(page, "assistant").catch(() => previousAssistantTurnCount)
+    assistantTurnCount: await withTimeout(
+      countPageMessages(page, "assistant"),
+      5e3,
+      "Timed out while counting assistant messages."
+    ).catch(() => previousAssistantTurnCount)
   };
-  const latestText = await readLatestMessageText(page, "assistant").catch(() => void 0);
-  const turnCount = await countPageMessages(page).catch(() => void 0);
+  const latestText = await withTimeout(
+    readLatestMessageText(page, "assistant"),
+    5e3,
+    "Timed out while reading latest assistant text."
+  ).catch(() => void 0);
+  const turnCount = await withTimeout(
+    countPageMessages(page),
+    5e3,
+    "Timed out while counting messages."
+  ).catch(() => void 0);
   if (latestText !== void 0) snapshot.latestText = latestText;
   if (turnCount !== void 0) snapshot.turnCount = turnCount;
   return snapshot;
@@ -6918,8 +6960,17 @@ function findUniqueMenuItem(items, wanted) {
   if (exact.length === 1) {
     return exact[0];
   }
-  const fuzzy = items.filter((item) => item.normalized.includes(normalized));
+  const fuzzy = items.filter((item) => visibleLabelMatches(item.normalized, normalized));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
+}
+function visibleLabelMatches(label, wanted) {
+  if (wanted.length <= 3) {
+    return new RegExp(`(^|[^a-z0-9])${escapeRegExp2(wanted)}([^a-z0-9]|$)`, "i").test(label);
+  }
+  return label.includes(wanted);
+}
+function escapeRegExp2(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // src/commands/modes.ts
@@ -6954,6 +7005,9 @@ async function setMode(env, args) {
     }
     await page.waitForTimeout?.(250);
     const candidates = await enumerateVisibleMenuItems(page);
+    if (candidates.length > 0 && !looksLikeModeMenu(candidates.map((candidate) => candidate.label))) {
+      return selectorDrift(page, "Opened menu does not look like a model/mode menu.", candidates.map((candidate) => candidate.label));
+    }
     const selected = [];
     for (const item of requested) {
       const match = findModeMenuItem(candidates, item);
@@ -7206,15 +7260,6 @@ function findUniqueVisibleLabel(labels, wanted) {
   }
   const fuzzy = labels.filter((label) => visibleLabelMatches(normalizeLabel(label), normalized));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
-}
-function visibleLabelMatches(label, wanted) {
-  if (wanted.length <= 3) {
-    return new RegExp(`(^|[^a-z0-9])${escapeRegExp2(wanted)}([^a-z0-9]|$)`, "i").test(label);
-  }
-  return label.includes(wanted);
-}
-function escapeRegExp2(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 function escapeAttributeValue(value) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
@@ -10718,6 +10763,7 @@ export {
   validateAttachPaths,
   validateResponsesCreateArgs,
   verifyIntegritySidecar,
+  visibleLabelMatches,
   waitAndRead,
   waitForArtifact,
   waitForClipboardChange,

--- a/plugins/codex-chatgpt-control/skills/chatgpt-pro-consult/SKILL.md
+++ b/plugins/codex-chatgpt-control/skills/chatgpt-pro-consult/SKILL.md
@@ -17,7 +17,17 @@ This skill is a thin workflow over the `codex-chatgpt-control` plugin. Use the s
 - Prefer a fresh thread unless the user asked to continue a specific ChatGPT thread.
 - Return Markdown by default. Use redacted reports by default; raw prompt/response content is opt-in only.
 - Treat ChatGPT Pro output as another model's judgment, not verified truth. Verify current, legal, medical, financial, or high-stakes claims with primary sources.
-- Keep each Codex tool call bounded. Submit the prompt under Pro first, then poll/read in chunks.
+- Keep each Codex tool call bounded. Submit the prompt under Pro in one call, persist the thread metadata immediately, then poll/read in separate bounded calls. Never combine submit and read in one call.
+
+## Timeout Layering
+
+Three timeout layers apply to every consult; JS-level `timeoutMs` is the innermost and cannot extend the outer two:
+
+1. Codex MCP `tools/call` cap (default 120s; `tool_timeout_sec` under `[mcp_servers.node_repl]` in `~/.codex/config.toml` raises it). When it fires, the tool call errors but the kernel usually keeps running, so variables often survive into the next call.
+2. The `node_repl` `js` tool's `timeout_ms` argument (default 30000 ms). When it fires, the kernel resets and all variables are lost. Always pass an explicit `timeout_ms` on every `js` call that touches the browser, larger than any JS-level deadline.
+3. SDK-level `timeoutMs` (for example `messages.waitAndRead`). Keep it at or below 75-90s so this is the layer that fires and returns a structured `timeout` or `partial` result.
+
+Safe pattern: `timeoutMs: 75_000` in JS, `timeout_ms: 110000` on the `js` tool call.
 
 ## Runtime Loader
 
@@ -47,15 +57,21 @@ Do not import from an older manually installed skill runtime; the plugin-bundled
 
 ## Quick Consult
 
-```js
-const TOOL_CALL_SAFE_WAIT = {
-  timeoutMs: 90_000,
-  stableMs: 2_000,
-  pollMs: 750,
-  mode: "deep_research"
-};
+Run each step as its own `node_repl` call with an explicit `timeout_ms` (110000 is a good default for browser steps).
 
-const pro = chatgpt.agent({
+Step 1 - preflight (after the Runtime Loader):
+
+```js
+var doctor = await chatgpt.doctor({ check: ["bridge", "login"] });
+console.log(JSON.stringify({ ok: doctor.ok, status: doctor.status }, null, 2));
+```
+
+Stop on bridge or login blockers. If the previous turn left ChatGPT generating a long answer, the page may be slow; prefer plain sleeps between later read attempts over tight polling.
+
+Step 2 - submit only, then validate mode and persist metadata in the same call:
+
+```js
+var pro = chatgpt.agent({
   name: "chatgpt-pro-consultant",
   instructions: [
     "You are being consulted as ChatGPT Pro from a visible ChatGPT web session.",
@@ -70,43 +86,62 @@ const pro = chatgpt.agent({
   }
 });
 
-const submitted = await chatgpt.runner.run(pro, {
+var submitted = await chatgpt.runner.run(pro, {
   input: "Review this plan and recommend improvements:\n\n...",
   thread: { type: "new" },
   mode: { model: "Pro" },
   report: { enabled: true, includeContent: false }
 });
 
-const modeStep = submitted.steps?.find(step => step.id === "mode");
-if (!submitted.ok || modeStep?.ok === false) {
-  console.log(JSON.stringify({
-    status: "blocked_before_submit_or_mode_unclean",
-    thread: submitted.state?.thread ?? submitted.data?.thread,
-    modeStep,
-    interruptions: submitted.interruptions
-  }, null, 2));
-} else {
-  const read = await chatgpt.messages.waitAndRead({
-    ...TOOL_CALL_SAFE_WAIT,
-    role: "assistant",
-    format: "markdown"
-  });
+var modeStep = submitted.steps?.find(step => step.id === "mode");
+var modeSelected = modeStep?.data?.selected ?? modeStep?.dataPreview?.selected ?? [];
+var modeCandidates = modeStep?.data?.candidates ?? modeStep?.dataPreview?.candidates ?? [];
+var PRO_LABEL = /(^|\s)pro(\s|$)/i;
+var MODE_VOCAB = /^(auto|instant|medium|high|extra high|thinking( mini)?|latest|extended|standard pro|pro( extended)?|gpt[\s-].*|o\d+.*|\d+(\.\d+)?)$/i;
+var proConfirmed = modeStep?.ok === true
+  && modeCandidates.length > 0
+  && modeCandidates.every(label => MODE_VOCAB.test(String(label).trim()))
+  && modeSelected.some(label => PRO_LABEL.test(String(label)));
 
-  if (!read.ok) {
-    console.log(JSON.stringify({
-      status: "submitted_wait_pending",
-      message: "Prompt is already submitted. Do not resubmit; run messages.waitAndRead again against this same thread.",
-      thread: submitted.state?.thread ?? submitted.data?.thread,
-      modeStep,
-      read
-    }, null, 2));
-  } else {
-    console.log(read.data?.responseText ?? "");
-  }
+var consultMeta = {
+  submittedOk: submitted.ok === true,
+  proConfirmed,
+  thread: submitted.state?.thread ?? submitted.data?.thread,
+  modeSelected,
+  modeCandidates,
+  interruptions: submitted.interruptions ?? []
+};
+var fsMod = await import("node:fs");
+fsMod.writeFileSync(`${nodeRepl.tmpDir}/chatgpt-consult-latest.json`, JSON.stringify(consultMeta, null, 2));
+console.log(JSON.stringify(consultMeta, null, 2));
+```
+
+If `proConfirmed` is false, stop and report the blocker with `modeCandidates`. A candidates list containing thread-menu labels such as `Move to project`, `Share`, or `Rename` means mode selection hit the wrong menu; treat it as selector drift even if the step reports `ok: true`, and do not trust the run.
+
+Step 3 - bounded read in a separate call. Repeat this call as needed; never resubmit:
+
+```js
+var read = await chatgpt.messages.waitAndRead({
+  timeoutMs: 75_000,
+  stableMs: 2_000,
+  pollMs: 1_500,
+  mode: "deep_research",
+  role: "assistant",
+  format: "markdown"
+});
+if (read.ok) {
+  console.log(read.data?.responseText ?? "");
+} else {
+  console.log(JSON.stringify({
+    status: "submitted_wait_pending",
+    message: "Prompt is already submitted. Do not resubmit; run this read step again.",
+    readStatus: read.status,
+    partialChars: (read.data?.responseText ?? "").length
+  }, null, 2));
 }
 ```
 
-Before trusting the answer, inspect `modeStep`. A clean Pro consult must show the mode step succeeded and selected a Pro-labelled model or mode.
+Pro and Pro Extended answers can take many minutes. On `timeout` or `partial`, run Step 3 again; the submitted thread and the metadata file from Step 2 are the source of truth.
 
 ## With Approved Files
 
@@ -143,13 +178,25 @@ await chatgpt.runner.run(pro, {
 });
 ```
 
+Existing-thread mode selection is higher risk than a fresh thread: a loaded conversation page has header/title menus that the mode opener can hit by mistake. Always apply the Step 2 `proConfirmed` validation; reject any mode step whose candidates are not model/mode labels.
+
+## Recovery After Timeout
+
+If a tool call times out or the kernel resets:
+
+1. Check whether variables survived (`typeof submitted !== "undefined"`). If the kernel reset, reload `${nodeRepl.tmpDir}/chatgpt-consult-latest.json` for the thread URL and mode evidence.
+2. Re-bootstrap the bridge if needed, then find the thread tab via `browser.user.openTabs()` by matching the `/c/<conversation-id>` URL.
+3. Run one bounded `chatgpt.messages.readLatest({ role: "assistant", format: "markdown", maxChars: 4000 })`. Do not call `goto` on a tab already showing the thread, do not take full DOM snapshots of ChatGPT threads, and do not resubmit the prompt.
+4. If reads still fail, report status `submitted-unread` with the thread URL, keep the tab open as a handoff, and let the user or a later session retrieve the answer. A confirmed-Pro submission with an unread answer is pending, not failed.
+
 ## Blockers
 
 If a run fails, report the structured blocker instead of retrying blindly.
 
 - `browser_bridge_unavailable`: bootstrap failed or the bridge remains unavailable.
 - `login_required`: ask the user to log in to ChatGPT in Chrome.
-- `selector_drift` during mode selection: report that Pro was not selectable and include candidates.
+- `selector_drift` during mode selection: report that Pro was not selectable and include candidates. This includes a mode step that "selected" a non-mode label (for example `Move to project`) from the wrong menu.
+- repeated read timeouts after a confirmed Pro submission: report `submitted-unread` with the thread URL instead of `blocked`; do not resubmit.
 - `file_permission`: tell the user to enable both Codex Chrome upload permission and Chrome extension file URL access.
 - `rate_limited`, `captcha`, or account-level confirmation: stop and ask the user to resolve it manually.
 


### PR DESCRIPTION
## Why this PR exists

This PR is about making long ChatGPT Pro consults recoverable across the three timeout layers involved in a Codex browser-control run.

A long Pro answer can cross three different timeout boundaries, and today they can fail in the wrong order:

1. **Outer Codex MCP tool/call cap**
   The host call can time out while the browser session and JS runtime may still be alive.

2. **Middle `node_repl` `js` timeout**
   If this fires, the JS kernel can reset and lose in-memory state such as the submitted thread URL, selected mode evidence, and read progress.

3. **Inner SDK/browser `timeoutMs`**
   This layer should return structured `timeout` or `partial` results, but unbounded DOM reads can consume the whole deadline before the SDK gets a chance to report a recoverable state.

That is a bad failure mode for long Pro consults: the prompt may already be submitted, but Codex can time out before the thread URL, mode evidence, or response state has been preserved by the calling workflow. A later recovery attempt can then lose browser state, reload an already-open large thread, or accidentally resubmit the same prompt.

This PR changes the runtime and skill guidance so the inner SDK/browser layer is more likely to fail first, fail boundedly, and return structured recovery state.

## What changed

Runtime changes:

- Add bounded guards around expensive DOM and wait/read probes, including:
  - assistant progress reads
  - page state reads
  - assistant generation-state reads
  - response-action checks
  - fallback latest-message, text, and count reads
- Skip `threads.open` navigation when the current tab is already on the target conversation.
- Export the empty generation-state fallback so timeout paths can degrade safely.
- Validate that an opened mode-selection menu actually looks like a ChatGPT model/mode menu.
- Make short menu-label matching token-aware, so `Pro` can match labels such as `Pro Extended` without matching unrelated text such as `Move to project`.

Skill and documentation changes:

- Document the three timeout layers explicitly.
- Replace the combined submit-and-read Pro consult example with a staged protocol:
  - preflight bridge/login
  - submit under Pro without waiting for the long answer
  - persist thread and mode evidence immediately after submission
  - read in separate bounded calls
  - report `submitted-unread` after confirmed-Pro submission plus repeated read failure, rather than resubmitting
- Warn recovery code not to call `goto`/reload when the current tab is already showing the target thread.

## Why the mode-menu fixes are included

The `Pro` / `Move to project` issue is not the main reason for this PR.

It matters because timeout recovery depends on trustworthy mode evidence. After a long consult times out, the recorded mode-selection step may be the only evidence that the prompt was actually submitted under Pro. If mode selection can accidentally open the wrong menu and accept a non-mode item, recovery can falsely treat the run as a confirmed Pro consult.

The mode-menu validation and token-aware matching are therefore guardrails for the timeout-recovery protocol, not the central feature.

## User and maintainer impact

- Long Pro consults are less likely to be dominated by outer tool-call or `node_repl` timeouts.
- SDK/browser reads are bounded so they can return structured `timeout`, `partial`, or `submitted-unread` states.
- Recovery can continue from the already-submitted thread instead of resubmitting the prompt.
- Existing-thread recovery avoids unnecessary reloads when the target conversation is already open.
- Incorrect mode-menu evidence is rejected before it can pollute recovery state.

## Validation

The following checks were run:

- `npm --prefix packages/node ci`
- `npm --prefix packages/node test -- tests/unit/threads.test.ts tests/unit/modes.test.ts tests/unit/menus.test.ts tests/unit/messages.test.ts`
- `npm --prefix packages/node run build`
- `npm run plugin:build`
- `npm run node:test`
- `npm run node:contracts`
- `npm run plugin:check`
- `npm run plugin:validate`
- `git diff --check`

## Notes

The plugin runtime bundles were regenerated from the TypeScript source with `npm run plugin:build`.
