### PR TITLE
[codex] Harden ChatGPT mode recovery

### DIFF
--- a/packages/node/references/localization.md
+++ b/packages/node/references/localization.md
@@ -77,7 +77,8 @@ Localized — lives in `src/dom/locale/en.ts` (English) and per-locale files, sa
 | `projectSourcesTab` / `projectSourcesAddSource` / `projectSourcesUploadFiles` | Project Sources tab and append-add flow | visible tab/button/menu text |
 | `copyResponse` | copy-response button | `aria-label` |
 | `download` / `downloadImage` / `imageContainerHint` | download affordances | `aria-label` / container hint |
-| `modeLabels` / `modeOpenerExtra` | model/effort switcher | visible button + menu text |
+| `modeLabels` / `modeOpenerExtra` | model/effort switcher recognition and openers | visible button + menu text |
+| `modeOptions.<semantic-id>` | selectable model/intelligence mode options | visible picker rows, keyed by stable ids such as `high`, `extraHigh`, and `pro` |
 | `tools.web_search` / `tools.deep_research` / `tools.create_image` | tool menu items | visible menu text |
 | `signedInMarkers` | signed-in detection | sidebar/shell words |
 | `transientAssistant` | streaming placeholder filter | assistant streaming text ("Thinking", etc.) |
@@ -141,7 +142,13 @@ import type { LocaleContribution } from "./types.js";
 
 export const de = {
   sendButton: ["Nachricht senden"],
-  modeLabels: ["Neueste", "Schnell", "Denken", "Erweitert", "Pro"],
+  modeLabels: ["Sofort", "Mittel", "Hoch", "Extra hoch"],
+  modeOptions: {
+    instant: ["Sofort"],
+    medium: ["Mittel"],
+    high: ["Hoch"],
+    extraHigh: ["Extra hoch"],
+  },
   tools: {
     web_search: ["Websuche"],
   },
@@ -150,11 +157,14 @@ export const de = {
 ```
 
 Leave the canonical English first (it comes from `en.ts`), and leave the API keys
-(`web_search`, the `effort` values) unchanged.
+(`web_search`, `modeOptions.pro`, `modeOptions.high`, and the other semantic ids)
+unchanged.
 
 Newer ChatGPT rollouts may expose `Medium`, `High`, `Extra High`, and `Pro`
 under an `Intelligence` picker. Add localized equivalents only after observing
-those exact labels in the target locale.
+those exact labels in the target locale. Put broad picker/opening labels in
+`modeLabels`, but put selectable labels under `modeOptions.<semantic-id>` so
+short labels such as `Pro` cannot match unrelated rows like `Move to project`.
 
 Then open [`src/dom/locale/index.ts`](../src/dom/locale/index.ts) and register the new
 locale:

--- a/packages/node/src/browser/page-state.ts
+++ b/packages/node/src/browser/page-state.ts
@@ -14,8 +14,17 @@ export type PageState = {
 };
 
 export function parseConversationId(url: string): string | undefined {
-  const match = /\/c\/([A-Za-z0-9-]+)/.exec(url);
-  return match?.[1];
+  let parsed: URL;
+  try {
+    parsed = new URL(url, "https://chatgpt.com");
+  } catch {
+    return undefined;
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments[0] !== "c" || segments[1] === undefined || segments[1].length === 0) {
+    return undefined;
+  }
+  return segments[1];
 }
 
 export async function readPageState(page: PageLike): Promise<PageState> {

--- a/packages/node/src/commands/context.ts
+++ b/packages/node/src/commands/context.ts
@@ -12,7 +12,9 @@ export async function contextFromPage(
   }
 
   const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => partial.url) : partial.url;
-  const title = typeof page.title === "function" ? await page.title().catch(() => undefined) : partial.title;
+  const title = typeof page.title === "function"
+    ? await withTimeout(page.title(), 1000, "Timed out while reading page title.").catch(() => partial.title)
+    : partial.title;
   const [turnCount, assistantTurnCount] = await Promise.all([
     withTimeout(countPageMessages(page), 1000, "Timed out while counting page messages.").catch(() => partial.turnCount),
     withTimeout(countPageMessages(page, "assistant"), 1000, "Timed out while counting assistant messages.").catch(() => partial.assistantTurnCount)

--- a/packages/node/src/commands/conversation.ts
+++ b/packages/node/src/commands/conversation.ts
@@ -1,0 +1,80 @@
+import { parseConversationId } from "../browser/page-state.js";
+import { countPageMessages, readLatestMessageText } from "../dom/messages.js";
+import type { PageLike } from "../types.js";
+
+const CHATGPT_HOME = "https://chatgpt.com/";
+
+export type ConversationTarget = {
+  href?: string;
+  url: string;
+};
+
+export type EnsureConversationTargetOptions = {
+  timeoutMs: number;
+};
+
+export type EnsureConversationTargetResult = {
+  navigated: boolean;
+  targetUrl: string;
+  expectedConversationId?: string;
+};
+
+export async function ensureConversationTarget(
+  page: PageLike,
+  target: ConversationTarget,
+  options: EnsureConversationTargetOptions
+): Promise<EnsureConversationTargetResult> {
+  const targetUrl = absoluteConversationUrl(target);
+  const expectedConversationId = parseConversationId(targetUrl);
+  const currentUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+  if (
+    expectedConversationId !== undefined
+    && parseConversationId(typeof currentUrl === "string" ? currentUrl : "") === expectedConversationId
+  ) {
+    await waitForConversationHydrated(page, options.timeoutMs, expectedConversationId);
+    return ensureResult(false, targetUrl, expectedConversationId);
+  }
+
+  await page.goto?.(targetUrl, { waitUntil: "domcontentloaded", timeout: options.timeoutMs });
+  await waitForConversationHydrated(page, options.timeoutMs, expectedConversationId);
+  return ensureResult(true, targetUrl, expectedConversationId);
+}
+
+export async function waitForConversationHydrated(
+  page: PageLike,
+  timeoutMs: number,
+  expectedConversationId?: string
+): Promise<void> {
+  const started = Date.now();
+  do {
+    const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+    const urlMatches = expectedConversationId === undefined || parseConversationId(typeof url === "string" ? url : "") === expectedConversationId;
+    const count = await countPageMessages(page).catch(() => 0);
+    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => undefined);
+    const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
+    if (urlMatches && ((latestAssistantText?.trim().length ?? 0) > 0 || (count > 0 && title.length > 0 && title !== "ChatGPT"))) {
+      await page.waitForTimeout?.(250);
+      return;
+    }
+    await page.waitForTimeout?.(500);
+  } while (Date.now() - started < timeoutMs);
+}
+
+function absoluteConversationUrl(target: ConversationTarget): string {
+  if (target.href !== undefined && target.href.startsWith("/")) {
+    return new URL(target.href, CHATGPT_HOME).toString();
+  }
+  return target.href ?? target.url;
+}
+
+function ensureResult(
+  navigated: boolean,
+  targetUrl: string,
+  expectedConversationId?: string
+): EnsureConversationTargetResult {
+  const result: EnsureConversationTargetResult = { navigated, targetUrl };
+  if (expectedConversationId !== undefined) {
+    result.expectedConversationId = expectedConversationId;
+  }
+  return result;
+}

--- a/packages/node/src/commands/deadline.ts
+++ b/packages/node/src/commands/deadline.ts
@@ -1,0 +1,22 @@
+export type Deadline = {
+  startedAtMs: number;
+  timeoutMs: number;
+  expiresAtMs: number;
+};
+
+export function createDeadline(timeoutMs: number, startedAtMs = Date.now()): Deadline {
+  const safeTimeoutMs = Math.max(0, timeoutMs);
+  return {
+    startedAtMs,
+    timeoutMs: safeTimeoutMs,
+    expiresAtMs: startedAtMs + safeTimeoutMs,
+  };
+}
+
+export function remainingMs(deadline: Deadline, nowMs = Date.now()): number {
+  return Math.max(0, deadline.expiresAtMs - nowMs);
+}
+
+export function childTimeoutMs(deadline: Deadline, capMs: number, nowMs = Date.now()): number {
+  return Math.max(0, Math.min(Math.max(0, capMs), remainingMs(deadline, nowMs)));
+}

--- a/packages/node/src/commands/doctor.ts
+++ b/packages/node/src/commands/doctor.ts
@@ -73,6 +73,7 @@ const REQUIRED_LOCALE_KEYS = [
   "rateLimitBlocker"
 ] as const;
 const REQUIRED_TOOL_IDS = ["web_search", "deep_research", "create_image"] as const;
+const REQUIRED_MODE_OPTION_IDS = ["latest", "instant", "thinking", "extended", "medium", "high", "extraHigh", "pro"] as const;
 
 export async function doctor(env: RuntimeEnv, args: DoctorArgs = {}): Promise<CommandResult<DoctorReport>> {
   const wanted = args.check ?? DEFAULT_CHECKS;
@@ -312,24 +313,30 @@ async function filePreflightCheck(env: RuntimeEnv, args: DoctorArgs): Promise<Ca
 function localizationCheck(env: RuntimeEnv): CapabilityCheck {
   const requiredKeysMissing = REQUIRED_LOCALE_KEYS.filter(key => localeLabels[key].length === 0);
   const missingToolIds = REQUIRED_TOOL_IDS.filter(id => (localeLabels.tools[id]?.length ?? 0) === 0);
+  const missingModeOptionIds = REQUIRED_MODE_OPTION_IDS.filter(id => (localeLabels.modeOptions[id]?.length ?? 0) === 0);
   const toolIds = Object.keys(localeLabels.tools);
+  const modeOptionIds = Object.keys(localeLabels.modeOptions);
   const englishCanonicalPresent = localeLabels.composerTextbox[0] === "Chat with ChatGPT"
     && localeLabels.sendButton[0] === "Send prompt"
     && localeLabels.modeLabels.includes("Thinking")
+    && localeLabels.modeOptions.pro?.[0] === "Pro"
     && localeLabels.tools.web_search?.[0] === "Web search";
   const labelCandidateCount = REQUIRED_LOCALE_KEYS.reduce((total, key) => total + localeLabels[key].length, 0)
-    + Object.values(localeLabels.tools).reduce((total, values) => total + values.length, 0);
+    + Object.values(localeLabels.tools).reduce((total, values) => total + values.length, 0)
+    + Object.values(localeLabels.modeOptions).reduce((total, values) => total + values.length, 0);
   const details = {
     englishCanonicalPresent,
     requiredKeysMissing,
     missingToolIds,
+    missingModeOptionIds,
     toolIds,
+    modeOptionIds,
     labelCandidateCount,
     pageAvailable: env.page !== undefined,
     runtimeSelectorCoverage: "registry_only_stage_2"
   };
 
-  if (englishCanonicalPresent && requiredKeysMissing.length === 0 && missingToolIds.length === 0) {
+  if (englishCanonicalPresent && requiredKeysMissing.length === 0 && missingToolIds.length === 0 && missingModeOptionIds.length === 0) {
     return unknown("The locale registry is loaded; localized runtime selector coverage is registry-only in Stage 2 and not fully proven.", undefined, details);
   }
 

--- a/packages/node/src/commands/messages.ts
+++ b/packages/node/src/commands/messages.ts
@@ -1,6 +1,6 @@
-import { readPageState } from "../browser/page-state.js";
+import { readPageState, type PageState } from "../browser/page-state.js";
 import { resultError, resultOk } from "../errors.js";
-import { latestAssistantTurnHasResponseActions, readAssistantGenerationState, type AssistantGenerationState } from "../dom/generation-state.js";
+import { EMPTY_GENERATION_STATE, latestAssistantTurnHasResponseActions, readAssistantGenerationState, type AssistantGenerationState } from "../dom/generation-state.js";
 import { countPageMessages, isTransientAssistantText, readLatestMessage, readLatestMessageText, readLatestMessageTextSnapshot, readMessages } from "../dom/messages.js";
 import { composerTextbox, sendButton } from "../dom/selectors.js";
 import { normalizeLineBreaks, normalizeWhitespace } from "../dom/visible-text.js";
@@ -21,7 +21,9 @@ import type {
   WaitData
 } from "../types.js";
 import { contextFromPage } from "./context.js";
+import { createDeadline } from "./deadline.js";
 import { withCommandOutputText } from "./output.js";
+import { createSingleFlightProbe, type ProbeResult } from "./probes.js";
 import { bootstrap } from "./session.js";
 
 export type CompletionSnapshot = {
@@ -345,24 +347,21 @@ export async function waitForMessage(
   const stableMs = args.stableMs ?? (args.mode === "deep_research" ? 10_000 : 2_000);
   const pollMs = args.pollMs ?? 750;
   const started = Date.now();
+  const deadline = createDeadline(timeoutMs, started);
+  const probeTimeoutMs = Math.max(50, Math.min(1000, Math.max(pollMs, Math.floor(timeoutMs / 4))));
+  const waitWarnings = new Set<string>();
+  const assistantProgressProbe = createSingleFlightProbe("assistant progress", readAssistantProgressSnapshot);
+  const pageStateProbe = createSingleFlightProbe("page state", readPageState);
+  const generationStateProbe = createSingleFlightProbe("assistant generation state", readAssistantGenerationState);
+  const responseActionsProbe = createSingleFlightProbe("assistant response actions", latestAssistantTurnHasResponseActions);
   let lastTargetText = "";
   let lastChangedAt = Date.now();
   let latestAssistantCount = await countPageMessages(page, "assistant").catch(() => 0);
 
   while (Date.now() - started < timeoutMs) {
-    const state = await readPageState(page).catch(() => undefined);
-    if (state?.blocker !== undefined && state.blocker.kind !== "modal") {
-      return {
-        ok: false,
-        status: "blocked",
-        warnings: [],
-        blocker: state.blocker,
-        context: await contextFromPage(page)
-      };
-    }
-
-    const progress = await readAssistantProgressSnapshot(page)
-      .catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
+    const progressResult = await assistantProgressProbe(page, deadline, { timeoutMs: probeTimeoutMs });
+    addWarnings(waitWarnings, progressResult.warnings);
+    const progress = await progressSnapshotFromProbeResult(page, progressResult, latestAssistantCount);
     latestAssistantCount = progress.assistantTurnCount;
     const targetReached = waitTargetReached(args, progress);
     const latestText = targetReached ? normalizeWhitespace(progress.latestText ?? "") : "";
@@ -372,12 +371,23 @@ export async function waitForMessage(
       lastChangedAt = Date.now();
     }
 
+    const state = await pageStateFromProbe(pageStateProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings);
+    if (state?.blocker !== undefined && state.blocker.kind !== "modal") {
+      return {
+        ok: false,
+        status: "blocked",
+        warnings: [...waitWarnings],
+        blocker: state.blocker,
+        context: await contextFromPage(page)
+      };
+    }
+
     const snapshot: CompletionSnapshot = {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      generation: await readAssistantGenerationState(page),
-      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
+      generation: await generationStateFromProbe(generationStateProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings),
+      hasResponseActions: await responseActionsFromProbe(responseActionsProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings)
     };
 
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
@@ -391,6 +401,7 @@ export async function waitForMessage(
           elapsedMs: Date.now() - started
         },
         warnings: [
+          ...waitWarnings,
           "ChatGPT generation appears to have been stopped or interrupted before completion.",
           ...snapshot.generation.signals.map(signal => `Generation state signal: ${signal}`)
         ],
@@ -401,7 +412,8 @@ export async function waitForMessage(
     if (targetReached && isResponseComplete(snapshot)) {
       return withCommandOutputText(resultOk(
         { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
-        await contextFromPage(page)
+        await contextFromPage(page),
+        [...waitWarnings]
       ));
     }
 
@@ -418,7 +430,7 @@ export async function waitForMessage(
         assistantTurnCount: latestAssistantCount,
         elapsedMs: Date.now() - started
       },
-      warnings: ["Timed out after receiving partial assistant text."],
+      warnings: [...waitWarnings, "Timed out after receiving partial assistant text."],
       context: await contextFromPage(page)
     } satisfies CommandResult<WaitData>);
   }
@@ -426,7 +438,7 @@ export async function waitForMessage(
   return {
     ok: false,
     status: "timeout",
-    warnings: [],
+    warnings: [...waitWarnings],
     error: {
       name: "WaitTimeout",
       message: "No assistant response appeared before the timeout.",
@@ -434,6 +446,53 @@ export async function waitForMessage(
     },
     context: await contextFromPage(page)
   };
+}
+
+async function pageStateFromProbe(
+  probe: Promise<ProbeResult<PageState>>,
+  warnings: Set<string>
+): Promise<PageState | undefined> {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : undefined;
+}
+
+async function progressSnapshotFromProbeResult(
+  page: PageLike,
+  result: ProbeResult<AssistantProgressSnapshot>,
+  previousAssistantTurnCount: number
+): Promise<AssistantProgressSnapshot> {
+  if (result.ok) {
+    return result.value;
+  }
+  if (result.timedOut === true || result.skipped === true) {
+    return { assistantTurnCount: previousAssistantTurnCount };
+  }
+  return fallbackAssistantProgressSnapshot(page, previousAssistantTurnCount);
+}
+
+async function generationStateFromProbe(
+  probe: Promise<ProbeResult<AssistantGenerationState>>,
+  warnings: Set<string>
+): Promise<AssistantGenerationState> {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : EMPTY_GENERATION_STATE;
+}
+
+async function responseActionsFromProbe(
+  probe: Promise<ProbeResult<boolean>>,
+  warnings: Set<string>
+): Promise<boolean> {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : false;
+}
+
+function addWarnings(target: Set<string>, warnings: readonly string[]): void {
+  for (const warning of warnings) {
+    target.add(warning);
+  }
 }
 
 export async function readLatest(

--- a/packages/node/src/commands/modes.ts
+++ b/packages/node/src/commands/modes.ts
@@ -1,23 +1,62 @@
 import { resultError, resultOk } from "../errors.js";
 import { enumerateVisibleMenuItems, findUniqueMenuItem, type MenuItem } from "../dom/menus.js";
 import { localeLabels } from "../dom/locale-labels.js";
+import { normalizeForLabelMatch, visibleLabelMatches } from "../dom/label-match.js";
 import { normalizeLabel, normalizeWhitespace } from "../dom/visible-text.js";
 import type { CommandResult, LocatorLike, PageLike, RuntimeEnv, SelectToolArgs, SetModeArgs } from "../types.js";
+import type { ModeOptionId } from "../dom/locale/types.js";
 import { contextFromPage } from "./context.js";
 import { bootstrap } from "./session.js";
 
 const DEFAULT_MODE_EFFORT = "Thinking";
-const CURRENT_MODE_LABELS: string[] = [...localeLabels.modeLabels];
+const CURRENT_MODE_LABELS: string[] = dedupeLabels([
+  ...localeLabels.modeLabels,
+  ...Object.values(localeLabels.modeOptions).flat(),
+]);
 const MODE_OPENER_LABELS = [...CURRENT_MODE_LABELS.filter(label => label !== "Pro"), ...localeLabels.modeOpenerExtra];
 const MODEL_VERSION_FAMILY_PATTERN = /^gpt[\s-]/i;
 const MODEL_VERSION_LABEL_PATTERN = /^(?:o\d+|\d+(?:\.\d+)?)$/i;
-const CANONICAL_INTELLIGENCE_ORDER = new Map<string, number>([
+const CANONICAL_INTELLIGENCE_ORDER = new Map<ModeOptionId, number>([
   ["instant", 0],
   ["medium", 1],
   ["high", 2],
-  ["extra high", 3],
+  ["extraHigh", 3],
   ["pro", 4],
 ]);
+const MODE_OPTION_IDS: ModeOptionId[] = [
+  "latest",
+  "instant",
+  "thinking",
+  "extended",
+  "medium",
+  "high",
+  "extraHigh",
+  "pro",
+];
+const MODE_ID_ALIASES: Record<ModeOptionId, string[]> = {
+  latest: ["latest"],
+  instant: ["instant"],
+  thinking: ["thinking"],
+  extended: ["extended"],
+  medium: ["medium"],
+  high: ["high"],
+  extraHigh: ["extra high", "extra-high", "extra_high", "extrahigh"],
+  pro: ["pro"],
+};
+const THREAD_ACTION_MENU_LABELS = new Set([
+  "archive",
+  "copy link",
+  "delete",
+  "move to project",
+  "rename",
+  "share",
+]);
+
+type RequestedMode = {
+  requested: string;
+  labels: string[];
+  modeId?: ModeOptionId;
+};
 
 export async function setMode(
   env: RuntimeEnv,
@@ -31,9 +70,9 @@ export async function setMode(
   const page = env.page!;
 
   try {
-    const requested = requestedModeLabels(args);
+    const requested = requestedModeSelections(args);
     const requestedVersion = requestedModelVersion(args);
-    const requestedForOpening = requestedVersion === undefined ? requested : [...requested, requestedVersion];
+    const requestedForOpening = requestedVersion === undefined ? requested : [...requested, requestedModeSelection(requestedVersion)];
     const opened = await waitForModeMenu(page, requestedForOpening, args.timeoutMs ?? 30000);
     if (requestedVersion === undefined && opened.alreadySelected.length === requested.length) {
       return resultOk({ selected: opened.alreadySelected, candidates: opened.modeButtons }, await contextFromPage(page));
@@ -45,15 +84,26 @@ export async function setMode(
     const candidates = await enumerateVisibleMenuItems(page);
     const selected: string[] = [];
 
-    for (const item of requested) {
-      const match = findModeMenuItem(candidates, item);
+    if (requested.length > 0 && shouldRejectAsWrongModeMenu(candidates)) {
+      const candidateLabels = candidates.map(candidate => candidate.label);
+      return {
+        ok: false,
+        status: "unsupported",
+        warnings: [],
+        blocker: selectorDriftBlocker("Visible menu appears to be a thread/action menu, not the ChatGPT mode menu.", candidateLabels),
+        context: await contextFromPage(page)
+      };
+    }
+
+    for (const request of requested) {
+      const match = findModeMenuItem(candidates, request);
       if (match === undefined) {
         const candidateLabels = candidates.map(candidate => candidate.label);
         return {
           ok: false,
           status: "unsupported",
           warnings: [],
-          blocker: selectorDriftBlocker(`Mode option "${item}" was not found or was ambiguous.`, candidateLabels),
+          blocker: selectorDriftBlocker(`Mode option "${request.requested}" was not found or was ambiguous.`, candidateLabels),
           context: await contextFromPage(page)
         };
       }
@@ -91,7 +141,7 @@ type ModeMenuOpenResult = {
   modeButtons: string[];
 };
 
-async function waitForModeMenu(page: PageLike, requested: string[], timeoutMs: number): Promise<ModeMenuOpenResult> {
+async function waitForModeMenu(page: PageLike, requested: RequestedMode[], timeoutMs: number): Promise<ModeMenuOpenResult> {
   const deadline = Date.now() + timeoutMs;
   let modeButtons: string[] = [];
 
@@ -208,6 +258,29 @@ function looksLikeModeMenu(labels: string[]): boolean {
   });
 }
 
+function shouldRejectAsWrongModeMenu(items: MenuItem[]): boolean {
+  if (items.length === 0) {
+    return false;
+  }
+  const hasPositiveModeEvidence = items.some(item => {
+    if (item.testId?.startsWith("model-switcher-") === true) {
+      return true;
+    }
+    if (MODEL_VERSION_FAMILY_PATTERN.test(item.label) || MODEL_VERSION_LABEL_PATTERN.test(item.label)) {
+      return true;
+    }
+    if (item.role === "menuitemradio" && CURRENT_MODE_LABELS.some(label => visibleLabelMatches(item.label, label))) {
+      return true;
+    }
+    return CURRENT_MODE_LABELS.some(label => visibleLabelMatches(item.label, label));
+  });
+  if (hasPositiveModeEvidence) {
+    return false;
+  }
+
+  return items.some(item => THREAD_ACTION_MENU_LABELS.has(normalizeForLabelMatch(item.label)));
+}
+
 async function clickMenuItem(page: PageLike, label: string): Promise<boolean> {
   if (await clickModelSwitcherMenuItem(page, label)) {
     return true;
@@ -319,13 +392,15 @@ function toolLabels(tool: string): string[] {
   return known !== undefined ? [...known] : [tool];
 }
 
-function findModeMenuItem(candidates: MenuItem[], wanted: string): MenuItem | undefined {
-  const exact = findUniqueMenuItem(candidates, wanted);
-  if (exact !== undefined) {
-    return exact;
+function findModeMenuItem(candidates: MenuItem[], request: RequestedMode): MenuItem | undefined {
+  for (const wanted of request.labels) {
+    const exact = findUniqueMenuItem(candidates, wanted);
+    if (exact !== undefined) {
+      return exact;
+    }
   }
 
-  const wantedIndex = CANONICAL_INTELLIGENCE_ORDER.get(normalizeLabel(wanted));
+  const wantedIndex = request.modeId === undefined ? undefined : CANONICAL_INTELLIGENCE_ORDER.get(request.modeId);
   if (wantedIndex === undefined) {
     return undefined;
   }
@@ -340,12 +415,42 @@ function findModeMenuItem(candidates: MenuItem[], wanted: string): MenuItem | un
     : undefined;
 }
 
-function requestedModeLabels(args: SetModeArgs): string[] {
+function requestedModeSelections(args: SetModeArgs): RequestedMode[] {
   const requested = [args.model, args.intelligence, args.effort].filter((value): value is string => value !== undefined);
   if (requestedModelVersion(args) !== undefined && requested.length === 0) {
     return [];
   }
-  return requested.length > 0 ? requested : [DEFAULT_MODE_EFFORT];
+  return (requested.length > 0 ? requested : [DEFAULT_MODE_EFFORT]).map(requestedModeSelection);
+}
+
+function requestedModeSelection(requested: string): RequestedMode {
+  const modeId = modeOptionIdFor(requested);
+  const labels = modeId === undefined ? [requested] : localeLabels.modeOptions[modeId];
+  const request: RequestedMode = {
+    requested,
+    labels: labels.length > 0 ? [...labels] : [requested],
+  };
+  if (modeId !== undefined) {
+    request.modeId = modeId;
+  }
+  return request;
+}
+
+function modeOptionIdFor(value: string): ModeOptionId | undefined {
+  const normalized = normalizeModeLookupKey(value);
+  for (const id of MODE_OPTION_IDS) {
+    if (MODE_ID_ALIASES[id].some(alias => normalizeModeLookupKey(alias) === normalized)) {
+      return id;
+    }
+    if (localeLabels.modeOptions[id].some(label => normalizeModeLookupKey(label) === normalized)) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+function normalizeModeLookupKey(value: string): string {
+  return normalizeForLabelMatch(value).replace(/[_-]+/g, " ");
 }
 
 function requestedModelVersion(args: SetModeArgs): string | undefined {
@@ -363,13 +468,6 @@ function findUniqueVisibleLabel(labels: string[], wanted: string): string | unde
   return fuzzy.length === 1 ? fuzzy[0] : undefined;
 }
 
-function visibleLabelMatches(label: string, wanted: string): boolean {
-  if (wanted.length <= 3) {
-    return new RegExp(`(^|[^a-z0-9])${escapeRegExp(wanted)}([^a-z0-9]|$)`, "i").test(label);
-  }
-  return label.includes(wanted);
-}
-
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -378,10 +476,20 @@ function escapeAttributeValue(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
 }
 
-function findAlreadySelectedModes(visibleButtons: string[], requested: string[]): string[] {
+function findAlreadySelectedModes(visibleButtons: string[], requested: RequestedMode[]): string[] {
   return requested
-    .map(label => findUniqueVisibleLabel(visibleButtons, label))
+    .map(request => findUniqueVisibleLabelForRequest(visibleButtons, request))
     .filter((label): label is string => label !== undefined);
+}
+
+function findUniqueVisibleLabelForRequest(labels: string[], request: RequestedMode): string | undefined {
+  for (const label of request.labels) {
+    const found = findUniqueVisibleLabel(labels, label);
+    if (found !== undefined) {
+      return found;
+    }
+  }
+  return undefined;
 }
 
 async function selectModelVersion(
@@ -392,7 +500,7 @@ async function selectModelVersion(
 ): Promise<{ selected?: string; candidates: string[] }> {
   let candidates = await enumerateVisibleMenuItems(page);
   if (!looksLikeModeMenu(candidates.map(candidate => candidate.label))) {
-    const opened = await waitForModeMenu(page, [requestedVersion], timeoutMs);
+    const opened = await waitForModeMenu(page, [{ requested: requestedVersion, labels: [requestedVersion] }], timeoutMs);
     if (opened.opened) {
       await page.waitForTimeout?.(250);
       candidates = await enumerateVisibleMenuItems(page);

--- a/packages/node/src/commands/probes.ts
+++ b/packages/node/src/commands/probes.ts
@@ -1,0 +1,77 @@
+import { childTimeoutMs, type Deadline } from "./deadline.js";
+
+export type ProbeResult<T> =
+  | { ok: true; value: T; warnings: string[] }
+  | { ok: false; timedOut?: boolean; skipped?: boolean; warnings: string[] };
+
+export type ProbeOptions = {
+  timeoutMs: number;
+};
+
+export function createSingleFlightProbe<A, T>(
+  name: string,
+  probe: (arg: A) => Promise<T>
+): (arg: A, deadline: Deadline, options: ProbeOptions) => Promise<ProbeResult<T>> {
+  let inFlight: Promise<T> | undefined;
+
+  return async (arg: A, deadline: Deadline, options: ProbeOptions): Promise<ProbeResult<T>> => {
+    if (inFlight !== undefined) {
+      return {
+        ok: false,
+        skipped: true,
+        warnings: [`Skipped ${name} DOM probe because previous browser-side work is still in flight.`]
+      };
+    }
+
+    const timeoutMs = childTimeoutMs(deadline, options.timeoutMs);
+    if (timeoutMs <= 0) {
+      return {
+        ok: false,
+        timedOut: true,
+        warnings: [`Skipped ${name} DOM probe because no deadline budget remained.`]
+      };
+    }
+
+    const current = probe(arg);
+    inFlight = current;
+    current.finally(() => {
+      if (inFlight === current) {
+        inFlight = undefined;
+      }
+    }).catch(() => undefined);
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const value = await Promise.race([
+        current,
+        new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(() => reject(new ProbeTimeoutError(timeoutMs)), timeoutMs);
+        })
+      ]);
+      return { ok: true, value, warnings: [] };
+    } catch (error) {
+      if (error instanceof ProbeTimeoutError) {
+        return {
+          ok: false,
+          timedOut: true,
+          warnings: [`Timed out waiting ${timeoutMs}ms for ${name} DOM probe; this stopped SDK waiting but did not cancel browser-side work.`]
+        };
+      }
+      return {
+        ok: false,
+        warnings: [`${name} DOM probe failed: ${error instanceof Error ? error.message : String(error)}`]
+      };
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+    }
+  };
+}
+
+class ProbeTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Probe timed out after ${timeoutMs}ms.`);
+    this.name = "ProbeTimeoutError";
+  }
+}

--- a/packages/node/src/commands/threads.ts
+++ b/packages/node/src/commands/threads.ts
@@ -1,6 +1,5 @@
 import { parseConversationId, readPageState } from "../browser/page-state.js";
 import { resultError, resultOk } from "../errors.js";
-import { countPageMessages, readLatestMessageText } from "../dom/messages.js";
 import { requiredLocator, searchChatsButton, searchChatsInput, newChatButton } from "../dom/selectors.js";
 import { anyLabelPattern, localeLabels } from "../dom/locale-labels.js";
 import { normalizeWhitespace, stripTags } from "../dom/visible-text.js";
@@ -15,6 +14,7 @@ import type {
   ThreadSearchResult
 } from "../types.js";
 import { contextFromPage } from "./context.js";
+import { ensureConversationTarget } from "./conversation.js";
 import { bootstrap } from "./session.js";
 
 const CHATGPT_HOME = "https://chatgpt.com/";
@@ -129,13 +129,7 @@ export async function openThread(
       };
     }
 
-    if (target.href !== undefined && target.href.startsWith("/")) {
-      await page.goto?.(new URL(target.href, CHATGPT_HOME).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 30000 });
-    } else {
-      await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 30000 });
-    }
-
-    await waitForThreadHydrated(page, args.timeoutMs ?? 30000, parseConversationId(target.url));
+    await ensureConversationTarget(page, target, { timeoutMs: args.timeoutMs ?? 30000 });
     const state = await readPageState(page);
     return resultOk(
       openThreadData(state.url, state.conversationId, state.title ?? target.title),
@@ -343,25 +337,4 @@ function filterResultsByQuery(results: ThreadSearchResult[], query: string): Thr
     const haystack = normalizeForMatch(`${result.title} ${result.snippet ?? ""}`);
     return haystack.includes(wanted) || wanted.includes(normalizeForMatch(result.title));
   });
-}
-
-async function waitForThreadHydrated(
-  page: NonNullable<RuntimeEnv["page"]>,
-  timeoutMs: number,
-  expectedConversationId?: string
-): Promise<void> {
-  const started = Date.now();
-  await page.waitForTimeout?.(1000);
-  while (Date.now() - started < timeoutMs) {
-    const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
-    const urlMatches = expectedConversationId === undefined || url.includes(expectedConversationId);
-    const count = await countPageMessages(page).catch(() => 0);
-    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => undefined);
-    const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
-    if (urlMatches && ((latestAssistantText?.trim().length ?? 0) > 0 || (count > 0 && title.length > 0 && title !== "ChatGPT"))) {
-      await page.waitForTimeout?.(250);
-      return;
-    }
-    await page.waitForTimeout?.(500);
-  }
 }

--- a/packages/node/src/dom/generation-state.ts
+++ b/packages/node/src/dom/generation-state.ts
@@ -8,7 +8,13 @@ export type AssistantGenerationState = {
   signals: string[];
 };
 
-const EMPTY_GENERATION_STATE: AssistantGenerationState = {
+/**
+ * Neutral fallback used when generation state cannot be inspected.
+ *
+ * This means "no active/stopped signal observed"; it is not evidence that a
+ * response is complete.
+ */
+export const EMPTY_GENERATION_STATE: AssistantGenerationState = {
   active: false,
   stopped: false,
   signals: []

--- a/packages/node/src/dom/label-match.ts
+++ b/packages/node/src/dom/label-match.ts
@@ -1,0 +1,29 @@
+import { normalizeWhitespace } from "./visible-text.js";
+
+export function normalizeForLabelMatch(text: string): string {
+  return normalizeWhitespace(text.normalize("NFKC")).toLocaleLowerCase();
+}
+
+export function visibleLabelMatches(label: string, wanted: string): boolean {
+  const normalizedLabel = normalizeForLabelMatch(label);
+  const normalizedWanted = normalizeForLabelMatch(wanted);
+  if (normalizedWanted.length === 0) {
+    return false;
+  }
+  if (normalizedLabel === normalizedWanted) {
+    return true;
+  }
+  if (isShortLatinToken(normalizedWanted)) {
+    return new RegExp(`(^|[^\\p{L}\\p{N}])${escapeRegExp(normalizedWanted)}([^\\p{L}\\p{N}]|$)`, "iu")
+      .test(normalizedLabel);
+  }
+  return normalizedLabel.includes(normalizedWanted);
+}
+
+function isShortLatinToken(value: string): boolean {
+  return value.length <= 3 && /^[a-z0-9]+$/i.test(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/node/src/dom/locale/am.ts
+++ b/packages/node/src/dom/locale/am.ts
@@ -19,6 +19,12 @@ export const am = {
   addPhotosFilesMenuItem: ["ፎቶዎችን እና ፋይሎችን ያክሉ"],
   copyResponse: ["ምላሹን ይቅዱ"],
   modeLabels: ["ፈጣን", "መካከለኛ", "ከፍተኛ", "እጅግ ከፍተኛ"],
+  modeOptions: {
+    instant: ["ፈጣን"],
+    medium: ["መካከለኛ"],
+    high: ["ከፍተኛ"],
+    extraHigh: ["እጅግ ከፍተኛ"],
+  },
   modeOpenerExtra: ["ያዋቅሩ"],
   tools: {
     web_search: ["የድር ፍለጋ"],

--- a/packages/node/src/dom/locale/ar.ts
+++ b/packages/node/src/dom/locale/ar.ts
@@ -19,6 +19,13 @@ export const ar = {
   addPhotosFilesMenuItem: ["إضافة صور وملفات"],
   copyResponse: ["نسخ إجابة"],
   modeLabels: ["فوري", "متوسط", "عالي", "مكثف جدًا", "احترافي"],
+  modeOptions: {
+    instant: ["فوري"],
+    medium: ["متوسط"],
+    high: ["عالي"],
+    extraHigh: ["مكثف جدًا"],
+    pro: ["احترافي"],
+  },
   modeOpenerExtra: ["تكوين"],
   tools: {
     web_search: ["البحث في الويب"],

--- a/packages/node/src/dom/locale/bg.ts
+++ b/packages/node/src/dom/locale/bg.ts
@@ -19,6 +19,13 @@ export const bg = {
   addPhotosFilesMenuItem: ["Добавяне на снимки и файлове"],
   copyResponse: ["Копирайте отговора"],
   modeLabels: ["Мигновен", "Среден", "Висок", "Много високо", "Про"],
+  modeOptions: {
+    instant: ["Мигновен"],
+    medium: ["Среден"],
+    high: ["Висок"],
+    extraHigh: ["Много високо"],
+    pro: ["Про"],
+  },
   modeOpenerExtra: ["Конфигурирайте"],
   tools: {
     web_search: ["Търсене в интернет"],

--- a/packages/node/src/dom/locale/bn.ts
+++ b/packages/node/src/dom/locale/bn.ts
@@ -19,6 +19,13 @@ export const bn = {
   addPhotosFilesMenuItem: ["ফটো এবং ফাইল আপলোড করুন"],
   copyResponse: ["উত্তর কপি করুন"],
   modeLabels: ["তাৎক্ষণিক", "মাঝারি", "উচ্চ", "অতি উচ্চ", "প্রো"],
+  modeOptions: {
+    instant: ["তাৎক্ষণিক"],
+    medium: ["মাঝারি"],
+    high: ["উচ্চ"],
+    extraHigh: ["অতি উচ্চ"],
+    pro: ["প্রো"],
+  },
   modeOpenerExtra: ["কনফিগার করুন..."],
   tools: {
     web_search: ["ওয়েব সন্ধান"],

--- a/packages/node/src/dom/locale/bs.ts
+++ b/packages/node/src/dom/locale/bs.ts
@@ -19,6 +19,12 @@ export const bs = {
   addPhotosFilesMenuItem: ["Dodaj slike i datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Brzo", "Srednji", "Visoko", "Vrlo visoko"],
+  modeOptions: {
+    instant: ["Brzo"],
+    medium: ["Srednji"],
+    high: ["Visoko"],
+    extraHigh: ["Vrlo visoko"],
+  },
   modeOpenerExtra: ["Podesi"],
   tools: {
     web_search: ["Internet pretraga"],

--- a/packages/node/src/dom/locale/ca.ts
+++ b/packages/node/src/dom/locale/ca.ts
@@ -19,6 +19,12 @@ export const ca = {
   addPhotosFilesMenuItem: ["Afegeix fotos i fitxers"],
   copyResponse: ["Copia la resposta"],
   modeLabels: ["Instantani", "Mitjà", "Alt", "Molt alt"],
+  modeOptions: {
+    instant: ["Instantani"],
+    medium: ["Mitjà"],
+    high: ["Alt"],
+    extraHigh: ["Molt alt"],
+  },
   modeOpenerExtra: ["Configura…"],
   tools: {
     web_search: ["Cerca a la xarxa"],

--- a/packages/node/src/dom/locale/cs.ts
+++ b/packages/node/src/dom/locale/cs.ts
@@ -19,6 +19,12 @@ export const cs = {
   addPhotosFilesMenuItem: ["Přidat fotografie a soubory"],
   copyResponse: ["Zkopírovat odpověď"],
   modeLabels: ["Okamžitá", "Střední", "Vysoká", "Velmi vysoká"],
+  modeOptions: {
+    instant: ["Okamžitá"],
+    medium: ["Střední"],
+    high: ["Vysoká"],
+    extraHigh: ["Velmi vysoká"],
+  },
   modeOpenerExtra: ["Konfigurovat…"],
   tools: {
     web_search: ["Vyhledávání na webu"],

--- a/packages/node/src/dom/locale/da.ts
+++ b/packages/node/src/dom/locale/da.ts
@@ -19,6 +19,11 @@ export const da = {
   addPhotosFilesMenuItem: ["Tilføj billeder og filer"],
   copyResponse: ["Kopiér svar"],
   modeLabels: ["Øjeblikkeligt", "Høj", "Ekstra høj"],
+  modeOptions: {
+    instant: ["Øjeblikkeligt"],
+    high: ["Høj"],
+    extraHigh: ["Ekstra høj"],
+  },
   modeOpenerExtra: ["Konfigurer ..."],
   tools: {
     web_search: ["Internetsøgning"],

--- a/packages/node/src/dom/locale/de.ts
+++ b/packages/node/src/dom/locale/de.ts
@@ -22,6 +22,12 @@ export const de = {
   addPhotosFilesMenuItem: ["Fotos und Dateien hinzufügen"],
   copyResponse: ["Antwort kopieren"],
   modeLabels: ["Sofort", "Mittel", "Hoch", "Extra hoch"],
+  modeOptions: {
+    instant: ["Sofort"],
+    medium: ["Mittel"],
+    high: ["Hoch"],
+    extraHigh: ["Extra hoch"],
+  },
   modeOpenerExtra: ["Konfigurieren"],
   tools: {
     web_search: ["Websuche"],

--- a/packages/node/src/dom/locale/el.ts
+++ b/packages/node/src/dom/locale/el.ts
@@ -19,6 +19,12 @@ export const el = {
   addPhotosFilesMenuItem: ["Προσθήκη φωτογραφιών & αρχείων"],
   copyResponse: ["Αντιγραφή απάντησης"],
   modeLabels: ["Άμεση", "Μεσαία", "Υψηλή", "Πολύ υψηλό"],
+  modeOptions: {
+    instant: ["Άμεση"],
+    medium: ["Μεσαία"],
+    high: ["Υψηλή"],
+    extraHigh: ["Πολύ υψηλό"],
+  },
   modeOpenerExtra: ["Διαμόρφωση…"],
   tools: {
     web_search: ["Αναζήτηση στον ιστό"],

--- a/packages/node/src/dom/locale/en.ts
+++ b/packages/node/src/dom/locale/en.ts
@@ -31,6 +31,16 @@ export const en = {
 
   // --- Mode switcher (also the canonical public API keys) ---
   modeLabels: ["Latest", "Instant", "Thinking", "Extended", "Medium", "High", "Extra High", "Pro"],
+  modeOptions: {
+    latest: ["Latest"],
+    instant: ["Instant"],
+    thinking: ["Thinking"],
+    extended: ["Extended"],
+    medium: ["Medium"],
+    high: ["High"],
+    extraHigh: ["Extra High"],
+    pro: ["Pro", "Pro Extended", "Extended Pro"],
+  },
   /** Extra openers that surface the mode menu but are not selectable modes themselves. */
   modeOpenerExtra: ["Configure"],
 

--- a/packages/node/src/dom/locale/es-419.ts
+++ b/packages/node/src/dom/locale/es-419.ts
@@ -19,6 +19,12 @@ export const es419 = {
   addPhotosFilesMenuItem: ["Agregar fotos y archivos"],
   copyResponse: ["Copiar respuesta"],
   modeLabels: ["Instantánea", "Media", "Alta", "Muy alta"],
+  modeOptions: {
+    instant: ["Instantánea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Muy alta"],
+  },
   modeOpenerExtra: ["Configurar..."],
   tools: {
     web_search: ["Busca en la web"],

--- a/packages/node/src/dom/locale/es-ES.ts
+++ b/packages/node/src/dom/locale/es-ES.ts
@@ -19,6 +19,12 @@ export const esES = {
   addPhotosFilesMenuItem: ["Añadir fotos y archivos"],
   copyResponse: ["Copiar respuesta"],
   modeLabels: ["Instantánea", "Media", "Alta", "Muy alta"],
+  modeOptions: {
+    instant: ["Instantánea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Muy alta"],
+  },
   modeOpenerExtra: ["Configurar"],
   tools: {
     web_search: ["Búsqueda en Internet"],

--- a/packages/node/src/dom/locale/et.ts
+++ b/packages/node/src/dom/locale/et.ts
@@ -19,6 +19,12 @@ export const et = {
   addPhotosFilesMenuItem: ["Lisa fotosid ja faile"],
   copyResponse: ["Kopeeri vastus"],
   modeLabels: ["Kohene", "Keskmine", "Kõrge", "Väga kõrge"],
+  modeOptions: {
+    instant: ["Kohene"],
+    medium: ["Keskmine"],
+    high: ["Kõrge"],
+    extraHigh: ["Väga kõrge"],
+  },
   modeOpenerExtra: ["Konfigureeri..."],
   tools: {
     web_search: ["Veebiotsing"],

--- a/packages/node/src/dom/locale/fa.ts
+++ b/packages/node/src/dom/locale/fa.ts
@@ -19,6 +19,13 @@ export const fa = {
   addPhotosFilesMenuItem: ["افزودن تصاویر و فایل‌ها"],
   copyResponse: ["کپی کردن پاسخ"],
   modeLabels: ["فوری", "متوسط", "بالا", "بسیار زیاد", "حرفه‌ای"],
+  modeOptions: {
+    instant: ["فوری"],
+    medium: ["متوسط"],
+    high: ["بالا"],
+    extraHigh: ["بسیار زیاد"],
+    pro: ["حرفه‌ای"],
+  },
   modeOpenerExtra: ["پیکربندی..."],
   tools: {
     web_search: ["جستجوی وب"],

--- a/packages/node/src/dom/locale/fi.ts
+++ b/packages/node/src/dom/locale/fi.ts
@@ -19,6 +19,12 @@ export const fi = {
   addPhotosFilesMenuItem: ["Lisää valokuvia & tiedostoja"],
   copyResponse: ["Kopioi vastaus"],
   modeLabels: ["Välitön", "Keskitaso", "Korkea", "Erittäin korkea"],
+  modeOptions: {
+    instant: ["Välitön"],
+    medium: ["Keskitaso"],
+    high: ["Korkea"],
+    extraHigh: ["Erittäin korkea"],
+  },
   modeOpenerExtra: ["Määritä..."],
   tools: {
     web_search: ["Verkkohaku"],

--- a/packages/node/src/dom/locale/fr-CA.ts
+++ b/packages/node/src/dom/locale/fr-CA.ts
@@ -20,6 +20,12 @@ export const frCA = {
   addPhotosFilesMenuItem: ["Ajouter des photos et des fichiers"],
   copyResponse: ["Copier la réponse"],
   modeLabels: ["Instantané", "Moyen", "Élevé", "Très élevé"],
+  modeOptions: {
+    instant: ["Instantané"],
+    medium: ["Moyen"],
+    high: ["Élevé"],
+    extraHigh: ["Très élevé"],
+  },
   modeOpenerExtra: ["Configurer..."],
   tools: {
     web_search: ["Recherche sur Internet"],

--- a/packages/node/src/dom/locale/fr-FR.ts
+++ b/packages/node/src/dom/locale/fr-FR.ts
@@ -21,6 +21,11 @@ export const frFR = {
   addPhotosFilesMenuItem: ["Ajouter des photos et fichiers"],
   copyResponse: ["Copier la réponse"],
   modeLabels: ["Moyen", "Avancé", "Très élevé"],
+  modeOptions: {
+    medium: ["Moyen"],
+    high: ["Avancé"],
+    extraHigh: ["Très élevé"],
+  },
   modeOpenerExtra: ["Configurer"],
   tools: {
     web_search: ["Recherche sur le Web"],

--- a/packages/node/src/dom/locale/gu.ts
+++ b/packages/node/src/dom/locale/gu.ts
@@ -19,6 +19,12 @@ export const gu = {
   addPhotosFilesMenuItem: ["ફોટા અને ફાઇલો ઉમેરો"],
   copyResponse: ["પ્રતિભાવ કૉપિ કરો"],
   modeLabels: ["તરત", "મધ્યમ", "ઉચ્ચ", "અતિ ઉચ્ચ"],
+  modeOptions: {
+    instant: ["તરત"],
+    medium: ["મધ્યમ"],
+    high: ["ઉચ્ચ"],
+    extraHigh: ["અતિ ઉચ્ચ"],
+  },
   modeOpenerExtra: ["કન્ફિગર કરો..."],
   tools: {
     web_search: ["વેબ શોધ"],

--- a/packages/node/src/dom/locale/hi.ts
+++ b/packages/node/src/dom/locale/hi.ts
@@ -19,6 +19,12 @@ export const hi = {
   addPhotosFilesMenuItem: ["फ़ोटो और फ़ाइलें जोड़ें"],
   copyResponse: ["जवाब को कॉपी करें"],
   modeLabels: ["तुरंत", "मध्यम", "उच्च", "बहुत उच्च"],
+  modeOptions: {
+    instant: ["तुरंत"],
+    medium: ["मध्यम"],
+    high: ["उच्च"],
+    extraHigh: ["बहुत उच्च"],
+  },
   modeOpenerExtra: ["कॉन्फ़िगर करें..."],
   tools: {
     web_search: ["वेब सर्च"],

--- a/packages/node/src/dom/locale/hr.ts
+++ b/packages/node/src/dom/locale/hr.ts
@@ -19,6 +19,11 @@ export const hr = {
   addPhotosFilesMenuItem: ["Dodaj fotografije i datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Srednje", "Visoko", "Vrlo visoka"],
+  modeOptions: {
+    medium: ["Srednje"],
+    high: ["Visoko"],
+    extraHigh: ["Vrlo visoka"],
+  },
   modeOpenerExtra: ["Konfiguriraj…"],
   tools: {
     web_search: ["Mrežno pretraživanje"],

--- a/packages/node/src/dom/locale/hu.ts
+++ b/packages/node/src/dom/locale/hu.ts
@@ -19,6 +19,12 @@ export const hu = {
   addPhotosFilesMenuItem: ["Fotók és fájlok hozzáadása"],
   copyResponse: ["Válasz másolása"],
   modeLabels: ["Azonnali", "Közepes", "Magas", "Kiemelkedően magas"],
+  modeOptions: {
+    instant: ["Azonnali"],
+    medium: ["Közepes"],
+    high: ["Magas"],
+    extraHigh: ["Kiemelkedően magas"],
+  },
   modeOpenerExtra: ["Konfigurálás..."],
   tools: {
     web_search: ["Internetes keresés"],

--- a/packages/node/src/dom/locale/hy.ts
+++ b/packages/node/src/dom/locale/hy.ts
@@ -19,6 +19,13 @@ export const hy = {
   addPhotosFilesMenuItem: ["Ավելացնել լուսանկարներ և ֆայլեր"],
   copyResponse: ["Պատճենել պատասխանը"],
   modeLabels: ["Ակնթարթային", "Միջին", "Բարձր", "Շատ բարձր", "Պրո"],
+  modeOptions: {
+    instant: ["Ակնթարթային"],
+    medium: ["Միջին"],
+    high: ["Բարձր"],
+    extraHigh: ["Շատ բարձր"],
+    pro: ["Պրո"],
+  },
   modeOpenerExtra: ["Կազմաձևել․․․"],
   tools: {
     web_search: ["Վեբ որոնում"],

--- a/packages/node/src/dom/locale/id.ts
+++ b/packages/node/src/dom/locale/id.ts
@@ -19,6 +19,12 @@ export const id = {
   addPhotosFilesMenuItem: ["Tambah foto & file"],
   copyResponse: ["Salin respons"],
   modeLabels: ["Instan", "Sedang", "Tinggi", "Sangat Tinggi"],
+  modeOptions: {
+    instant: ["Instan"],
+    medium: ["Sedang"],
+    high: ["Tinggi"],
+    extraHigh: ["Sangat Tinggi"],
+  },
   modeOpenerExtra: ["Konfigurasi..."],
   tools: {
     web_search: ["Pencarian web"],

--- a/packages/node/src/dom/locale/index.ts
+++ b/packages/node/src/dom/locale/index.ts
@@ -101,7 +101,7 @@ import { sr } from "./sr.js";
 import { mn } from "./mn.js";
 import { my } from "./my.js";
 import { ta } from "./ta.js";
-import type { LocaleContribution, LocaleStrings } from "./types.js";
+import type { LocaleContribution, LocaleStrings, ModeOptionId } from "./types.js";
 
 // --- Locale registration ---
 // English MUST be first (canonical). Append additional locale objects here.
@@ -111,6 +111,16 @@ const locales: readonly (LocaleStrings | LocaleContribution)[] = [en, de, esES, 
 
 type ToolId = "web_search" | "deep_research" | "create_image";
 const TOOL_IDS: ToolId[] = ["web_search", "deep_research", "create_image"];
+const MODE_OPTION_IDS: ModeOptionId[] = [
+  "latest",
+  "instant",
+  "thinking",
+  "extended",
+  "medium",
+  "high",
+  "extraHigh",
+  "pro",
+];
 
 /**
  * Flatten contributions for a single non-tools key, deduplicating strings while
@@ -167,6 +177,35 @@ function flattenTool(
   return result;
 }
 
+/**
+ * Flatten contributions for a single semantic mode id across all locales.
+ */
+function flattenModeOption(
+  localeList: readonly (LocaleStrings | LocaleContribution)[],
+  optionId: ModeOptionId
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const locale of localeList) {
+    const modeOptions = (locale as Record<string, unknown>)["modeOptions"] as
+      | Partial<Record<ModeOptionId, string | readonly string[]>>
+      | undefined;
+    if (modeOptions === undefined || modeOptions === null) continue;
+    const value = modeOptions[optionId];
+    if (value === undefined || value === null) continue;
+    const candidates: readonly string[] = typeof value === "string" ? [value] : (value as readonly string[]);
+    for (const candidate of candidates) {
+      if (candidate.length > 0 && !seen.has(candidate)) {
+        seen.add(candidate);
+        result.push(candidate);
+      }
+    }
+  }
+
+  return result;
+}
+
 // Build the combined localeLabels object by flattening all locales.
 const nonToolKeys = [
   "composerTextbox",
@@ -204,6 +243,10 @@ const builtTools = Object.fromEntries(
   TOOL_IDS.map(id => [id, flattenTool(locales, id)])
 ) as Record<ToolId, string[]>;
 
+const builtModeOptions = Object.fromEntries(
+  MODE_OPTION_IDS.map(id => [id, flattenModeOption(locales, id)])
+) as Record<ModeOptionId, string[]>;
+
 /**
  * The combined locale registry. Values are `string[]` (mutable; English-first; deduped).
  * Consumers treat this identically to the previous `as const` object — the array contents
@@ -226,6 +269,7 @@ export const localeLabels: {
   downloadImage: string[];
   imageContainerHint: string[];
   modeLabels: string[];
+  modeOptions: Record<ModeOptionId, string[]>;
   modeOpenerExtra: string[];
   tools: Record<string, string[]>;
   signedInMarkers: string[];
@@ -238,6 +282,7 @@ export const localeLabels: {
   rateLimitBlocker: string[];
 } = {
   ...builtLabels,
+  modeOptions: builtModeOptions,
   tools: builtTools,
 };
 
@@ -257,4 +302,4 @@ export function anyLabelPattern(candidates: readonly string[]): RegExp {
   return new RegExp(candidates.map(escapeRegExp).join("|"), "i");
 }
 
-export type { LocaleStrings, LocaleContribution } from "./types.js";
+export type { LocaleStrings, LocaleContribution, ModeOptionId, ModeOptionLabels, ModeOptionContribution } from "./types.js";

--- a/packages/node/src/dom/locale/is.ts
+++ b/packages/node/src/dom/locale/is.ts
@@ -19,6 +19,12 @@ export const is = {
   addPhotosFilesMenuItem: ["Bæta myndum og skrám við"],
   copyResponse: ["Afrita svar"],
   modeLabels: ["Strax", "Miðlungs", "Hátt", "Mjög hátt"],
+  modeOptions: {
+    instant: ["Strax"],
+    medium: ["Miðlungs"],
+    high: ["Hátt"],
+    extraHigh: ["Mjög hátt"],
+  },
   modeOpenerExtra: ["Stillir…"],
   tools: {
     web_search: ["Vefleit"],

--- a/packages/node/src/dom/locale/it.ts
+++ b/packages/node/src/dom/locale/it.ts
@@ -19,6 +19,12 @@ export const it = {
   addPhotosFilesMenuItem: ["Aggiungi foto e file"],
   copyResponse: ["Copia risposta"],
   modeLabels: ["Istantanea", "Media", "Alta", "Extra elevata"],
+  modeOptions: {
+    instant: ["Istantanea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Extra elevata"],
+  },
   modeOpenerExtra: ["Configura"],
   tools: {
     web_search: ["Ricerca sul web"],

--- a/packages/node/src/dom/locale/ja.ts
+++ b/packages/node/src/dom/locale/ja.ts
@@ -19,6 +19,12 @@ export const ja = {
   addPhotosFilesMenuItem: ["写真とファイルを追加"],
   copyResponse: ["回答をコピーする"],
   modeLabels: ["最速", "標準", "高", "最高"],
+  modeOptions: {
+    instant: ["最速"],
+    medium: ["標準"],
+    high: ["高"],
+    extraHigh: ["最高"],
+  },
   modeOpenerExtra: ["設定する"],
   tools: {
     web_search: ["ウェブ検索"],

--- a/packages/node/src/dom/locale/ka.ts
+++ b/packages/node/src/dom/locale/ka.ts
@@ -19,6 +19,12 @@ export const ka = {
   addPhotosFilesMenuItem: ["ფოტოების და ფაილების დამატება"],
   copyResponse: ["პასუხის კოპირება"],
   modeLabels: ["მყისიერი", "საშუალო", "მაღალი", "ძალიან მაღალი"],
+  modeOptions: {
+    instant: ["მყისიერი"],
+    medium: ["საშუალო"],
+    high: ["მაღალი"],
+    extraHigh: ["ძალიან მაღალი"],
+  },
   modeOpenerExtra: ["კონფიგურირება…"],
   tools: {
     web_search: ["ვებში ძიება"],

--- a/packages/node/src/dom/locale/kk.ts
+++ b/packages/node/src/dom/locale/kk.ts
@@ -19,6 +19,12 @@ export const kk = {
   addPhotosFilesMenuItem: ["Фотосуреттер мен файлдар қосу"],
   copyResponse: ["Жауапты көшіру"],
   modeLabels: ["Жедел", "Орташа", "Жоғары", "Аса жоғары"],
+  modeOptions: {
+    instant: ["Жедел"],
+    medium: ["Орташа"],
+    high: ["Жоғары"],
+    extraHigh: ["Аса жоғары"],
+  },
   modeOpenerExtra: ["Кофигурациялау..."],
   tools: {
     web_search: ["Іздеу"],

--- a/packages/node/src/dom/locale/kn.ts
+++ b/packages/node/src/dom/locale/kn.ts
@@ -19,6 +19,13 @@ export const kn = {
   addPhotosFilesMenuItem: ["ಫೋಟೊ ಮತ್ತು ಫೈಲ್‌ಗಳನ್ನು ಸೇರಿಸಿ"],
   copyResponse: ["ಪ್ರತಿಕ್ರಿಯೆಯನ್ನು ನಕಲಿಸಿ"],
   modeLabels: ["ತಕ್ಷಣ", "ಮಧ್ಯಮ", "ಉನ್ನತ", "ಅತಿ ಹೆಚ್ಚು", "ಪ್ರೊ"],
+  modeOptions: {
+    instant: ["ತಕ್ಷಣ"],
+    medium: ["ಮಧ್ಯಮ"],
+    high: ["ಉನ್ನತ"],
+    extraHigh: ["ಅತಿ ಹೆಚ್ಚು"],
+    pro: ["ಪ್ರೊ"],
+  },
   modeOpenerExtra: ["ಕಾನ್ಫಿಗರ್ ಮಾಡಿ..."],
   tools: {
     web_search: ["ವೆಬ್ ಸರ್ಚ್"],

--- a/packages/node/src/dom/locale/ko.ts
+++ b/packages/node/src/dom/locale/ko.ts
@@ -19,6 +19,12 @@ export const ko = {
   addPhotosFilesMenuItem: ["사진 및 파일 추가"],
   copyResponse: ["응답 복사"],
   modeLabels: ["즉시", "중간", "높음", "매우 높음"],
+  modeOptions: {
+    instant: ["즉시"],
+    medium: ["중간"],
+    high: ["높음"],
+    extraHigh: ["매우 높음"],
+  },
   modeOpenerExtra: ["구성…"],
   tools: {
     web_search: ["웹 검색"],

--- a/packages/node/src/dom/locale/lt.ts
+++ b/packages/node/src/dom/locale/lt.ts
@@ -19,6 +19,13 @@ export const lt = {
   addPhotosFilesMenuItem: ["Pridėti nuotraukų ir failų"],
   copyResponse: ["Kopijuoti atsakymą"],
   modeLabels: ["Momentinis", "Vidutinis", "Aukštas", "Ypač didelis", "Profesionalus"],
+  modeOptions: {
+    instant: ["Momentinis"],
+    medium: ["Vidutinis"],
+    high: ["Aukštas"],
+    extraHigh: ["Ypač didelis"],
+    pro: ["Profesionalus"],
+  },
   modeOpenerExtra: ["Konfigūruoti..."],
   tools: {
     web_search: ["Žiniatinklio paieška"],

--- a/packages/node/src/dom/locale/lv.ts
+++ b/packages/node/src/dom/locale/lv.ts
@@ -19,6 +19,12 @@ export const lv = {
   addPhotosFilesMenuItem: ["Augšupielādēt foto un failus"],
   copyResponse: ["Kopēt atbildi"],
   modeLabels: ["Tūlītējs", "Vidējs", "Augsts", "Ļoti augsts"],
+  modeOptions: {
+    instant: ["Tūlītējs"],
+    medium: ["Vidējs"],
+    high: ["Augsts"],
+    extraHigh: ["Ļoti augsts"],
+  },
   modeOpenerExtra: ["Konfigurēt..."],
   tools: {
     web_search: ["Meklēšana tīmeklī"],

--- a/packages/node/src/dom/locale/mk.ts
+++ b/packages/node/src/dom/locale/mk.ts
@@ -19,6 +19,11 @@ export const mk = {
   addPhotosFilesMenuItem: ["Постави фотографии и датотеки"],
   copyResponse: ["Копирај одговор"],
   modeLabels: ["Средно", "Високо", "Многу високо"],
+  modeOptions: {
+    medium: ["Средно"],
+    high: ["Високо"],
+    extraHigh: ["Многу високо"],
+  },
   modeOpenerExtra: ["Конфигурирај..."],
   tools: {
     web_search: ["Пребарување на интернет"],

--- a/packages/node/src/dom/locale/ml.ts
+++ b/packages/node/src/dom/locale/ml.ts
@@ -19,6 +19,13 @@ export const ml = {
   addPhotosFilesMenuItem: ["ഫോട്ടോകളും ഫയലുകളും അപ്‌ലോഡ് ചെയ്യുക"],
   copyResponse: ["മറുപടി കോപ്പി ചെയ്യുക"],
   modeLabels: ["തൽക്ഷണം", "ഇടത്തരം", "ഉയർന്നത്", "വളരെ ഉയർന്ന", "പ്രോ"],
+  modeOptions: {
+    instant: ["തൽക്ഷണം"],
+    medium: ["ഇടത്തരം"],
+    high: ["ഉയർന്നത്"],
+    extraHigh: ["വളരെ ഉയർന്ന"],
+    pro: ["പ്രോ"],
+  },
   modeOpenerExtra: ["കോൺഫിഗർ ചെയ്യുക…"],
   tools: {
     web_search: ["വെബ് തിരയൽ"],

--- a/packages/node/src/dom/locale/mn.ts
+++ b/packages/node/src/dom/locale/mn.ts
@@ -19,6 +19,13 @@ export const mn = {
   addPhotosFilesMenuItem: ["Зураг ба файл байршуулах"],
   copyResponse: ["Хариулт хуулах"],
   modeLabels: ["Шуурхай", "Дунд", "Өндөр", "Маш өндөр", "Про"],
+  modeOptions: {
+    instant: ["Шуурхай"],
+    medium: ["Дунд"],
+    high: ["Өндөр"],
+    extraHigh: ["Маш өндөр"],
+    pro: ["Про"],
+  },
   modeOpenerExtra: ["Тохируулах..."],
   tools: {
     web_search: ["Веб хайлт"],

--- a/packages/node/src/dom/locale/mr.ts
+++ b/packages/node/src/dom/locale/mr.ts
@@ -19,6 +19,13 @@ export const mr = {
   addPhotosFilesMenuItem: ["फोटो आणि फाइल्स अपलोड करा"],
   copyResponse: ["प्रतिसाद कॉपी करा"],
   modeLabels: ["झटपट", "मध्यम", "उच्च", "अतिउच्च", "प्रो"],
+  modeOptions: {
+    instant: ["झटपट"],
+    medium: ["मध्यम"],
+    high: ["उच्च"],
+    extraHigh: ["अतिउच्च"],
+    pro: ["प्रो"],
+  },
   modeOpenerExtra: ["कॉन्फिगर करा..."],
   tools: {
     web_search: ["वेबवर शोध"],

--- a/packages/node/src/dom/locale/ms.ts
+++ b/packages/node/src/dom/locale/ms.ts
@@ -19,6 +19,12 @@ export const ms = {
   addPhotosFilesMenuItem: ["Muat naik foto & fail"],
   copyResponse: ["Salin tindak balas"],
   modeLabels: ["Segera", "Sederhana", "Tinggi", "Sangat Tinggi"],
+  modeOptions: {
+    instant: ["Segera"],
+    medium: ["Sederhana"],
+    high: ["Tinggi"],
+    extraHigh: ["Sangat Tinggi"],
+  },
   modeOpenerExtra: ["Konfigurasikan…"],
   tools: {
     web_search: ["Carian web"],

--- a/packages/node/src/dom/locale/my.ts
+++ b/packages/node/src/dom/locale/my.ts
@@ -19,6 +19,12 @@ export const my = {
   addPhotosFilesMenuItem: ["ဓာတ်ပုံများနှင့် ဖိုင်များကို တင်ပါ"],
   copyResponse: ["တုံ့ပြန်မှု ကူးယူရန်"],
   modeLabels: ["ချက်ချင်း", "အလယ်အလတ်", "မြင့်", "အလွန်မြင့်"],
+  modeOptions: {
+    instant: ["ချက်ချင်း"],
+    medium: ["အလယ်အလတ်"],
+    high: ["မြင့်"],
+    extraHigh: ["အလွန်မြင့်"],
+  },
   modeOpenerExtra: ["ပြုပြင်မွမ်းမံရန်"],
   tools: {
     web_search: ["ဝဘ်ရှာဖွေရန်"],

--- a/packages/node/src/dom/locale/nb.ts
+++ b/packages/node/src/dom/locale/nb.ts
@@ -19,6 +19,12 @@ export const nb = {
   addPhotosFilesMenuItem: ["Last opp bilder og filer"],
   copyResponse: ["Kopier svar"],
   modeLabels: ["Øyeblikkelig", "Middels", "Høy", "Ekstra høy"],
+  modeOptions: {
+    instant: ["Øyeblikkelig"],
+    medium: ["Middels"],
+    high: ["Høy"],
+    extraHigh: ["Ekstra høy"],
+  },
   modeOpenerExtra: ["Konfigurer …"],
   tools: {
     web_search: ["Nettsøk"],

--- a/packages/node/src/dom/locale/nl.ts
+++ b/packages/node/src/dom/locale/nl.ts
@@ -19,6 +19,12 @@ export const nl = {
   addPhotosFilesMenuItem: ["Foto's en bestanden uploaden"],
   copyResponse: ["Reactie kopiëren"],
   modeLabels: ["Direct", "Gemiddeld", "Hoog", "Extra hoog"],
+  modeOptions: {
+    instant: ["Direct"],
+    medium: ["Gemiddeld"],
+    high: ["Hoog"],
+    extraHigh: ["Extra hoog"],
+  },
   modeOpenerExtra: ["Configureren..."],
   tools: {
     web_search: ["Zoeken op internet"],

--- a/packages/node/src/dom/locale/pa.ts
+++ b/packages/node/src/dom/locale/pa.ts
@@ -19,6 +19,13 @@ export const pa = {
   addPhotosFilesMenuItem: ["ਫ਼ੋਟੋਆਂ ਅਤੇ ਫ਼ਾਈਲਾਂ ਅੱਪਲੋਡ ਕਰੋ"],
   copyResponse: ["ਜਵਾਬ ਕਾਪੀ ਕਰੋ"],
   modeLabels: ["ਤੁਰੰਤ", "ਮੱਧਮ", "ਉੱਚ", "ਅਤਿ ਉੱਚ", "ਪ੍ਰੋ"],
+  modeOptions: {
+    instant: ["ਤੁਰੰਤ"],
+    medium: ["ਮੱਧਮ"],
+    high: ["ਉੱਚ"],
+    extraHigh: ["ਅਤਿ ਉੱਚ"],
+    pro: ["ਪ੍ਰੋ"],
+  },
   modeOpenerExtra: ["ਕੌਨਫਿਗਰ..."],
   tools: {
     web_search: ["ਵੈੱਬ ਖੋਜ"],

--- a/packages/node/src/dom/locale/pl.ts
+++ b/packages/node/src/dom/locale/pl.ts
@@ -19,6 +19,12 @@ export const pl = {
   addPhotosFilesMenuItem: ["Prześlij zdjęcia i pliki"],
   copyResponse: ["Kopiuj odpowiedź"],
   modeLabels: ["Błyskawiczny", "Średni", "Zaawansowana", "Bardzo wysoki"],
+  modeOptions: {
+    instant: ["Błyskawiczny"],
+    medium: ["Średni"],
+    high: ["Zaawansowana"],
+    extraHigh: ["Bardzo wysoki"],
+  },
   modeOpenerExtra: ["Skonfiguruj..."],
   tools: {
     web_search: ["Wyszukiwanie w sieci"],

--- a/packages/node/src/dom/locale/pt-BR.ts
+++ b/packages/node/src/dom/locale/pt-BR.ts
@@ -19,6 +19,12 @@ export const ptBR = {
   addPhotosFilesMenuItem: ["Carregar fotos e arquivos"],
   copyResponse: ["Copiar resposta"],
   modeLabels: ["Instantâneo", "Médio", "Alto", "Muito alta"],
+  modeOptions: {
+    instant: ["Instantâneo"],
+    medium: ["Médio"],
+    high: ["Alto"],
+    extraHigh: ["Muito alta"],
+  },
   modeOpenerExtra: ["Configurar…"],
   tools: {
     web_search: ["Busca na web"],

--- a/packages/node/src/dom/locale/pt-PT.ts
+++ b/packages/node/src/dom/locale/pt-PT.ts
@@ -19,6 +19,12 @@ export const ptPT = {
   addPhotosFilesMenuItem: ["Carregar fotos e ficheiros"],
   copyResponse: ["Copiar resposta"],
   modeLabels: ["Instantâneo", "Média", "Alta", "Máximo"],
+  modeOptions: {
+    instant: ["Instantâneo"],
+    medium: ["Média"],
+    high: ["Alta"],
+    extraHigh: ["Máximo"],
+  },
   modeOpenerExtra: ["Configurar..."],
   tools: {
     web_search: ["Procurar na web"],

--- a/packages/node/src/dom/locale/ro.ts
+++ b/packages/node/src/dom/locale/ro.ts
@@ -19,6 +19,11 @@ export const ro = {
   addPhotosFilesMenuItem: ["Încarcă fotografii și fișiere"],
   copyResponse: ["Copiază răspunsul"],
   modeLabels: ["Mediu", "Ridicat", "Foarte ridicată"],
+  modeOptions: {
+    medium: ["Mediu"],
+    high: ["Ridicat"],
+    extraHigh: ["Foarte ridicată"],
+  },
   modeOpenerExtra: ["Configurează..."],
   tools: {
     web_search: ["Căutare pe internet"],

--- a/packages/node/src/dom/locale/ru.ts
+++ b/packages/node/src/dom/locale/ru.ts
@@ -19,6 +19,9 @@ export const ru = {
   addPhotosFilesMenuItem: ["Загрузить фотографии и файлы"],
   copyResponse: ["Копировать ответ"],
   modeLabels: ["Очень высокий"],
+  modeOptions: {
+    extraHigh: ["Очень высокий"],
+  },
   modeOpenerExtra: ["Конфигурация..."],
   tools: {
     web_search: ["Поиск в сети"],

--- a/packages/node/src/dom/locale/sk.ts
+++ b/packages/node/src/dom/locale/sk.ts
@@ -19,6 +19,12 @@ export const sk = {
   addPhotosFilesMenuItem: ["Nahrať fotografie a súbory"],
   copyResponse: ["Kopírovať odpoveď"],
   modeLabels: ["Okamžitá", "Stredná", "Vysoká", "Extra vysoká"],
+  modeOptions: {
+    instant: ["Okamžitá"],
+    medium: ["Stredná"],
+    high: ["Vysoká"],
+    extraHigh: ["Extra vysoká"],
+  },
   modeOpenerExtra: ["Konfigurovať..."],
   tools: {
     web_search: ["Prehľadávaj web"],

--- a/packages/node/src/dom/locale/sl.ts
+++ b/packages/node/src/dom/locale/sl.ts
@@ -19,6 +19,12 @@ export const sl = {
   addPhotosFilesMenuItem: ["Naloži fotografije in datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Takoj", "Srednja", "Visoka", "Zelo visoko"],
+  modeOptions: {
+    instant: ["Takoj"],
+    medium: ["Srednja"],
+    high: ["Visoka"],
+    extraHigh: ["Zelo visoko"],
+  },
   modeOpenerExtra: ["Konfiguracija …"],
   tools: {
     web_search: ["Iskanje po spletu"],

--- a/packages/node/src/dom/locale/so.ts
+++ b/packages/node/src/dom/locale/so.ts
@@ -19,6 +19,12 @@ export const so = {
   addPhotosFilesMenuItem: ["Soo geli sawirada & faylasha"],
   copyResponse: ["Koobiyee jawaabta"],
   modeLabels: ["Degdeg", "Dhexdhexaad", "Sare", "Aad u sarreeya"],
+  modeOptions: {
+    instant: ["Degdeg"],
+    medium: ["Dhexdhexaad"],
+    high: ["Sare"],
+    extraHigh: ["Aad u sarreeya"],
+  },
   modeOpenerExtra: ["Ku xidh..."],
   tools: {
     web_search: ["Raadi shakabada"],

--- a/packages/node/src/dom/locale/sq.ts
+++ b/packages/node/src/dom/locale/sq.ts
@@ -19,6 +19,12 @@ export const sq = {
   addPhotosFilesMenuItem: ["Ngarko foto dhe skedarë"],
   copyResponse: ["Kopjo përgjigjen"],
   modeLabels: ["I menjëhershëm", "Mesatar", "Lartë", "Shumë i lartë"],
+  modeOptions: {
+    instant: ["I menjëhershëm"],
+    medium: ["Mesatar"],
+    high: ["Lartë"],
+    extraHigh: ["Shumë i lartë"],
+  },
   modeOpenerExtra: ["Konfiguro..."],
   tools: {
     web_search: ["Kërkim në ueb"],

--- a/packages/node/src/dom/locale/sr.ts
+++ b/packages/node/src/dom/locale/sr.ts
@@ -19,6 +19,9 @@ export const sr = {
   addPhotosFilesMenuItem: ["Отпреми фотографије и датотеке"],
   copyResponse: ["Копирај одговор"],
   modeLabels: ["Веома високо"],
+  modeOptions: {
+    extraHigh: ["Веома високо"],
+  },
   modeOpenerExtra: ["Конфигуриши..."],
   tools: {
     web_search: ["Претрага веба"],

--- a/packages/node/src/dom/locale/sv.ts
+++ b/packages/node/src/dom/locale/sv.ts
@@ -19,6 +19,12 @@ export const sv = {
   addPhotosFilesMenuItem: ["Ladda upp foton och filer"],
   copyResponse: ["Kopiera svar"],
   modeLabels: ["Direkt", "Balanserad", "Hög", "Extra hög"],
+  modeOptions: {
+    instant: ["Direkt"],
+    medium: ["Balanserad"],
+    high: ["Hög"],
+    extraHigh: ["Extra hög"],
+  },
   modeOpenerExtra: ["Konfigurera …"],
   tools: {
     web_search: ["Webbsökning"],

--- a/packages/node/src/dom/locale/sw.ts
+++ b/packages/node/src/dom/locale/sw.ts
@@ -19,6 +19,12 @@ export const sw = {
   addPhotosFilesMenuItem: ["Pakia picha na mafaili"],
   copyResponse: ["Nakili jibu"],
   modeLabels: ["Papo hapo", "Wastani", "Juu", "Juu Zaidi"],
+  modeOptions: {
+    instant: ["Papo hapo"],
+    medium: ["Wastani"],
+    high: ["Juu"],
+    extraHigh: ["Juu Zaidi"],
+  },
   modeOpenerExtra: ["Sanidi..."],
   tools: {
     web_search: ["Utafutaji wa wavuti"],

--- a/packages/node/src/dom/locale/ta.ts
+++ b/packages/node/src/dom/locale/ta.ts
@@ -19,6 +19,13 @@ export const ta = {
   addPhotosFilesMenuItem: ["படங்கள் மற்றும் ஃபைல்களைப் பதிவேற்று"],
   copyResponse: ["பதிலை நகலெடுக்கலாம்"],
   modeLabels: ["உடனடி", "நடுத்தர", "உயர்", "மிக உயர்வு", "ப்ரோ"],
+  modeOptions: {
+    instant: ["உடனடி"],
+    medium: ["நடுத்தர"],
+    high: ["உயர்"],
+    extraHigh: ["மிக உயர்வு"],
+    pro: ["ப்ரோ"],
+  },
   modeOpenerExtra: ["கட்டமைக்கவும்..."],
   tools: {
     web_search: ["இணைய தேடல்"],

--- a/packages/node/src/dom/locale/te.ts
+++ b/packages/node/src/dom/locale/te.ts
@@ -19,6 +19,13 @@ export const te = {
   addPhotosFilesMenuItem: ["ఫోటోలు & ఫైల్‌లను అప్‌లోడ్ చేయండి"],
   copyResponse: ["ప్రతిస్పందనను కాపీ చేయండి"],
   modeLabels: ["తక్షణం", "మధ్యస్థ", "అధిక", "అత్యధిక", "ప్రో"],
+  modeOptions: {
+    instant: ["తక్షణం"],
+    medium: ["మధ్యస్థ"],
+    high: ["అధిక"],
+    extraHigh: ["అత్యధిక"],
+    pro: ["ప్రో"],
+  },
   modeOpenerExtra: ["కాన్ఫిగర్ చేయండి"],
   tools: {
     web_search: ["వెబ్‌లో వెతకడం"],

--- a/packages/node/src/dom/locale/th.ts
+++ b/packages/node/src/dom/locale/th.ts
@@ -19,6 +19,12 @@ export const th = {
   addPhotosFilesMenuItem: ["อัปโหลดรูปและไฟล์"],
   copyResponse: ["คัดลอกคำตอบ"],
   modeLabels: ["ทันที", "ปานกลาง", "สูง", "สูงมาก"],
+  modeOptions: {
+    instant: ["ทันที"],
+    medium: ["ปานกลาง"],
+    high: ["สูง"],
+    extraHigh: ["สูงมาก"],
+  },
   modeOpenerExtra: ["กำหนดค่า..."],
   tools: {
     web_search: ["ค้นหาเว็บ"],

--- a/packages/node/src/dom/locale/tr.ts
+++ b/packages/node/src/dom/locale/tr.ts
@@ -19,6 +19,12 @@ export const tr = {
   addPhotosFilesMenuItem: ["Fotoğraf ve dosya yükle"],
   copyResponse: ["Yanıtı kopyala"],
   modeLabels: ["Anında", "Orta", "Yüksek", "Çok Yüksek"],
+  modeOptions: {
+    instant: ["Anında"],
+    medium: ["Orta"],
+    high: ["Yüksek"],
+    extraHigh: ["Çok Yüksek"],
+  },
   modeOpenerExtra: ["Yapılandır..."],
   tools: {
     web_search: ["Web araması"],

--- a/packages/node/src/dom/locale/types.ts
+++ b/packages/node/src/dom/locale/types.ts
@@ -8,6 +8,19 @@
  * `tools` is keyed by logical tool id (stable API keys — callers pass `tool: "web_search"`).
  * A locale only needs to list the tools whose display text differs from English.
  */
+export type ModeOptionId =
+  | "latest"
+  | "instant"
+  | "thinking"
+  | "extended"
+  | "medium"
+  | "high"
+  | "extraHigh"
+  | "pro";
+
+export type ModeOptionLabels = Record<ModeOptionId, string | readonly string[]>;
+export type ModeOptionContribution = Partial<ModeOptionLabels>;
+
 export type LocaleStrings = {
   // --- Primary interaction path (accessible names) ---
   composerTextbox: string | readonly string[];
@@ -30,6 +43,7 @@ export type LocaleStrings = {
 
   // --- Mode switcher ---
   modeLabels: string | readonly string[];
+  modeOptions: ModeOptionLabels;
   modeOpenerExtra: string | readonly string[];
 
   // --- Tool menu items, keyed by logical tool id ---
@@ -52,6 +66,7 @@ export type LocaleStrings = {
  * The type for non-English locale files. Every key is optional so a contributor only
  * needs to supply the strings that differ from English. `tools` is also partial.
  */
-export type LocaleContribution = Partial<Omit<LocaleStrings, "tools">> & {
+export type LocaleContribution = Partial<Omit<LocaleStrings, "tools" | "modeOptions">> & {
+  modeOptions?: ModeOptionContribution;
   tools?: Partial<Record<"web_search" | "deep_research" | "create_image", string | readonly string[]>>;
 };

--- a/packages/node/src/dom/locale/uk.ts
+++ b/packages/node/src/dom/locale/uk.ts
@@ -19,6 +19,12 @@ export const uk = {
   addPhotosFilesMenuItem: ["Додати світлини та файли"],
   copyResponse: ["Копіювати відповідь"],
   modeLabels: ["Миттєвий", "Середній", "Високий", "Дуже високий"],
+  modeOptions: {
+    instant: ["Миттєвий"],
+    medium: ["Середній"],
+    high: ["Високий"],
+    extraHigh: ["Дуже високий"],
+  },
   modeOpenerExtra: ["Налаштувати…"],
   tools: {
     web_search: ["Пошук в Інтернеті"],

--- a/packages/node/src/dom/locale/ur.ts
+++ b/packages/node/src/dom/locale/ur.ts
@@ -19,6 +19,12 @@ export const ur = {
   addPhotosFilesMenuItem: ["تصویریں اور فائلیں شامل کریں"],
   copyResponse: ["جواب کاپی کریں"],
   modeLabels: ["فوری", "اوسط", "اعلیٰ", "انتہائی اعلیٰ"],
+  modeOptions: {
+    instant: ["فوری"],
+    medium: ["اوسط"],
+    high: ["اعلیٰ"],
+    extraHigh: ["انتہائی اعلیٰ"],
+  },
   modeOpenerExtra: ["کنفیگر کریں..."],
   tools: {
     web_search: ["ویب پر تلاش"],

--- a/packages/node/src/dom/locale/vi.ts
+++ b/packages/node/src/dom/locale/vi.ts
@@ -19,6 +19,12 @@ export const vi = {
   addPhotosFilesMenuItem: ["Thêm ảnh và tệp"],
   copyResponse: ["Sao chép phản hồi"],
   modeLabels: ["Tức thì", "Trung bình", "Cao", "Rất cao"],
+  modeOptions: {
+    instant: ["Tức thì"],
+    medium: ["Trung bình"],
+    high: ["Cao"],
+    extraHigh: ["Rất cao"],
+  },
   modeOpenerExtra: ["Định cấu hình"],
   tools: {
     web_search: ["Tìm kiếm trên mạng"],

--- a/packages/node/src/dom/locale/zh-HK.ts
+++ b/packages/node/src/dom/locale/zh-HK.ts
@@ -19,6 +19,13 @@ export const zhHK = {
   addPhotosFilesMenuItem: ["加入相片和檔案"],
   copyResponse: ["複製回覆"],
   modeLabels: ["即時", "均衡", "高", "極高", "專業"],
+  modeOptions: {
+    instant: ["即時"],
+    medium: ["均衡"],
+    high: ["高"],
+    extraHigh: ["極高"],
+    pro: ["專業"],
+  },
   modeOpenerExtra: ["設定"],
   tools: {
     web_search: ["網絡搜尋"],

--- a/packages/node/src/dom/locale/zh-Hans.ts
+++ b/packages/node/src/dom/locale/zh-Hans.ts
@@ -19,6 +19,13 @@ export const zhHans = {
   addPhotosFilesMenuItem: ["添加照片和文件"],
   copyResponse: ["复制回复"],
   modeLabels: ["极速", "均衡", "高级", "超高", "专业"],
+  modeOptions: {
+    instant: ["极速"],
+    medium: ["均衡"],
+    high: ["高级"],
+    extraHigh: ["超高"],
+    pro: ["专业"],
+  },
   modeOpenerExtra: ["配置…"],
   tools: {
     web_search: ["网页搜索"],

--- a/packages/node/src/dom/locale/zh-TW.ts
+++ b/packages/node/src/dom/locale/zh-TW.ts
@@ -20,6 +20,13 @@ export const zhTW = {
   addPhotosFilesMenuItem: ["新增照片和檔案"],
   copyResponse: ["複製回應"],
   modeLabels: ["即時", "中等", "高", "超高", "專業"],
+  modeOptions: {
+    instant: ["即時"],
+    medium: ["中等"],
+    high: ["高"],
+    extraHigh: ["超高"],
+    pro: ["專業"],
+  },
   modeOpenerExtra: ["設定"],
   tools: {
     web_search: ["網頁搜尋"],

--- a/packages/node/src/dom/menus.ts
+++ b/packages/node/src/dom/menus.ts
@@ -1,4 +1,5 @@
 import type { PageLike } from "../types.js";
+import { visibleLabelMatches } from "./label-match.js";
 import { normalizeLabel, normalizeWhitespace } from "./visible-text.js";
 
 export type MenuItem = {
@@ -82,6 +83,6 @@ export function findUniqueMenuItem(items: MenuItem[], wanted: string): MenuItem 
     return exact[0];
   }
 
-  const fuzzy = items.filter(item => item.normalized.includes(normalized));
+  const fuzzy = items.filter(item => visibleLabelMatches(item.label, wanted));
   return fuzzy.length === 1 ? fuzzy[0] : undefined;
 }

--- a/packages/node/src/scripts/apply-intelligence-locale-captures.ts
+++ b/packages/node/src/scripts/apply-intelligence-locale-captures.ts
@@ -15,7 +15,17 @@ type ApplyOptions = {
   coveragePath: string;
 };
 
+type IntelligenceModeOptionId = "instant" | "medium" | "high" | "extraHigh" | "pro";
+
 const ENGLISH_MODE_LABELS = new Set(["Latest", "Instant", "Thinking", "Extended", "Medium", "High", "Extra High", "Pro"]);
+const INTELLIGENCE_MODE_OPTION_IDS: IntelligenceModeOptionId[] = ["instant", "medium", "high", "extraHigh", "pro"];
+const ENGLISH_INTELLIGENCE_MODE_OPTIONS: Record<IntelligenceModeOptionId, string> = {
+  instant: "Instant",
+  medium: "Medium",
+  high: "High",
+  extraHigh: "Extra High",
+  pro: "Pro",
+};
 const UPDATE_NOTE = " * Intelligence picker labels updated 2026-06-10 from a visible ChatGPT Pro session.";
 
 class ApplyUsageError extends Error {
@@ -50,7 +60,12 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   const root = packageRoot();
   const languages = await readLanguageCoverage(options.coveragePath);
   const captures = latestSuccessfulCaptures(await readFile(options.input, "utf8"));
-  const planned: Array<{ locale: string; file: string; labels: string[] }> = [];
+  const planned: Array<{
+    locale: string;
+    file: string;
+    labels: string[];
+    modeOptions: Partial<Record<IntelligenceModeOptionId, string[]>>;
+  }> = [];
 
   for (const language of languages) {
     if (/^en(?:-|$)/i.test(language.bcp47)) continue;
@@ -59,11 +74,13 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
       throw new ApplyUsageError(`Missing successful capture for ${language.bcp47}.`, 1);
     }
     const labels = observedNonEnglishLabels(record);
-    if (labels.length === 0) continue;
+    const modeOptions = observedNonEnglishModeOptions(record);
+    if (labels.length === 0 && Object.keys(modeOptions).length === 0) continue;
     planned.push({
       locale: language.bcp47,
       file: resolve(root, "src/dom/locale", `${language.bcp47}.ts`),
       labels,
+      modeOptions,
     });
   }
 
@@ -77,10 +94,10 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
 
   for (const change of planned) {
     const before = await readFile(change.file, "utf8");
-    const after = mergeModeLabels(before, change.labels);
+    const after = mergeModeCapture(before, change.labels, change.modeOptions);
     if (after !== before) {
       await writeFile(change.file, after, "utf8");
-      console.log(`updated ${change.locale} labels=${change.labels.length}`);
+      console.log(`updated ${change.locale} labels=${change.labels.length} modeOptions=${Object.keys(change.modeOptions).length}`);
     }
   }
 
@@ -110,21 +127,43 @@ function observedNonEnglishLabels(record: CaptureRecord): string[] {
   return labels;
 }
 
-function mergeModeLabels(source: string, labels: readonly string[]): string {
+function observedNonEnglishModeOptions(record: CaptureRecord): Partial<Record<IntelligenceModeOptionId, string[]>> {
+  const labels = record.intelligenceLabels ?? [];
+  if (labels.length !== INTELLIGENCE_MODE_OPTION_IDS.length) {
+    throw new ApplyUsageError(`${record.requestedLocale} has ${labels.length} Intelligence labels; expected ${INTELLIGENCE_MODE_OPTION_IDS.length}.`, 1);
+  }
+  const modeOptions: Partial<Record<IntelligenceModeOptionId, string[]>> = {};
+  for (let index = 0; index < INTELLIGENCE_MODE_OPTION_IDS.length; index += 1) {
+    const id = INTELLIGENCE_MODE_OPTION_IDS[index]!;
+    const label = labels[index]!;
+    if (label !== ENGLISH_INTELLIGENCE_MODE_OPTIONS[id]) {
+      modeOptions[id] = [label];
+    }
+  }
+  return modeOptions;
+}
+
+function mergeModeCapture(
+  source: string,
+  labels: readonly string[],
+  modeOptions: Partial<Record<IntelligenceModeOptionId, string[]>>
+): string {
   let text = updateComment(source);
-  const existing = parseExistingModeLabels(text);
-  const merged = dedupe([...existing, ...labels]);
-  const line = `  modeLabels: [${merged.map(label => JSON.stringify(label)).join(", ")}],`;
+  if (labels.length > 0) {
+    const existing = parseExistingModeLabels(text);
+    const merged = dedupe([...existing, ...labels]);
+    const line = `  modeLabels: [${merged.map(label => JSON.stringify(label)).join(", ")}],`;
 
-  if (/^\s*modeLabels:\s*\[[^\]]*\],/m.test(text)) {
-    return text.replace(/^\s*modeLabels:\s*\[[^\]]*\],/m, line);
+    if (/^\s*modeLabels:\s*\[[^\]]*\],/m.test(text)) {
+      text = text.replace(/^\s*modeLabels:\s*\[[^\]]*\],/m, line);
+    } else if (/^\s*copyResponse:\s*.*,\n/m.test(text)) {
+      text = text.replace(/^(\s*copyResponse:\s*.*,\n)/m, `$1${line}\n`);
+    } else {
+      text = text.replace(/^export const \w+ = \{\n/m, match => `${match}${line}\n`);
+    }
   }
 
-  if (/^\s*copyResponse:\s*.*,\n/m.test(text)) {
-    return text.replace(/^(\s*copyResponse:\s*.*,\n)/m, `$1${line}\n`);
-  }
-
-  return text.replace(/^export const \w+ = \{\n/m, match => `${match}${line}\n`);
+  return mergeModeOptions(text, modeOptions);
 }
 
 function parseExistingModeLabels(source: string): string[] {
@@ -136,6 +175,66 @@ function parseExistingModeLabels(source: string): string[] {
     labels.push(JSON.parse(`"${stringMatch[1]}"`) as string);
   }
   return labels;
+}
+
+function mergeModeOptions(
+  source: string,
+  modeOptions: Partial<Record<IntelligenceModeOptionId, string[]>>
+): string {
+  const existing = parseExistingModeOptions(source);
+  const merged: Partial<Record<IntelligenceModeOptionId, string[]>> = {};
+  for (const id of INTELLIGENCE_MODE_OPTION_IDS) {
+    const values = dedupe([...(existing[id] ?? []), ...(modeOptions[id] ?? [])]);
+    if (values.length > 0) {
+      merged[id] = values;
+    }
+  }
+  const block = formatModeOptions(merged);
+  if (block === undefined) {
+    return source;
+  }
+  if (/^\s*modeOptions:\s*\{[\s\S]*?^\s*\},\n/m.test(source)) {
+    return source.replace(/^\s*modeOptions:\s*\{[\s\S]*?^\s*\},\n/m, `${block}\n`);
+  }
+  if (/^\s*modeLabels:\s*\[[^\]]*\],\n/m.test(source)) {
+    return source.replace(/^(\s*modeLabels:\s*\[[^\]]*\],\n)/m, `$1${block}\n`);
+  }
+  return source.replace(/^export const \w+ = \{\n/m, match => `${match}${block}\n`);
+}
+
+function parseExistingModeOptions(source: string): Partial<Record<IntelligenceModeOptionId, string[]>> {
+  const options: Partial<Record<IntelligenceModeOptionId, string[]>> = {};
+  const blockMatch = /^\s*modeOptions:\s*\{(?<body>[\s\S]*?)^\s*\},/m.exec(source);
+  const body = blockMatch?.groups?.body;
+  if (body === undefined) return options;
+  for (const id of INTELLIGENCE_MODE_OPTION_IDS) {
+    const lineMatch = new RegExp(`^\\s*${id}:\\s*\\[(?<body>[^\\]]*)\\],`, "m").exec(body);
+    const lineBody = lineMatch?.groups?.body;
+    if (lineBody === undefined) continue;
+    const values: string[] = [];
+    for (const stringMatch of lineBody.matchAll(/"((?:\\"|[^"])*)"/g)) {
+      values.push(JSON.parse(`"${stringMatch[1]}"`) as string);
+    }
+    if (values.length > 0) {
+      options[id] = values;
+    }
+  }
+  return options;
+}
+
+function formatModeOptions(modeOptions: Partial<Record<IntelligenceModeOptionId, string[]>>): string | undefined {
+  const lines = INTELLIGENCE_MODE_OPTION_IDS
+    .map(id => {
+      const values = modeOptions[id];
+      return values === undefined || values.length === 0
+        ? undefined
+        : `    ${id}: [${values.map(value => JSON.stringify(value)).join(", ")}],`;
+    })
+    .filter((line): line is string => line !== undefined);
+  if (lines.length === 0) {
+    return undefined;
+  }
+  return ["  modeOptions: {", ...lines, "  },"].join("\n");
 }
 
 function updateComment(source: string): string {

--- a/packages/node/tests/unit/conversation.test.ts
+++ b/packages/node/tests/unit/conversation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { parseConversationId } from "../../src/browser/page-state.js";
+import { ensureConversationTarget } from "../../src/commands/conversation.js";
+import type { PageLike } from "../../src/types.js";
+
+describe("conversation navigation", () => {
+  it("parses exact conversation ids from the URL path and accepts hashes", () => {
+    expect(parseConversationId("https://chatgpt.com/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5#settings"))
+      .toBe("6a2b2771-7810-83ea-83eb-cb9e31ca01f5");
+    expect(parseConversationId("/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5?model=gpt"))
+      .toBe("6a2b2771-7810-83ea-83eb-cb9e31ca01f5");
+  });
+
+  it("does not parse conversation ids from query strings or hashes", () => {
+    expect(parseConversationId("https://chatgpt.com/?next=/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5"))
+      .toBeUndefined();
+    expect(parseConversationId("https://chatgpt.com/c/other-thread#target=/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5"))
+      .toBe("other-thread");
+  });
+
+  it("does not reload when the current page is already on the target conversation", async () => {
+    const page = conversationPage("https://chatgpt.com/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5#settings");
+
+    const result = await ensureConversationTarget(page, {
+      url: "https://chatgpt.com/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5"
+    }, { timeoutMs: 0 });
+
+    expect(result).toEqual({
+      navigated: false,
+      expectedConversationId: "6a2b2771-7810-83ea-83eb-cb9e31ca01f5",
+      targetUrl: "https://chatgpt.com/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5"
+    });
+    expect(page.gotoCalls).toEqual([]);
+    expect(page.evaluateCalls).toBeGreaterThan(0);
+  });
+
+  it("navigates when the target id only appears in routing metadata", async () => {
+    const page = conversationPage("https://chatgpt.com/?next=/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5");
+
+    const result = await ensureConversationTarget(page, {
+      url: "https://chatgpt.com/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5"
+    }, { timeoutMs: 0 });
+
+    expect(result.navigated).toBe(true);
+    expect(page.gotoCalls).toEqual(["https://chatgpt.com/c/6a2b2771-7810-83ea-83eb-cb9e31ca01f5"]);
+  });
+});
+
+type ConversationPage = PageLike & {
+  gotoCalls: string[];
+  evaluateCalls: number;
+  waitForTimeoutCalls: number[];
+};
+
+function conversationPage(initialUrl: string): ConversationPage {
+  let currentUrl = initialUrl;
+  const gotoCalls: string[] = [];
+  const waitForTimeoutCalls: number[] = [];
+  let evaluateCalls = 0;
+  return {
+    gotoCalls,
+    get evaluateCalls() {
+      return evaluateCalls;
+    },
+    waitForTimeoutCalls,
+    url: () => currentUrl,
+    goto: async (url: string) => {
+      gotoCalls.push(url);
+      currentUrl = url;
+    },
+    waitForTimeout: async (ms?: number) => {
+      waitForTimeoutCalls.push(ms ?? 0);
+    },
+    title: async () => "Existing conversation",
+    evaluate: async <T, A = unknown>(fn: (arg: A) => T | Promise<T>, arg?: A) => {
+      evaluateCalls += 1;
+      const previousDocument = globalThis.document;
+      try {
+        globalThis.document = {
+          querySelectorAll: () => [],
+          body: { innerText: "Existing assistant answer" }
+        } as unknown as Document;
+        return await fn(arg as A);
+      } finally {
+        globalThis.document = previousDocument;
+      }
+    }
+  };
+}

--- a/packages/node/tests/unit/locale-labels.test.ts
+++ b/packages/node/tests/unit/locale-labels.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { localeLabels } from "../../src/dom/locale-labels.js";
 import { en } from "../../src/dom/locale/en.js";
-import type { LocaleStrings } from "../../src/dom/locale/types.js";
+import type { LocaleStrings, ModeOptionId } from "../../src/dom/locale/types.js";
 
 const norm = (value: string | readonly string[]): string[] =>
   typeof value === "string" ? [value] : [...value];
@@ -13,7 +13,9 @@ const norm = (value: string | readonly string[]): string[] =>
  */
 describe("localeLabels — English canonical preserved", () => {
   const nonToolKeys = (Object.keys(en) as Array<keyof LocaleStrings>)
-    .filter((key): key is Exclude<keyof LocaleStrings, "tools"> => key !== "tools");
+    .filter((key): key is Exclude<keyof LocaleStrings, "tools" | "modeOptions"> =>
+      key !== "tools" && key !== "modeOptions"
+    );
 
   for (const key of nonToolKeys) {
     it(`${key} begins with the English values`, () => {
@@ -30,10 +32,28 @@ describe("localeLabels — English canonical preserved", () => {
     });
   }
 
+  for (const id of [
+    "latest",
+    "instant",
+    "thinking",
+    "extended",
+    "medium",
+    "high",
+    "extraHigh",
+    "pro",
+  ] as const satisfies readonly ModeOptionId[]) {
+    it(`modeOptions.${id} begins with the English values`, () => {
+      const expected = norm(en.modeOptions[id]);
+      const actual = localeLabels.modeOptions[id] ?? [];
+      expect(actual.slice(0, expected.length)).toEqual(expected);
+    });
+  }
+
   it("contains no duplicate candidates in any list", () => {
     const lists = [
       ...nonToolKeys.map(key => localeLabels[key]),
-      ...Object.values(localeLabels.tools)
+      ...Object.values(localeLabels.tools),
+      ...Object.values(localeLabels.modeOptions)
     ];
     for (const list of lists) {
       expect(new Set(list).size, list.join("|")).toBe(list.length);
@@ -49,6 +69,14 @@ describe("localeLabels — English canonical preserved", () => {
       "Moyen",
       "Avancé",
       "Très élevé",
+    ]));
+    expect(localeLabels.modeOptions.pro).toEqual(expect.arrayContaining([
+      "حرفه‌ای",
+      "专业",
+    ]));
+    expect(localeLabels.modeOptions.high).toEqual(expect.arrayContaining([
+      "بالا",
+      "高级",
     ]));
   });
 });
@@ -76,6 +104,7 @@ describe("en locale — completeness", () => {
     "downloadImage",
     "imageContainerHint",
     "modeLabels",
+    "modeOptions",
     "modeOpenerExtra",
     "signedInMarkers",
     "transientAssistant",
@@ -88,6 +117,16 @@ describe("en locale — completeness", () => {
   ];
 
   const requiredToolIds = ["web_search", "deep_research", "create_image"] as const;
+  const requiredModeIds: readonly ModeOptionId[] = [
+    "latest",
+    "instant",
+    "thinking",
+    "extended",
+    "medium",
+    "high",
+    "extraHigh",
+    "pro",
+  ];
 
   it("has every required top-level key", () => {
     for (const key of requiredTopLevelKeys) {
@@ -102,6 +141,12 @@ describe("en locale — completeness", () => {
   it("has every required tool id", () => {
     for (const id of requiredToolIds) {
       expect(Object.prototype.hasOwnProperty.call(en.tools, id), `en.tools.${id} is present`).toBe(true);
+    }
+  });
+
+  it("has every required semantic mode id", () => {
+    for (const id of requiredModeIds) {
+      expect(Object.prototype.hasOwnProperty.call(en.modeOptions, id), `en.modeOptions.${id} is present`).toBe(true);
     }
   });
 });

--- a/packages/node/tests/unit/menus.test.ts
+++ b/packages/node/tests/unit/menus.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { visibleLabelMatches } from "../../src/dom/label-match.js";
 import { extractMenuItemsFromText, findUniqueMenuItem } from "../../src/dom/menus.js";
 
 describe("menu helpers", () => {
@@ -13,5 +14,23 @@ describe("menu helpers", () => {
   it("returns a unique fuzzy match", () => {
     const items = extractMenuItemsFromText("Web search\nDeep research\nCreate image");
     expect(findUniqueMenuItem(items, "deep")?.label).toBe("Deep research");
+  });
+
+  it("does not let short Pro matching select project menu rows", () => {
+    const items = extractMenuItemsFromText("Move to project");
+    expect(findUniqueMenuItem(items, "Pro")).toBeUndefined();
+  });
+
+  it("matches short labels only on token boundaries", () => {
+    expect(visibleLabelMatches("Pro", "Pro")).toBe(true);
+    expect(visibleLabelMatches("Pro Extended", "Pro")).toBe(true);
+    expect(visibleLabelMatches("Move to project", "Pro")).toBe(false);
+    expect(visibleLabelMatches("Projects", "Pro")).toBe(false);
+  });
+
+  it("matches CJK labels by exact alias or meaningful substring only", () => {
+    expect(visibleLabelMatches("专业", "专业")).toBe(true);
+    expect(visibleLabelMatches("专业模式", "专业")).toBe(true);
+    expect(visibleLabelMatches("项目", "专业")).toBe(false);
   });
 });

--- a/packages/node/tests/unit/messages.test.ts
+++ b/packages/node/tests/unit/messages.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { askMessage, readLatest, submittedUserTurnMatches, submitMessage, waitForMessage } from "../../src/commands/messages.js";
+import { askMessage, isResponseComplete, readLatest, submittedUserTurnMatches, submitMessage, waitForMessage } from "../../src/commands/messages.js";
 import { copyResponse } from "../../src/commands/response-actions.js";
+import { EMPTY_GENERATION_STATE } from "../../src/dom/generation-state.js";
 import {
   countMessages,
   extractMessagesFromHtml,
@@ -13,6 +14,16 @@ import {
 import type { LocatorLike, PageLike } from "../../src/types.js";
 
 describe("extractMessagesFromHtml", () => {
+  it("does not treat the empty generation-state fallback as completion evidence", () => {
+    expect(isResponseComplete({
+      latestText: "",
+      stableMs: 0,
+      textStableForMs: 0,
+      generation: EMPTY_GENERATION_STATE,
+      hasResponseActions: true
+    })).toBe(false);
+  });
+
   it("extracts ordered user and assistant messages", () => {
     const html = readFileSync("tests/fixtures/chat-basic.html", "utf8");
     const messages = extractMessagesFromHtml(html);
@@ -317,6 +328,33 @@ describe("extractMessagesFromHtml", () => {
 
     expect(result.ok).toBe(false);
     expect(result.status).toBe("partial");
+  });
+
+  it("bounds page-state blocker scans so partial text is not lost", async () => {
+    const page = scriptedWaitPage([
+      {
+        totalCount: 2,
+        assistantCount: 1,
+        latestAssistantTurnIndex: 2,
+        latestAssistantText: "Partial text survived the page-state probe.",
+        hasStopControl: false,
+        hasResponseActions: true
+      }
+    ]);
+    page.title = async () => new Promise<string>(() => {});
+
+    const result = await waitForMessage({ page }, {
+      afterAssistantTurnCount: 0,
+      timeoutMs: 20,
+      stableMs: 0,
+      pollMs: 1
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+    expect(result.output_text).toBe("Partial text survived the page-state probe.");
+    expect(result.warnings.join(" ")).toContain("page state DOM probe");
+    expect(result.warnings.join(" ")).toContain("did not cancel browser-side work");
   });
 
   it("falls back to a guarded read when wait misses a submitted assistant turn", async () => {

--- a/packages/node/tests/unit/modes.test.ts
+++ b/packages/node/tests/unit/modes.test.ts
@@ -120,6 +120,71 @@ describe("mode and tool selection blockers", () => {
     });
   });
 
+  it("selects a localized semantic mode without relying on menu position", async () => {
+    const page = menuPage(["حرفه‌ای"], ["حرفه‌ای"]);
+
+    const result = await setMode({ page }, { model: "Pro" });
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      selected: ["حرفه‌ای"],
+      candidates: ["حرفه‌ای"]
+    });
+  });
+
+  it("selects a localized high intelligence row from semantic labels", async () => {
+    const page = menuPage(["متوسط", "بالا"], ["بالا"]);
+
+    const result = await setMode({ page }, { intelligence: "high" });
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      selected: ["بالا"],
+      candidates: ["متوسط", "بالا"]
+    });
+  });
+
+  it("does not select a project action row for a short Pro model request", async () => {
+    const page = menuPage(["Move to project"], ["Move to project"]);
+
+    const result = await setMode({ page }, { model: "Pro" });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("unsupported");
+    expect(result.blocker).toMatchObject({
+      kind: "selector_drift",
+      code: "visible_candidate_not_found",
+      candidates: [{ label: "Move to project" }]
+    });
+  });
+
+  it("rejects a visible thread action menu before attempting mode selection", async () => {
+    const page = menuPage(["Share", "Rename", "Move to project"], ["Move to project"]);
+
+    const result = await setMode({ page }, { model: "Pro" });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("unsupported");
+    expect(result.blocker).toMatchObject({
+      kind: "selector_drift",
+      code: "visible_candidate_not_found",
+      message: "Visible menu appears to be a thread/action menu, not the ChatGPT mode menu.",
+      candidates: [{ label: "Share" }, { label: "Rename" }, { label: "Move to project" }]
+    });
+  });
+
+  it("does not reject a model-version-only menu as the wrong menu", async () => {
+    const page = menuPage(["5.5", "5.4"], ["5.4"]);
+
+    const result = await setMode({ page }, { version: "5.4" });
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      selected: ["5.4"],
+      candidates: ["5.5", "5.4"]
+    });
+  });
+
   it("selects nested model versions after localized intelligence selection", async () => {
     const labels = ["فوری", "متوسط", "بالا", "بسیار زیاد", "حرفه‌ای"];
     const page = intelligencePickerPage({ current: "بالا", labels });

--- a/packages/node/tests/unit/probes.test.ts
+++ b/packages/node/tests/unit/probes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { childTimeoutMs, createDeadline, remainingMs } from "../../src/commands/deadline.js";
+import { createSingleFlightProbe } from "../../src/commands/probes.js";
+
+describe("deadline helpers", () => {
+  it("clamps remaining time and child probe timeouts to the parent deadline", () => {
+    const deadline = createDeadline(1000, 10_000);
+
+    expect(remainingMs(deadline, 10_250)).toBe(750);
+    expect(remainingMs(deadline, 11_500)).toBe(0);
+    expect(childTimeoutMs(deadline, 500, 10_250)).toBe(500);
+    expect(childTimeoutMs(deadline, 900, 10_250)).toBe(750);
+  });
+});
+
+describe("single-flight DOM probes", () => {
+  it("reports that timeout only stops waiting and does not cancel browser work", async () => {
+    const probe = createSingleFlightProbe("assistant progress", async () => new Promise<string>(() => {}));
+
+    const result = await probe(undefined, createDeadline(50), { timeoutMs: 1 });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.timedOut).toBe(true);
+    expect(result.warnings.join(" ")).toContain("did not cancel browser-side work");
+  });
+
+  it("does not start a second probe while timed-out browser work is still in flight", async () => {
+    let starts = 0;
+    let resolveProbe: ((value: string) => void) | undefined;
+    const probe = createSingleFlightProbe("generation state", async () => {
+      starts += 1;
+      return new Promise<string>(resolve => {
+        resolveProbe = resolve;
+      });
+    });
+
+    const first = await probe(undefined, createDeadline(50), { timeoutMs: 1 });
+    const second = await probe(undefined, createDeadline(50), { timeoutMs: 1 });
+
+    expect(first.ok).toBe(false);
+    expect(second.ok).toBe(false);
+    expect(second.ok === false && second.skipped).toBe(true);
+    expect(starts).toBe(1);
+
+    resolveProbe?.("settled");
+  });
+});

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
@@ -161,6 +161,16 @@ var en = {
   imageContainerHint: ["image"],
   // --- Mode switcher (also the canonical public API keys) ---
   modeLabels: ["Latest", "Instant", "Thinking", "Extended", "Medium", "High", "Extra High", "Pro"],
+  modeOptions: {
+    latest: ["Latest"],
+    instant: ["Instant"],
+    thinking: ["Thinking"],
+    extended: ["Extended"],
+    medium: ["Medium"],
+    high: ["High"],
+    extraHigh: ["Extra High"],
+    pro: ["Pro", "Pro Extended", "Extended Pro"]
+  },
   /** Extra openers that surface the mode menu but are not selectable modes themselves. */
   modeOpenerExtra: ["Configure"],
   // --- Tool menu items, keyed by logical tool id ---
@@ -201,6 +211,12 @@ var de = {
   addPhotosFilesMenuItem: ["Fotos und Dateien hinzuf\xFCgen"],
   copyResponse: ["Antwort kopieren"],
   modeLabels: ["Sofort", "Mittel", "Hoch", "Extra hoch"],
+  modeOptions: {
+    instant: ["Sofort"],
+    medium: ["Mittel"],
+    high: ["Hoch"],
+    extraHigh: ["Extra hoch"]
+  },
   modeOpenerExtra: ["Konfigurieren"],
   tools: {
     web_search: ["Websuche"],
@@ -222,6 +238,12 @@ var esES = {
   addPhotosFilesMenuItem: ["A\xF1adir fotos y archivos"],
   copyResponse: ["Copiar respuesta"],
   modeLabels: ["Instant\xE1nea", "Media", "Alta", "Muy alta"],
+  modeOptions: {
+    instant: ["Instant\xE1nea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Muy alta"]
+  },
   modeOpenerExtra: ["Configurar"],
   tools: {
     web_search: ["B\xFAsqueda en Internet"],
@@ -244,6 +266,11 @@ var frFR = {
   addPhotosFilesMenuItem: ["Ajouter des photos et fichiers"],
   copyResponse: ["Copier la r\xE9ponse"],
   modeLabels: ["Moyen", "Avanc\xE9", "Tr\xE8s \xE9lev\xE9"],
+  modeOptions: {
+    medium: ["Moyen"],
+    high: ["Avanc\xE9"],
+    extraHigh: ["Tr\xE8s \xE9lev\xE9"]
+  },
   modeOpenerExtra: ["Configurer"],
   tools: {
     web_search: ["Recherche sur le Web"],
@@ -266,6 +293,13 @@ var zhHK = {
   addPhotosFilesMenuItem: ["\u52A0\u5165\u76F8\u7247\u548C\u6A94\u6848"],
   copyResponse: ["\u8907\u88FD\u56DE\u8986"],
   modeLabels: ["\u5373\u6642", "\u5747\u8861", "\u9AD8", "\u6975\u9AD8", "\u5C08\u696D"],
+  modeOptions: {
+    instant: ["\u5373\u6642"],
+    medium: ["\u5747\u8861"],
+    high: ["\u9AD8"],
+    extraHigh: ["\u6975\u9AD8"],
+    pro: ["\u5C08\u696D"]
+  },
   modeOpenerExtra: ["\u8A2D\u5B9A"],
   tools: {
     web_search: ["\u7DB2\u7D61\u641C\u5C0B"],
@@ -288,6 +322,13 @@ var zhTW = {
   addPhotosFilesMenuItem: ["\u65B0\u589E\u7167\u7247\u548C\u6A94\u6848"],
   copyResponse: ["\u8907\u88FD\u56DE\u61C9"],
   modeLabels: ["\u5373\u6642", "\u4E2D\u7B49", "\u9AD8", "\u8D85\u9AD8", "\u5C08\u696D"],
+  modeOptions: {
+    instant: ["\u5373\u6642"],
+    medium: ["\u4E2D\u7B49"],
+    high: ["\u9AD8"],
+    extraHigh: ["\u8D85\u9AD8"],
+    pro: ["\u5C08\u696D"]
+  },
   modeOpenerExtra: ["\u8A2D\u5B9A"],
   tools: {
     web_search: ["\u7DB2\u9801\u641C\u5C0B"],
@@ -310,6 +351,12 @@ var ja = {
   addPhotosFilesMenuItem: ["\u5199\u771F\u3068\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0"],
   copyResponse: ["\u56DE\u7B54\u3092\u30B3\u30D4\u30FC\u3059\u308B"],
   modeLabels: ["\u6700\u901F", "\u6A19\u6E96", "\u9AD8", "\u6700\u9AD8"],
+  modeOptions: {
+    instant: ["\u6700\u901F"],
+    medium: ["\u6A19\u6E96"],
+    high: ["\u9AD8"],
+    extraHigh: ["\u6700\u9AD8"]
+  },
   modeOpenerExtra: ["\u8A2D\u5B9A\u3059\u308B"],
   tools: {
     web_search: ["\u30A6\u30A7\u30D6\u691C\u7D22"],
@@ -331,6 +378,12 @@ var it = {
   addPhotosFilesMenuItem: ["Aggiungi foto e file"],
   copyResponse: ["Copia risposta"],
   modeLabels: ["Istantanea", "Media", "Alta", "Extra elevata"],
+  modeOptions: {
+    instant: ["Istantanea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Extra elevata"]
+  },
   modeOpenerExtra: ["Configura"],
   tools: {
     web_search: ["Ricerca sul web"],
@@ -352,6 +405,12 @@ var vi = {
   addPhotosFilesMenuItem: ["Th\xEAm \u1EA3nh v\xE0 t\u1EC7p"],
   copyResponse: ["Sao ch\xE9p ph\u1EA3n h\u1ED3i"],
   modeLabels: ["T\u1EE9c th\xEC", "Trung b\xECnh", "Cao", "R\u1EA5t cao"],
+  modeOptions: {
+    instant: ["T\u1EE9c th\xEC"],
+    medium: ["Trung b\xECnh"],
+    high: ["Cao"],
+    extraHigh: ["R\u1EA5t cao"]
+  },
   modeOpenerExtra: ["\u0110\u1ECBnh c\u1EA5u h\xECnh"],
   tools: {
     web_search: ["T\xECm ki\u1EBFm tr\xEAn m\u1EA1ng"],
@@ -374,6 +433,12 @@ var am = {
   addPhotosFilesMenuItem: ["\u134E\u1276\u12CE\u127D\u1295 \u12A5\u1293 \u134B\u12ED\u120E\u127D\u1295 \u12EB\u12AD\u1209"],
   copyResponse: ["\u121D\u120B\u1239\u1295 \u12ED\u1245\u12F1"],
   modeLabels: ["\u1348\u1323\u1295", "\u1218\u12AB\u12A8\u1208\u129B", "\u12A8\u134D\u1270\u129B", "\u12A5\u1305\u130D \u12A8\u134D\u1270\u129B"],
+  modeOptions: {
+    instant: ["\u1348\u1323\u1295"],
+    medium: ["\u1218\u12AB\u12A8\u1208\u129B"],
+    high: ["\u12A8\u134D\u1270\u129B"],
+    extraHigh: ["\u12A5\u1305\u130D \u12A8\u134D\u1270\u129B"]
+  },
   modeOpenerExtra: ["\u12EB\u12CB\u1245\u1229"],
   tools: {
     web_search: ["\u12E8\u12F5\u122D \u134D\u1208\u130B"],
@@ -396,6 +461,13 @@ var ar = {
   addPhotosFilesMenuItem: ["\u0625\u0636\u0627\u0641\u0629 \u0635\u0648\u0631 \u0648\u0645\u0644\u0641\u0627\u062A"],
   copyResponse: ["\u0646\u0633\u062E \u0625\u062C\u0627\u0628\u0629"],
   modeLabels: ["\u0641\u0648\u0631\u064A", "\u0645\u062A\u0648\u0633\u0637", "\u0639\u0627\u0644\u064A", "\u0645\u0643\u062B\u0641 \u062C\u062F\u064B\u0627", "\u0627\u062D\u062A\u0631\u0627\u0641\u064A"],
+  modeOptions: {
+    instant: ["\u0641\u0648\u0631\u064A"],
+    medium: ["\u0645\u062A\u0648\u0633\u0637"],
+    high: ["\u0639\u0627\u0644\u064A"],
+    extraHigh: ["\u0645\u0643\u062B\u0641 \u062C\u062F\u064B\u0627"],
+    pro: ["\u0627\u062D\u062A\u0631\u0627\u0641\u064A"]
+  },
   modeOpenerExtra: ["\u062A\u0643\u0648\u064A\u0646"],
   tools: {
     web_search: ["\u0627\u0644\u0628\u062D\u062B \u0641\u064A \u0627\u0644\u0648\u064A\u0628"],
@@ -418,6 +490,13 @@ var bg = {
   addPhotosFilesMenuItem: ["\u0414\u043E\u0431\u0430\u0432\u044F\u043D\u0435 \u043D\u0430 \u0441\u043D\u0438\u043C\u043A\u0438 \u0438 \u0444\u0430\u0439\u043B\u043E\u0432\u0435"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u0430\u0439\u0442\u0435 \u043E\u0442\u0433\u043E\u0432\u043E\u0440\u0430"],
   modeLabels: ["\u041C\u0438\u0433\u043D\u043E\u0432\u0435\u043D", "\u0421\u0440\u0435\u0434\u0435\u043D", "\u0412\u0438\u0441\u043E\u043A", "\u041C\u043D\u043E\u0433\u043E \u0432\u0438\u0441\u043E\u043A\u043E", "\u041F\u0440\u043E"],
+  modeOptions: {
+    instant: ["\u041C\u0438\u0433\u043D\u043E\u0432\u0435\u043D"],
+    medium: ["\u0421\u0440\u0435\u0434\u0435\u043D"],
+    high: ["\u0412\u0438\u0441\u043E\u043A"],
+    extraHigh: ["\u041C\u043D\u043E\u0433\u043E \u0432\u0438\u0441\u043E\u043A\u043E"],
+    pro: ["\u041F\u0440\u043E"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0438\u0440\u0430\u0439\u0442\u0435"],
   tools: {
     web_search: ["\u0422\u044A\u0440\u0441\u0435\u043D\u0435 \u0432 \u0438\u043D\u0442\u0435\u0440\u043D\u0435\u0442"],
@@ -440,6 +519,12 @@ var bs = {
   addPhotosFilesMenuItem: ["Dodaj slike i datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Brzo", "Srednji", "Visoko", "Vrlo visoko"],
+  modeOptions: {
+    instant: ["Brzo"],
+    medium: ["Srednji"],
+    high: ["Visoko"],
+    extraHigh: ["Vrlo visoko"]
+  },
   modeOpenerExtra: ["Podesi"],
   tools: {
     web_search: ["Internet pretraga"],
@@ -462,6 +547,12 @@ var ca = {
   addPhotosFilesMenuItem: ["Afegeix fotos i fitxers"],
   copyResponse: ["Copia la resposta"],
   modeLabels: ["Instantani", "Mitj\xE0", "Alt", "Molt alt"],
+  modeOptions: {
+    instant: ["Instantani"],
+    medium: ["Mitj\xE0"],
+    high: ["Alt"],
+    extraHigh: ["Molt alt"]
+  },
   modeOpenerExtra: ["Configura\u2026"],
   tools: {
     web_search: ["Cerca a la xarxa"],
@@ -484,6 +575,12 @@ var cs = {
   addPhotosFilesMenuItem: ["P\u0159idat fotografie a soubory"],
   copyResponse: ["Zkop\xEDrovat odpov\u011B\u010F"],
   modeLabels: ["Okam\u017Eit\xE1", "St\u0159edn\xED", "Vysok\xE1", "Velmi vysok\xE1"],
+  modeOptions: {
+    instant: ["Okam\u017Eit\xE1"],
+    medium: ["St\u0159edn\xED"],
+    high: ["Vysok\xE1"],
+    extraHigh: ["Velmi vysok\xE1"]
+  },
   modeOpenerExtra: ["Konfigurovat\u2026"],
   tools: {
     web_search: ["Vyhled\xE1v\xE1n\xED na webu"],
@@ -506,6 +603,11 @@ var da = {
   addPhotosFilesMenuItem: ["Tilf\xF8j billeder og filer"],
   copyResponse: ["Kopi\xE9r svar"],
   modeLabels: ["\xD8jeblikkeligt", "H\xF8j", "Ekstra h\xF8j"],
+  modeOptions: {
+    instant: ["\xD8jeblikkeligt"],
+    high: ["H\xF8j"],
+    extraHigh: ["Ekstra h\xF8j"]
+  },
   modeOpenerExtra: ["Konfigurer ..."],
   tools: {
     web_search: ["Internets\xF8gning"],
@@ -528,6 +630,12 @@ var el = {
   addPhotosFilesMenuItem: ["\u03A0\u03C1\u03BF\u03C3\u03B8\u03AE\u03BA\u03B7 \u03C6\u03C9\u03C4\u03BF\u03B3\u03C1\u03B1\u03C6\u03B9\u03CE\u03BD & \u03B1\u03C1\u03C7\u03B5\u03AF\u03C9\u03BD"],
   copyResponse: ["\u0391\u03BD\u03C4\u03B9\u03B3\u03C1\u03B1\u03C6\u03AE \u03B1\u03C0\u03AC\u03BD\u03C4\u03B7\u03C3\u03B7\u03C2"],
   modeLabels: ["\u0386\u03BC\u03B5\u03C3\u03B7", "\u039C\u03B5\u03C3\u03B1\u03AF\u03B1", "\u03A5\u03C8\u03B7\u03BB\u03AE", "\u03A0\u03BF\u03BB\u03CD \u03C5\u03C8\u03B7\u03BB\u03CC"],
+  modeOptions: {
+    instant: ["\u0386\u03BC\u03B5\u03C3\u03B7"],
+    medium: ["\u039C\u03B5\u03C3\u03B1\u03AF\u03B1"],
+    high: ["\u03A5\u03C8\u03B7\u03BB\u03AE"],
+    extraHigh: ["\u03A0\u03BF\u03BB\u03CD \u03C5\u03C8\u03B7\u03BB\u03CC"]
+  },
   modeOpenerExtra: ["\u0394\u03B9\u03B1\u03BC\u03CC\u03C1\u03C6\u03C9\u03C3\u03B7\u2026"],
   tools: {
     web_search: ["\u0391\u03BD\u03B1\u03B6\u03AE\u03C4\u03B7\u03C3\u03B7 \u03C3\u03C4\u03BF\u03BD \u03B9\u03C3\u03C4\u03CC"],
@@ -550,6 +658,12 @@ var es419 = {
   addPhotosFilesMenuItem: ["Agregar fotos y archivos"],
   copyResponse: ["Copiar respuesta"],
   modeLabels: ["Instant\xE1nea", "Media", "Alta", "Muy alta"],
+  modeOptions: {
+    instant: ["Instant\xE1nea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Muy alta"]
+  },
   modeOpenerExtra: ["Configurar..."],
   tools: {
     web_search: ["Busca en la web"],
@@ -572,6 +686,12 @@ var et = {
   addPhotosFilesMenuItem: ["Lisa fotosid ja faile"],
   copyResponse: ["Kopeeri vastus"],
   modeLabels: ["Kohene", "Keskmine", "K\xF5rge", "V\xE4ga k\xF5rge"],
+  modeOptions: {
+    instant: ["Kohene"],
+    medium: ["Keskmine"],
+    high: ["K\xF5rge"],
+    extraHigh: ["V\xE4ga k\xF5rge"]
+  },
   modeOpenerExtra: ["Konfigureeri..."],
   tools: {
     web_search: ["Veebiotsing"],
@@ -594,6 +714,13 @@ var fa = {
   addPhotosFilesMenuItem: ["\u0627\u0641\u0632\u0648\u062F\u0646 \u062A\u0635\u0627\u0648\u06CC\u0631 \u0648 \u0641\u0627\u06CC\u0644\u200C\u0647\u0627"],
   copyResponse: ["\u06A9\u067E\u06CC \u06A9\u0631\u062F\u0646 \u067E\u0627\u0633\u062E"],
   modeLabels: ["\u0641\u0648\u0631\u06CC", "\u0645\u062A\u0648\u0633\u0637", "\u0628\u0627\u0644\u0627", "\u0628\u0633\u06CC\u0627\u0631 \u0632\u06CC\u0627\u062F", "\u062D\u0631\u0641\u0647\u200C\u0627\u06CC"],
+  modeOptions: {
+    instant: ["\u0641\u0648\u0631\u06CC"],
+    medium: ["\u0645\u062A\u0648\u0633\u0637"],
+    high: ["\u0628\u0627\u0644\u0627"],
+    extraHigh: ["\u0628\u0633\u06CC\u0627\u0631 \u0632\u06CC\u0627\u062F"],
+    pro: ["\u062D\u0631\u0641\u0647\u200C\u0627\u06CC"]
+  },
   modeOpenerExtra: ["\u067E\u06CC\u06A9\u0631\u0628\u0646\u062F\u06CC..."],
   tools: {
     web_search: ["\u062C\u0633\u062A\u062C\u0648\u06CC \u0648\u0628"],
@@ -616,6 +743,12 @@ var fi = {
   addPhotosFilesMenuItem: ["Lis\xE4\xE4 valokuvia & tiedostoja"],
   copyResponse: ["Kopioi vastaus"],
   modeLabels: ["V\xE4lit\xF6n", "Keskitaso", "Korkea", "Eritt\xE4in korkea"],
+  modeOptions: {
+    instant: ["V\xE4lit\xF6n"],
+    medium: ["Keskitaso"],
+    high: ["Korkea"],
+    extraHigh: ["Eritt\xE4in korkea"]
+  },
   modeOpenerExtra: ["M\xE4\xE4rit\xE4..."],
   tools: {
     web_search: ["Verkkohaku"],
@@ -638,6 +771,12 @@ var frCA = {
   addPhotosFilesMenuItem: ["Ajouter des photos et des fichiers"],
   copyResponse: ["Copier la r\xE9ponse"],
   modeLabels: ["Instantan\xE9", "Moyen", "\xC9lev\xE9", "Tr\xE8s \xE9lev\xE9"],
+  modeOptions: {
+    instant: ["Instantan\xE9"],
+    medium: ["Moyen"],
+    high: ["\xC9lev\xE9"],
+    extraHigh: ["Tr\xE8s \xE9lev\xE9"]
+  },
   modeOpenerExtra: ["Configurer..."],
   tools: {
     web_search: ["Recherche sur Internet"],
@@ -660,6 +799,12 @@ var gu = {
   addPhotosFilesMenuItem: ["\u0AAB\u0ACB\u0A9F\u0ABE \u0A85\u0AA8\u0AC7 \u0AAB\u0ABE\u0A87\u0AB2\u0ACB \u0A89\u0AAE\u0AC7\u0AB0\u0ACB"],
   copyResponse: ["\u0AAA\u0ACD\u0AB0\u0AA4\u0ABF\u0AAD\u0ABE\u0AB5 \u0A95\u0AC9\u0AAA\u0ABF \u0A95\u0AB0\u0ACB"],
   modeLabels: ["\u0AA4\u0AB0\u0AA4", "\u0AAE\u0AA7\u0ACD\u0AAF\u0AAE", "\u0A89\u0A9A\u0ACD\u0A9A", "\u0A85\u0AA4\u0ABF \u0A89\u0A9A\u0ACD\u0A9A"],
+  modeOptions: {
+    instant: ["\u0AA4\u0AB0\u0AA4"],
+    medium: ["\u0AAE\u0AA7\u0ACD\u0AAF\u0AAE"],
+    high: ["\u0A89\u0A9A\u0ACD\u0A9A"],
+    extraHigh: ["\u0A85\u0AA4\u0ABF \u0A89\u0A9A\u0ACD\u0A9A"]
+  },
   modeOpenerExtra: ["\u0A95\u0AA8\u0ACD\u0AAB\u0ABF\u0A97\u0AB0 \u0A95\u0AB0\u0ACB..."],
   tools: {
     web_search: ["\u0AB5\u0AC7\u0AAC \u0AB6\u0ACB\u0AA7"],
@@ -682,6 +827,12 @@ var hi = {
   addPhotosFilesMenuItem: ["\u092B\u093C\u094B\u091F\u094B \u0914\u0930 \u092B\u093C\u093E\u0907\u0932\u0947\u0902 \u091C\u094B\u0921\u093C\u0947\u0902"],
   copyResponse: ["\u091C\u0935\u093E\u092C \u0915\u094B \u0915\u0949\u092A\u0940 \u0915\u0930\u0947\u0902"],
   modeLabels: ["\u0924\u0941\u0930\u0902\u0924", "\u092E\u0927\u094D\u092F\u092E", "\u0909\u091A\u094D\u091A", "\u092C\u0939\u0941\u0924 \u0909\u091A\u094D\u091A"],
+  modeOptions: {
+    instant: ["\u0924\u0941\u0930\u0902\u0924"],
+    medium: ["\u092E\u0927\u094D\u092F\u092E"],
+    high: ["\u0909\u091A\u094D\u091A"],
+    extraHigh: ["\u092C\u0939\u0941\u0924 \u0909\u091A\u094D\u091A"]
+  },
   modeOpenerExtra: ["\u0915\u0949\u0928\u094D\u092B\u093C\u093F\u0917\u0930 \u0915\u0930\u0947\u0902..."],
   tools: {
     web_search: ["\u0935\u0947\u092C \u0938\u0930\u094D\u091A"],
@@ -704,6 +855,11 @@ var hr = {
   addPhotosFilesMenuItem: ["Dodaj fotografije i datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Srednje", "Visoko", "Vrlo visoka"],
+  modeOptions: {
+    medium: ["Srednje"],
+    high: ["Visoko"],
+    extraHigh: ["Vrlo visoka"]
+  },
   modeOpenerExtra: ["Konfiguriraj\u2026"],
   tools: {
     web_search: ["Mre\u017Eno pretra\u017Eivanje"],
@@ -726,6 +882,12 @@ var hu = {
   addPhotosFilesMenuItem: ["Fot\xF3k \xE9s f\xE1jlok hozz\xE1ad\xE1sa"],
   copyResponse: ["V\xE1lasz m\xE1sol\xE1sa"],
   modeLabels: ["Azonnali", "K\xF6zepes", "Magas", "Kiemelked\u0151en magas"],
+  modeOptions: {
+    instant: ["Azonnali"],
+    medium: ["K\xF6zepes"],
+    high: ["Magas"],
+    extraHigh: ["Kiemelked\u0151en magas"]
+  },
   modeOpenerExtra: ["Konfigur\xE1l\xE1s..."],
   tools: {
     web_search: ["Internetes keres\xE9s"],
@@ -748,6 +910,13 @@ var hy = {
   addPhotosFilesMenuItem: ["\u0531\u057E\u0565\u056C\u0561\u0581\u0576\u0565\u056C \u056C\u0578\u0582\u057D\u0561\u0576\u056F\u0561\u0580\u0576\u0565\u0580 \u0587 \u0586\u0561\u0575\u056C\u0565\u0580"],
   copyResponse: ["\u054A\u0561\u057F\u0573\u0565\u0576\u0565\u056C \u057A\u0561\u057F\u0561\u057D\u056D\u0561\u0576\u0568"],
   modeLabels: ["\u0531\u056F\u0576\u0569\u0561\u0580\u0569\u0561\u0575\u056B\u0576", "\u0544\u056B\u057B\u056B\u0576", "\u0532\u0561\u0580\u0571\u0580", "\u0547\u0561\u057F \u0562\u0561\u0580\u0571\u0580", "\u054A\u0580\u0578"],
+  modeOptions: {
+    instant: ["\u0531\u056F\u0576\u0569\u0561\u0580\u0569\u0561\u0575\u056B\u0576"],
+    medium: ["\u0544\u056B\u057B\u056B\u0576"],
+    high: ["\u0532\u0561\u0580\u0571\u0580"],
+    extraHigh: ["\u0547\u0561\u057F \u0562\u0561\u0580\u0571\u0580"],
+    pro: ["\u054A\u0580\u0578"]
+  },
   modeOpenerExtra: ["\u053F\u0561\u0566\u0574\u0561\u0571\u0587\u0565\u056C\u2024\u2024\u2024"],
   tools: {
     web_search: ["\u054E\u0565\u0562 \u0578\u0580\u0578\u0576\u0578\u0582\u0574"],
@@ -770,6 +939,12 @@ var id = {
   addPhotosFilesMenuItem: ["Tambah foto & file"],
   copyResponse: ["Salin respons"],
   modeLabels: ["Instan", "Sedang", "Tinggi", "Sangat Tinggi"],
+  modeOptions: {
+    instant: ["Instan"],
+    medium: ["Sedang"],
+    high: ["Tinggi"],
+    extraHigh: ["Sangat Tinggi"]
+  },
   modeOpenerExtra: ["Konfigurasi..."],
   tools: {
     web_search: ["Pencarian web"],
@@ -792,6 +967,12 @@ var is = {
   addPhotosFilesMenuItem: ["B\xE6ta myndum og skr\xE1m vi\xF0"],
   copyResponse: ["Afrita svar"],
   modeLabels: ["Strax", "Mi\xF0lungs", "H\xE1tt", "Mj\xF6g h\xE1tt"],
+  modeOptions: {
+    instant: ["Strax"],
+    medium: ["Mi\xF0lungs"],
+    high: ["H\xE1tt"],
+    extraHigh: ["Mj\xF6g h\xE1tt"]
+  },
   modeOpenerExtra: ["Stillir\u2026"],
   tools: {
     web_search: ["Vefleit"],
@@ -814,6 +995,12 @@ var ka = {
   addPhotosFilesMenuItem: ["\u10E4\u10DD\u10E2\u10DD\u10D4\u10D1\u10D8\u10E1 \u10D3\u10D0 \u10E4\u10D0\u10D8\u10DA\u10D4\u10D1\u10D8\u10E1 \u10D3\u10D0\u10DB\u10D0\u10E2\u10D4\u10D1\u10D0"],
   copyResponse: ["\u10DE\u10D0\u10E1\u10E3\u10EE\u10D8\u10E1 \u10D9\u10DD\u10DE\u10D8\u10E0\u10D4\u10D1\u10D0"],
   modeLabels: ["\u10DB\u10E7\u10D8\u10E1\u10D8\u10D4\u10E0\u10D8", "\u10E1\u10D0\u10E8\u10E3\u10D0\u10DA\u10DD", "\u10DB\u10D0\u10E6\u10D0\u10DA\u10D8", "\u10EB\u10D0\u10DA\u10D8\u10D0\u10DC \u10DB\u10D0\u10E6\u10D0\u10DA\u10D8"],
+  modeOptions: {
+    instant: ["\u10DB\u10E7\u10D8\u10E1\u10D8\u10D4\u10E0\u10D8"],
+    medium: ["\u10E1\u10D0\u10E8\u10E3\u10D0\u10DA\u10DD"],
+    high: ["\u10DB\u10D0\u10E6\u10D0\u10DA\u10D8"],
+    extraHigh: ["\u10EB\u10D0\u10DA\u10D8\u10D0\u10DC \u10DB\u10D0\u10E6\u10D0\u10DA\u10D8"]
+  },
   modeOpenerExtra: ["\u10D9\u10DD\u10DC\u10E4\u10D8\u10D2\u10E3\u10E0\u10D8\u10E0\u10D4\u10D1\u10D0\u2026"],
   tools: {
     web_search: ["\u10D5\u10D4\u10D1\u10E8\u10D8 \u10EB\u10D8\u10D4\u10D1\u10D0"],
@@ -836,6 +1023,12 @@ var kk = {
   addPhotosFilesMenuItem: ["\u0424\u043E\u0442\u043E\u0441\u0443\u0440\u0435\u0442\u0442\u0435\u0440 \u043C\u0435\u043D \u0444\u0430\u0439\u043B\u0434\u0430\u0440 \u049B\u043E\u0441\u0443"],
   copyResponse: ["\u0416\u0430\u0443\u0430\u043F\u0442\u044B \u043A\u04E9\u0448\u0456\u0440\u0443"],
   modeLabels: ["\u0416\u0435\u0434\u0435\u043B", "\u041E\u0440\u0442\u0430\u0448\u0430", "\u0416\u043E\u0493\u0430\u0440\u044B", "\u0410\u0441\u0430 \u0436\u043E\u0493\u0430\u0440\u044B"],
+  modeOptions: {
+    instant: ["\u0416\u0435\u0434\u0435\u043B"],
+    medium: ["\u041E\u0440\u0442\u0430\u0448\u0430"],
+    high: ["\u0416\u043E\u0493\u0430\u0440\u044B"],
+    extraHigh: ["\u0410\u0441\u0430 \u0436\u043E\u0493\u0430\u0440\u044B"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F\u043B\u0430\u0443..."],
   tools: {
     web_search: ["\u0406\u0437\u0434\u0435\u0443"],
@@ -858,6 +1051,13 @@ var kn = {
   addPhotosFilesMenuItem: ["\u0CAB\u0CCB\u0C9F\u0CCA \u0CAE\u0CA4\u0CCD\u0CA4\u0CC1 \u0CAB\u0CC8\u0CB2\u0CCD\u200C\u0C97\u0CB3\u0CA8\u0CCD\u0CA8\u0CC1 \u0CB8\u0CC7\u0CB0\u0CBF\u0CB8\u0CBF"],
   copyResponse: ["\u0CAA\u0CCD\u0CB0\u0CA4\u0CBF\u0C95\u0CCD\u0CB0\u0CBF\u0CAF\u0CC6\u0CAF\u0CA8\u0CCD\u0CA8\u0CC1 \u0CA8\u0C95\u0CB2\u0CBF\u0CB8\u0CBF"],
   modeLabels: ["\u0CA4\u0C95\u0CCD\u0CB7\u0CA3", "\u0CAE\u0CA7\u0CCD\u0CAF\u0CAE", "\u0C89\u0CA8\u0CCD\u0CA8\u0CA4", "\u0C85\u0CA4\u0CBF \u0CB9\u0CC6\u0C9A\u0CCD\u0C9A\u0CC1", "\u0CAA\u0CCD\u0CB0\u0CCA"],
+  modeOptions: {
+    instant: ["\u0CA4\u0C95\u0CCD\u0CB7\u0CA3"],
+    medium: ["\u0CAE\u0CA7\u0CCD\u0CAF\u0CAE"],
+    high: ["\u0C89\u0CA8\u0CCD\u0CA8\u0CA4"],
+    extraHigh: ["\u0C85\u0CA4\u0CBF \u0CB9\u0CC6\u0C9A\u0CCD\u0C9A\u0CC1"],
+    pro: ["\u0CAA\u0CCD\u0CB0\u0CCA"]
+  },
   modeOpenerExtra: ["\u0C95\u0CBE\u0CA8\u0CCD\u0CAB\u0CBF\u0C97\u0CB0\u0CCD \u0CAE\u0CBE\u0CA1\u0CBF..."],
   tools: {
     web_search: ["\u0CB5\u0CC6\u0CAC\u0CCD \u0CB8\u0CB0\u0CCD\u0C9A\u0CCD"],
@@ -880,6 +1080,12 @@ var ko = {
   addPhotosFilesMenuItem: ["\uC0AC\uC9C4 \uBC0F \uD30C\uC77C \uCD94\uAC00"],
   copyResponse: ["\uC751\uB2F5 \uBCF5\uC0AC"],
   modeLabels: ["\uC989\uC2DC", "\uC911\uAC04", "\uB192\uC74C", "\uB9E4\uC6B0 \uB192\uC74C"],
+  modeOptions: {
+    instant: ["\uC989\uC2DC"],
+    medium: ["\uC911\uAC04"],
+    high: ["\uB192\uC74C"],
+    extraHigh: ["\uB9E4\uC6B0 \uB192\uC74C"]
+  },
   modeOpenerExtra: ["\uAD6C\uC131\u2026"],
   tools: {
     web_search: ["\uC6F9 \uAC80\uC0C9"],
@@ -902,6 +1108,13 @@ var lt = {
   addPhotosFilesMenuItem: ["Prid\u0117ti nuotrauk\u0173 ir fail\u0173"],
   copyResponse: ["Kopijuoti atsakym\u0105"],
   modeLabels: ["Momentinis", "Vidutinis", "Auk\u0161tas", "Ypa\u010D didelis", "Profesionalus"],
+  modeOptions: {
+    instant: ["Momentinis"],
+    medium: ["Vidutinis"],
+    high: ["Auk\u0161tas"],
+    extraHigh: ["Ypa\u010D didelis"],
+    pro: ["Profesionalus"]
+  },
   modeOpenerExtra: ["Konfig\u016Bruoti..."],
   tools: {
     web_search: ["\u017Diniatinklio paie\u0161ka"],
@@ -924,6 +1137,13 @@ var zhHans = {
   addPhotosFilesMenuItem: ["\u6DFB\u52A0\u7167\u7247\u548C\u6587\u4EF6"],
   copyResponse: ["\u590D\u5236\u56DE\u590D"],
   modeLabels: ["\u6781\u901F", "\u5747\u8861", "\u9AD8\u7EA7", "\u8D85\u9AD8", "\u4E13\u4E1A"],
+  modeOptions: {
+    instant: ["\u6781\u901F"],
+    medium: ["\u5747\u8861"],
+    high: ["\u9AD8\u7EA7"],
+    extraHigh: ["\u8D85\u9AD8"],
+    pro: ["\u4E13\u4E1A"]
+  },
   modeOpenerExtra: ["\u914D\u7F6E\u2026"],
   tools: {
     web_search: ["\u7F51\u9875\u641C\u7D22"],
@@ -946,6 +1166,12 @@ var ur = {
   addPhotosFilesMenuItem: ["\u062A\u0635\u0648\u06CC\u0631\u06CC\u06BA \u0627\u0648\u0631 \u0641\u0627\u0626\u0644\u06CC\u06BA \u0634\u0627\u0645\u0644 \u06A9\u0631\u06CC\u06BA"],
   copyResponse: ["\u062C\u0648\u0627\u0628 \u06A9\u0627\u067E\u06CC \u06A9\u0631\u06CC\u06BA"],
   modeLabels: ["\u0641\u0648\u0631\u06CC", "\u0627\u0648\u0633\u0637", "\u0627\u0639\u0644\u06CC\u0670", "\u0627\u0646\u062A\u06C1\u0627\u0626\u06CC \u0627\u0639\u0644\u06CC\u0670"],
+  modeOptions: {
+    instant: ["\u0641\u0648\u0631\u06CC"],
+    medium: ["\u0627\u0648\u0633\u0637"],
+    high: ["\u0627\u0639\u0644\u06CC\u0670"],
+    extraHigh: ["\u0627\u0646\u062A\u06C1\u0627\u0626\u06CC \u0627\u0639\u0644\u06CC\u0670"]
+  },
   modeOpenerExtra: ["\u06A9\u0646\u0641\u06CC\u06AF\u0631 \u06A9\u0631\u06CC\u06BA..."],
   tools: {
     web_search: ["\u0648\u06CC\u0628 \u067E\u0631 \u062A\u0644\u0627\u0634"],
@@ -968,6 +1194,12 @@ var uk = {
   addPhotosFilesMenuItem: ["\u0414\u043E\u0434\u0430\u0442\u0438 \u0441\u0432\u0456\u0442\u043B\u0438\u043D\u0438 \u0442\u0430 \u0444\u0430\u0439\u043B\u0438"],
   copyResponse: ["\u041A\u043E\u043F\u0456\u044E\u0432\u0430\u0442\u0438 \u0432\u0456\u0434\u043F\u043E\u0432\u0456\u0434\u044C"],
   modeLabels: ["\u041C\u0438\u0442\u0442\u0454\u0432\u0438\u0439", "\u0421\u0435\u0440\u0435\u0434\u043D\u0456\u0439", "\u0412\u0438\u0441\u043E\u043A\u0438\u0439", "\u0414\u0443\u0436\u0435 \u0432\u0438\u0441\u043E\u043A\u0438\u0439"],
+  modeOptions: {
+    instant: ["\u041C\u0438\u0442\u0442\u0454\u0432\u0438\u0439"],
+    medium: ["\u0421\u0435\u0440\u0435\u0434\u043D\u0456\u0439"],
+    high: ["\u0412\u0438\u0441\u043E\u043A\u0438\u0439"],
+    extraHigh: ["\u0414\u0443\u0436\u0435 \u0432\u0438\u0441\u043E\u043A\u0438\u0439"]
+  },
   modeOpenerExtra: ["\u041D\u0430\u043B\u0430\u0448\u0442\u0443\u0432\u0430\u0442\u0438\u2026"],
   tools: {
     web_search: ["\u041F\u043E\u0448\u0443\u043A \u0432 \u0406\u043D\u0442\u0435\u0440\u043D\u0435\u0442\u0456"],
@@ -990,6 +1222,12 @@ var ptBR = {
   addPhotosFilesMenuItem: ["Carregar fotos e arquivos"],
   copyResponse: ["Copiar resposta"],
   modeLabels: ["Instant\xE2neo", "M\xE9dio", "Alto", "Muito alta"],
+  modeOptions: {
+    instant: ["Instant\xE2neo"],
+    medium: ["M\xE9dio"],
+    high: ["Alto"],
+    extraHigh: ["Muito alta"]
+  },
   modeOpenerExtra: ["Configurar\u2026"],
   tools: {
     web_search: ["Busca na web"],
@@ -1012,6 +1250,12 @@ var ptPT = {
   addPhotosFilesMenuItem: ["Carregar fotos e ficheiros"],
   copyResponse: ["Copiar resposta"],
   modeLabels: ["Instant\xE2neo", "M\xE9dia", "Alta", "M\xE1ximo"],
+  modeOptions: {
+    instant: ["Instant\xE2neo"],
+    medium: ["M\xE9dia"],
+    high: ["Alta"],
+    extraHigh: ["M\xE1ximo"]
+  },
   modeOpenerExtra: ["Configurar..."],
   tools: {
     web_search: ["Procurar na web"],
@@ -1034,6 +1278,12 @@ var pl = {
   addPhotosFilesMenuItem: ["Prze\u015Blij zdj\u0119cia i pliki"],
   copyResponse: ["Kopiuj odpowied\u017A"],
   modeLabels: ["B\u0142yskawiczny", "\u015Aredni", "Zaawansowana", "Bardzo wysoki"],
+  modeOptions: {
+    instant: ["B\u0142yskawiczny"],
+    medium: ["\u015Aredni"],
+    high: ["Zaawansowana"],
+    extraHigh: ["Bardzo wysoki"]
+  },
   modeOpenerExtra: ["Skonfiguruj..."],
   tools: {
     web_search: ["Wyszukiwanie w sieci"],
@@ -1056,6 +1306,12 @@ var sk = {
   addPhotosFilesMenuItem: ["Nahra\u0165 fotografie a s\xFAbory"],
   copyResponse: ["Kop\xEDrova\u0165 odpove\u010F"],
   modeLabels: ["Okam\u017Eit\xE1", "Stredn\xE1", "Vysok\xE1", "Extra vysok\xE1"],
+  modeOptions: {
+    instant: ["Okam\u017Eit\xE1"],
+    medium: ["Stredn\xE1"],
+    high: ["Vysok\xE1"],
+    extraHigh: ["Extra vysok\xE1"]
+  },
   modeOpenerExtra: ["Konfigurova\u0165..."],
   tools: {
     web_search: ["Preh\u013Ead\xE1vaj web"],
@@ -1078,6 +1334,11 @@ var ro = {
   addPhotosFilesMenuItem: ["\xCEncarc\u0103 fotografii \u0219i fi\u0219iere"],
   copyResponse: ["Copiaz\u0103 r\u0103spunsul"],
   modeLabels: ["Mediu", "Ridicat", "Foarte ridicat\u0103"],
+  modeOptions: {
+    medium: ["Mediu"],
+    high: ["Ridicat"],
+    extraHigh: ["Foarte ridicat\u0103"]
+  },
   modeOpenerExtra: ["Configureaz\u0103..."],
   tools: {
     web_search: ["C\u0103utare pe internet"],
@@ -1100,6 +1361,12 @@ var nb = {
   addPhotosFilesMenuItem: ["Last opp bilder og filer"],
   copyResponse: ["Kopier svar"],
   modeLabels: ["\xD8yeblikkelig", "Middels", "H\xF8y", "Ekstra h\xF8y"],
+  modeOptions: {
+    instant: ["\xD8yeblikkelig"],
+    medium: ["Middels"],
+    high: ["H\xF8y"],
+    extraHigh: ["Ekstra h\xF8y"]
+  },
   modeOpenerExtra: ["Konfigurer \u2026"],
   tools: {
     web_search: ["Netts\xF8k"],
@@ -1122,6 +1389,13 @@ var ml = {
   addPhotosFilesMenuItem: ["\u0D2B\u0D4B\u0D1F\u0D4D\u0D1F\u0D4B\u0D15\u0D33\u0D41\u0D02 \u0D2B\u0D2F\u0D32\u0D41\u0D15\u0D33\u0D41\u0D02 \u0D05\u0D2A\u0D4D\u200C\u0D32\u0D4B\u0D21\u0D4D \u0D1A\u0D46\u0D2F\u0D4D\u0D2F\u0D41\u0D15"],
   copyResponse: ["\u0D2E\u0D31\u0D41\u0D2A\u0D1F\u0D3F \u0D15\u0D4B\u0D2A\u0D4D\u0D2A\u0D3F \u0D1A\u0D46\u0D2F\u0D4D\u0D2F\u0D41\u0D15"],
   modeLabels: ["\u0D24\u0D7D\u0D15\u0D4D\u0D37\u0D23\u0D02", "\u0D07\u0D1F\u0D24\u0D4D\u0D24\u0D30\u0D02", "\u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28\u0D24\u0D4D", "\u0D35\u0D33\u0D30\u0D46 \u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28", "\u0D2A\u0D4D\u0D30\u0D4B"],
+  modeOptions: {
+    instant: ["\u0D24\u0D7D\u0D15\u0D4D\u0D37\u0D23\u0D02"],
+    medium: ["\u0D07\u0D1F\u0D24\u0D4D\u0D24\u0D30\u0D02"],
+    high: ["\u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28\u0D24\u0D4D"],
+    extraHigh: ["\u0D35\u0D33\u0D30\u0D46 \u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28"],
+    pro: ["\u0D2A\u0D4D\u0D30\u0D4B"]
+  },
   modeOpenerExtra: ["\u0D15\u0D4B\u0D7A\u0D2B\u0D3F\u0D17\u0D7C \u0D1A\u0D46\u0D2F\u0D4D\u0D2F\u0D41\u0D15\u2026"],
   tools: {
     web_search: ["\u0D35\u0D46\u0D2C\u0D4D \u0D24\u0D3F\u0D30\u0D2F\u0D7D"],
@@ -1144,6 +1418,9 @@ var ru = {
   addPhotosFilesMenuItem: ["\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0444\u043E\u0442\u043E\u0433\u0440\u0430\u0444\u0438\u0438 \u0438 \u0444\u0430\u0439\u043B\u044B"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u043E\u0432\u0430\u0442\u044C \u043E\u0442\u0432\u0435\u0442"],
   modeLabels: ["\u041E\u0447\u0435\u043D\u044C \u0432\u044B\u0441\u043E\u043A\u0438\u0439"],
+  modeOptions: {
+    extraHigh: ["\u041E\u0447\u0435\u043D\u044C \u0432\u044B\u0441\u043E\u043A\u0438\u0439"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F..."],
   tools: {
     web_search: ["\u041F\u043E\u0438\u0441\u043A \u0432 \u0441\u0435\u0442\u0438"],
@@ -1166,6 +1443,13 @@ var pa = {
   addPhotosFilesMenuItem: ["\u0A2B\u0A3C\u0A4B\u0A1F\u0A4B\u0A06\u0A02 \u0A05\u0A24\u0A47 \u0A2B\u0A3C\u0A3E\u0A08\u0A32\u0A3E\u0A02 \u0A05\u0A71\u0A2A\u0A32\u0A4B\u0A21 \u0A15\u0A30\u0A4B"],
   copyResponse: ["\u0A1C\u0A35\u0A3E\u0A2C \u0A15\u0A3E\u0A2A\u0A40 \u0A15\u0A30\u0A4B"],
   modeLabels: ["\u0A24\u0A41\u0A30\u0A70\u0A24", "\u0A2E\u0A71\u0A27\u0A2E", "\u0A09\u0A71\u0A1A", "\u0A05\u0A24\u0A3F \u0A09\u0A71\u0A1A", "\u0A2A\u0A4D\u0A30\u0A4B"],
+  modeOptions: {
+    instant: ["\u0A24\u0A41\u0A30\u0A70\u0A24"],
+    medium: ["\u0A2E\u0A71\u0A27\u0A2E"],
+    high: ["\u0A09\u0A71\u0A1A"],
+    extraHigh: ["\u0A05\u0A24\u0A3F \u0A09\u0A71\u0A1A"],
+    pro: ["\u0A2A\u0A4D\u0A30\u0A4B"]
+  },
   modeOpenerExtra: ["\u0A15\u0A4C\u0A28\u0A2B\u0A3F\u0A17\u0A30..."],
   tools: {
     web_search: ["\u0A35\u0A48\u0A71\u0A2C \u0A16\u0A4B\u0A1C"],
@@ -1188,6 +1472,13 @@ var mr = {
   addPhotosFilesMenuItem: ["\u092B\u094B\u091F\u094B \u0906\u0923\u093F \u092B\u093E\u0907\u0932\u094D\u0938 \u0905\u092A\u0932\u094B\u0921 \u0915\u0930\u093E"],
   copyResponse: ["\u092A\u094D\u0930\u0924\u093F\u0938\u093E\u0926 \u0915\u0949\u092A\u0940 \u0915\u0930\u093E"],
   modeLabels: ["\u091D\u091F\u092A\u091F", "\u092E\u0927\u094D\u092F\u092E", "\u0909\u091A\u094D\u091A", "\u0905\u0924\u093F\u0909\u091A\u094D\u091A", "\u092A\u094D\u0930\u094B"],
+  modeOptions: {
+    instant: ["\u091D\u091F\u092A\u091F"],
+    medium: ["\u092E\u0927\u094D\u092F\u092E"],
+    high: ["\u0909\u091A\u094D\u091A"],
+    extraHigh: ["\u0905\u0924\u093F\u0909\u091A\u094D\u091A"],
+    pro: ["\u092A\u094D\u0930\u094B"]
+  },
   modeOpenerExtra: ["\u0915\u0949\u0928\u094D\u092B\u093F\u0917\u0930 \u0915\u0930\u093E..."],
   tools: {
     web_search: ["\u0935\u0947\u092C\u0935\u0930 \u0936\u094B\u0927"],
@@ -1210,6 +1501,12 @@ var tr = {
   addPhotosFilesMenuItem: ["Foto\u011Fraf ve dosya y\xFCkle"],
   copyResponse: ["Yan\u0131t\u0131 kopyala"],
   modeLabels: ["An\u0131nda", "Orta", "Y\xFCksek", "\xC7ok Y\xFCksek"],
+  modeOptions: {
+    instant: ["An\u0131nda"],
+    medium: ["Orta"],
+    high: ["Y\xFCksek"],
+    extraHigh: ["\xC7ok Y\xFCksek"]
+  },
   modeOpenerExtra: ["Yap\u0131land\u0131r..."],
   tools: {
     web_search: ["Web aramas\u0131"],
@@ -1232,6 +1529,12 @@ var sw = {
   addPhotosFilesMenuItem: ["Pakia picha na mafaili"],
   copyResponse: ["Nakili jibu"],
   modeLabels: ["Papo hapo", "Wastani", "Juu", "Juu Zaidi"],
+  modeOptions: {
+    instant: ["Papo hapo"],
+    medium: ["Wastani"],
+    high: ["Juu"],
+    extraHigh: ["Juu Zaidi"]
+  },
   modeOpenerExtra: ["Sanidi..."],
   tools: {
     web_search: ["Utafutaji wa wavuti"],
@@ -1254,6 +1557,13 @@ var te = {
   addPhotosFilesMenuItem: ["\u0C2B\u0C4B\u0C1F\u0C4B\u0C32\u0C41 & \u0C2B\u0C48\u0C32\u0C4D\u200C\u0C32\u0C28\u0C41 \u0C05\u0C2A\u0C4D\u200C\u0C32\u0C4B\u0C21\u0C4D \u0C1A\u0C47\u0C2F\u0C02\u0C21\u0C3F"],
   copyResponse: ["\u0C2A\u0C4D\u0C30\u0C24\u0C3F\u0C38\u0C4D\u0C2A\u0C02\u0C26\u0C28\u0C28\u0C41 \u0C15\u0C3E\u0C2A\u0C40 \u0C1A\u0C47\u0C2F\u0C02\u0C21\u0C3F"],
   modeLabels: ["\u0C24\u0C15\u0C4D\u0C37\u0C23\u0C02", "\u0C2E\u0C27\u0C4D\u0C2F\u0C38\u0C4D\u0C25", "\u0C05\u0C27\u0C3F\u0C15", "\u0C05\u0C24\u0C4D\u0C2F\u0C27\u0C3F\u0C15", "\u0C2A\u0C4D\u0C30\u0C4B"],
+  modeOptions: {
+    instant: ["\u0C24\u0C15\u0C4D\u0C37\u0C23\u0C02"],
+    medium: ["\u0C2E\u0C27\u0C4D\u0C2F\u0C38\u0C4D\u0C25"],
+    high: ["\u0C05\u0C27\u0C3F\u0C15"],
+    extraHigh: ["\u0C05\u0C24\u0C4D\u0C2F\u0C27\u0C3F\u0C15"],
+    pro: ["\u0C2A\u0C4D\u0C30\u0C4B"]
+  },
   modeOpenerExtra: ["\u0C15\u0C3E\u0C28\u0C4D\u0C2B\u0C3F\u0C17\u0C30\u0C4D \u0C1A\u0C47\u0C2F\u0C02\u0C21\u0C3F"],
   tools: {
     web_search: ["\u0C35\u0C46\u0C2C\u0C4D\u200C\u0C32\u0C4B \u0C35\u0C46\u0C24\u0C15\u0C21\u0C02"],
@@ -1296,6 +1606,12 @@ var th = {
   addPhotosFilesMenuItem: ["\u0E2D\u0E31\u0E1B\u0E42\u0E2B\u0E25\u0E14\u0E23\u0E39\u0E1B\u0E41\u0E25\u0E30\u0E44\u0E1F\u0E25\u0E4C"],
   copyResponse: ["\u0E04\u0E31\u0E14\u0E25\u0E2D\u0E01\u0E04\u0E33\u0E15\u0E2D\u0E1A"],
   modeLabels: ["\u0E17\u0E31\u0E19\u0E17\u0E35", "\u0E1B\u0E32\u0E19\u0E01\u0E25\u0E32\u0E07", "\u0E2A\u0E39\u0E07", "\u0E2A\u0E39\u0E07\u0E21\u0E32\u0E01"],
+  modeOptions: {
+    instant: ["\u0E17\u0E31\u0E19\u0E17\u0E35"],
+    medium: ["\u0E1B\u0E32\u0E19\u0E01\u0E25\u0E32\u0E07"],
+    high: ["\u0E2A\u0E39\u0E07"],
+    extraHigh: ["\u0E2A\u0E39\u0E07\u0E21\u0E32\u0E01"]
+  },
   modeOpenerExtra: ["\u0E01\u0E33\u0E2B\u0E19\u0E14\u0E04\u0E48\u0E32..."],
   tools: {
     web_search: ["\u0E04\u0E49\u0E19\u0E2B\u0E32\u0E40\u0E27\u0E47\u0E1A"],
@@ -1318,6 +1634,13 @@ var bn = {
   addPhotosFilesMenuItem: ["\u09AB\u099F\u09CB \u098F\u09AC\u0982 \u09AB\u09BE\u0987\u09B2 \u0986\u09AA\u09B2\u09CB\u09A1 \u0995\u09B0\u09C1\u09A8"],
   copyResponse: ["\u0989\u09A4\u09CD\u09A4\u09B0 \u0995\u09AA\u09BF \u0995\u09B0\u09C1\u09A8"],
   modeLabels: ["\u09A4\u09BE\u09CE\u0995\u09CD\u09B7\u09A3\u09BF\u0995", "\u09AE\u09BE\u099D\u09BE\u09B0\u09BF", "\u0989\u099A\u09CD\u099A", "\u0985\u09A4\u09BF \u0989\u099A\u09CD\u099A", "\u09AA\u09CD\u09B0\u09CB"],
+  modeOptions: {
+    instant: ["\u09A4\u09BE\u09CE\u0995\u09CD\u09B7\u09A3\u09BF\u0995"],
+    medium: ["\u09AE\u09BE\u099D\u09BE\u09B0\u09BF"],
+    high: ["\u0989\u099A\u09CD\u099A"],
+    extraHigh: ["\u0985\u09A4\u09BF \u0989\u099A\u09CD\u099A"],
+    pro: ["\u09AA\u09CD\u09B0\u09CB"]
+  },
   modeOpenerExtra: ["\u0995\u09A8\u09AB\u09BF\u0997\u09BE\u09B0 \u0995\u09B0\u09C1\u09A8..."],
   tools: {
     web_search: ["\u0993\u09AF\u09BC\u09C7\u09AC \u09B8\u09A8\u09CD\u09A7\u09BE\u09A8"],
@@ -1340,6 +1663,12 @@ var ms = {
   addPhotosFilesMenuItem: ["Muat naik foto & fail"],
   copyResponse: ["Salin tindak balas"],
   modeLabels: ["Segera", "Sederhana", "Tinggi", "Sangat Tinggi"],
+  modeOptions: {
+    instant: ["Segera"],
+    medium: ["Sederhana"],
+    high: ["Tinggi"],
+    extraHigh: ["Sangat Tinggi"]
+  },
   modeOpenerExtra: ["Konfigurasikan\u2026"],
   tools: {
     web_search: ["Carian web"],
@@ -1362,6 +1691,12 @@ var so = {
   addPhotosFilesMenuItem: ["Soo geli sawirada & faylasha"],
   copyResponse: ["Koobiyee jawaabta"],
   modeLabels: ["Degdeg", "Dhexdhexaad", "Sare", "Aad u sarreeya"],
+  modeOptions: {
+    instant: ["Degdeg"],
+    medium: ["Dhexdhexaad"],
+    high: ["Sare"],
+    extraHigh: ["Aad u sarreeya"]
+  },
   modeOpenerExtra: ["Ku xidh..."],
   tools: {
     web_search: ["Raadi shakabada"],
@@ -1384,6 +1719,12 @@ var nl = {
   addPhotosFilesMenuItem: ["Foto's en bestanden uploaden"],
   copyResponse: ["Reactie kopi\xEBren"],
   modeLabels: ["Direct", "Gemiddeld", "Hoog", "Extra hoog"],
+  modeOptions: {
+    instant: ["Direct"],
+    medium: ["Gemiddeld"],
+    high: ["Hoog"],
+    extraHigh: ["Extra hoog"]
+  },
   modeOpenerExtra: ["Configureren..."],
   tools: {
     web_search: ["Zoeken op internet"],
@@ -1406,6 +1747,12 @@ var sv = {
   addPhotosFilesMenuItem: ["Ladda upp foton och filer"],
   copyResponse: ["Kopiera svar"],
   modeLabels: ["Direkt", "Balanserad", "H\xF6g", "Extra h\xF6g"],
+  modeOptions: {
+    instant: ["Direkt"],
+    medium: ["Balanserad"],
+    high: ["H\xF6g"],
+    extraHigh: ["Extra h\xF6g"]
+  },
   modeOpenerExtra: ["Konfigurera \u2026"],
   tools: {
     web_search: ["Webbs\xF6kning"],
@@ -1428,6 +1775,12 @@ var lv = {
   addPhotosFilesMenuItem: ["Aug\u0161upiel\u0101d\u0113t foto un failus"],
   copyResponse: ["Kop\u0113t atbildi"],
   modeLabels: ["T\u016Bl\u012Bt\u0113js", "Vid\u0113js", "Augsts", "\u013Boti augsts"],
+  modeOptions: {
+    instant: ["T\u016Bl\u012Bt\u0113js"],
+    medium: ["Vid\u0113js"],
+    high: ["Augsts"],
+    extraHigh: ["\u013Boti augsts"]
+  },
   modeOpenerExtra: ["Konfigur\u0113t..."],
   tools: {
     web_search: ["Mekl\u0113\u0161ana t\u012Bmekl\u012B"],
@@ -1450,6 +1803,11 @@ var mk = {
   addPhotosFilesMenuItem: ["\u041F\u043E\u0441\u0442\u0430\u0432\u0438 \u0444\u043E\u0442\u043E\u0433\u0440\u0430\u0444\u0438\u0438 \u0438 \u0434\u0430\u0442\u043E\u0442\u0435\u043A\u0438"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u0430\u0458 \u043E\u0434\u0433\u043E\u0432\u043E\u0440"],
   modeLabels: ["\u0421\u0440\u0435\u0434\u043D\u043E", "\u0412\u0438\u0441\u043E\u043A\u043E", "\u041C\u043D\u043E\u0433\u0443 \u0432\u0438\u0441\u043E\u043A\u043E"],
+  modeOptions: {
+    medium: ["\u0421\u0440\u0435\u0434\u043D\u043E"],
+    high: ["\u0412\u0438\u0441\u043E\u043A\u043E"],
+    extraHigh: ["\u041C\u043D\u043E\u0433\u0443 \u0432\u0438\u0441\u043E\u043A\u043E"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0438\u0440\u0430\u0458..."],
   tools: {
     web_search: ["\u041F\u0440\u0435\u0431\u0430\u0440\u0443\u0432\u0430\u045A\u0435 \u043D\u0430 \u0438\u043D\u0442\u0435\u0440\u043D\u0435\u0442"],
@@ -1472,6 +1830,12 @@ var sq = {
   addPhotosFilesMenuItem: ["Ngarko foto dhe skedar\xEB"],
   copyResponse: ["Kopjo p\xEBrgjigjen"],
   modeLabels: ["I menj\xEBhersh\xEBm", "Mesatar", "Lart\xEB", "Shum\xEB i lart\xEB"],
+  modeOptions: {
+    instant: ["I menj\xEBhersh\xEBm"],
+    medium: ["Mesatar"],
+    high: ["Lart\xEB"],
+    extraHigh: ["Shum\xEB i lart\xEB"]
+  },
   modeOpenerExtra: ["Konfiguro..."],
   tools: {
     web_search: ["K\xEBrkim n\xEB ueb"],
@@ -1494,6 +1858,12 @@ var sl = {
   addPhotosFilesMenuItem: ["Nalo\u017Ei fotografije in datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Takoj", "Srednja", "Visoka", "Zelo visoko"],
+  modeOptions: {
+    instant: ["Takoj"],
+    medium: ["Srednja"],
+    high: ["Visoka"],
+    extraHigh: ["Zelo visoko"]
+  },
   modeOpenerExtra: ["Konfiguracija \u2026"],
   tools: {
     web_search: ["Iskanje po spletu"],
@@ -1516,6 +1886,9 @@ var sr = {
   addPhotosFilesMenuItem: ["\u041E\u0442\u043F\u0440\u0435\u043C\u0438 \u0444\u043E\u0442\u043E\u0433\u0440\u0430\u0444\u0438\u0458\u0435 \u0438 \u0434\u0430\u0442\u043E\u0442\u0435\u043A\u0435"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u0430\u0458 \u043E\u0434\u0433\u043E\u0432\u043E\u0440"],
   modeLabels: ["\u0412\u0435\u043E\u043C\u0430 \u0432\u0438\u0441\u043E\u043A\u043E"],
+  modeOptions: {
+    extraHigh: ["\u0412\u0435\u043E\u043C\u0430 \u0432\u0438\u0441\u043E\u043A\u043E"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0438\u0448\u0438..."],
   tools: {
     web_search: ["\u041F\u0440\u0435\u0442\u0440\u0430\u0433\u0430 \u0432\u0435\u0431\u0430"],
@@ -1538,6 +1911,13 @@ var mn = {
   addPhotosFilesMenuItem: ["\u0417\u0443\u0440\u0430\u0433 \u0431\u0430 \u0444\u0430\u0439\u043B \u0431\u0430\u0439\u0440\u0448\u0443\u0443\u043B\u0430\u0445"],
   copyResponse: ["\u0425\u0430\u0440\u0438\u0443\u043B\u0442 \u0445\u0443\u0443\u043B\u0430\u0445"],
   modeLabels: ["\u0428\u0443\u0443\u0440\u0445\u0430\u0439", "\u0414\u0443\u043D\u0434", "\u04E8\u043D\u0434\u04E9\u0440", "\u041C\u0430\u0448 \u04E9\u043D\u0434\u04E9\u0440", "\u041F\u0440\u043E"],
+  modeOptions: {
+    instant: ["\u0428\u0443\u0443\u0440\u0445\u0430\u0439"],
+    medium: ["\u0414\u0443\u043D\u0434"],
+    high: ["\u04E8\u043D\u0434\u04E9\u0440"],
+    extraHigh: ["\u041C\u0430\u0448 \u04E9\u043D\u0434\u04E9\u0440"],
+    pro: ["\u041F\u0440\u043E"]
+  },
   modeOpenerExtra: ["\u0422\u043E\u0445\u0438\u0440\u0443\u0443\u043B\u0430\u0445..."],
   tools: {
     web_search: ["\u0412\u0435\u0431 \u0445\u0430\u0439\u043B\u0442"],
@@ -1560,6 +1940,12 @@ var my = {
   addPhotosFilesMenuItem: ["\u1013\u102C\u1010\u103A\u1015\u102F\u1036\u1019\u103B\u102C\u1038\u1014\u103E\u1004\u1037\u103A \u1016\u102D\u102F\u1004\u103A\u1019\u103B\u102C\u1038\u1000\u102D\u102F \u1010\u1004\u103A\u1015\u102B"],
   copyResponse: ["\u1010\u102F\u1036\u1037\u1015\u103C\u1014\u103A\u1019\u103E\u102F \u1000\u1030\u1038\u101A\u1030\u101B\u1014\u103A"],
   modeLabels: ["\u1001\u103B\u1000\u103A\u1001\u103B\u1004\u103A\u1038", "\u1021\u101C\u101A\u103A\u1021\u101C\u1010\u103A", "\u1019\u103C\u1004\u1037\u103A", "\u1021\u101C\u103D\u1014\u103A\u1019\u103C\u1004\u1037\u103A"],
+  modeOptions: {
+    instant: ["\u1001\u103B\u1000\u103A\u1001\u103B\u1004\u103A\u1038"],
+    medium: ["\u1021\u101C\u101A\u103A\u1021\u101C\u1010\u103A"],
+    high: ["\u1019\u103C\u1004\u1037\u103A"],
+    extraHigh: ["\u1021\u101C\u103D\u1014\u103A\u1019\u103C\u1004\u1037\u103A"]
+  },
   modeOpenerExtra: ["\u1015\u103C\u102F\u1015\u103C\u1004\u103A\u1019\u103D\u1019\u103A\u1038\u1019\u1036\u101B\u1014\u103A"],
   tools: {
     web_search: ["\u101D\u1018\u103A\u101B\u103E\u102C\u1016\u103D\u1031\u101B\u1014\u103A"],
@@ -1582,6 +1968,13 @@ var ta = {
   addPhotosFilesMenuItem: ["\u0BAA\u0B9F\u0B99\u0BCD\u0B95\u0BB3\u0BCD \u0BAE\u0BB1\u0BCD\u0BB1\u0BC1\u0BAE\u0BCD \u0B83\u0BAA\u0BC8\u0BB2\u0BCD\u0B95\u0BB3\u0BC8\u0BAA\u0BCD \u0BAA\u0BA4\u0BBF\u0BB5\u0BC7\u0BB1\u0BCD\u0BB1\u0BC1"],
   copyResponse: ["\u0BAA\u0BA4\u0BBF\u0BB2\u0BC8 \u0BA8\u0B95\u0BB2\u0BC6\u0B9F\u0BC1\u0B95\u0BCD\u0B95\u0BB2\u0BBE\u0BAE\u0BCD"],
   modeLabels: ["\u0B89\u0B9F\u0BA9\u0B9F\u0BBF", "\u0BA8\u0B9F\u0BC1\u0BA4\u0BCD\u0BA4\u0BB0", "\u0B89\u0BAF\u0BB0\u0BCD", "\u0BAE\u0BBF\u0B95 \u0B89\u0BAF\u0BB0\u0BCD\u0BB5\u0BC1", "\u0BAA\u0BCD\u0BB0\u0BCB"],
+  modeOptions: {
+    instant: ["\u0B89\u0B9F\u0BA9\u0B9F\u0BBF"],
+    medium: ["\u0BA8\u0B9F\u0BC1\u0BA4\u0BCD\u0BA4\u0BB0"],
+    high: ["\u0B89\u0BAF\u0BB0\u0BCD"],
+    extraHigh: ["\u0BAE\u0BBF\u0B95 \u0B89\u0BAF\u0BB0\u0BCD\u0BB5\u0BC1"],
+    pro: ["\u0BAA\u0BCD\u0BB0\u0BCB"]
+  },
   modeOpenerExtra: ["\u0B95\u0B9F\u0BCD\u0B9F\u0BAE\u0BC8\u0B95\u0BCD\u0B95\u0BB5\u0BC1\u0BAE\u0BCD..."],
   tools: {
     web_search: ["\u0B87\u0BA3\u0BC8\u0BAF \u0BA4\u0BC7\u0B9F\u0BB2\u0BCD"],
@@ -1595,6 +1988,16 @@ var ta = {
 // src/dom/locale/index.ts
 var locales = [en, de, esES, frFR, zhHK, zhTW, ja, it, vi, am, ar, bg, bs, ca, cs, da, el, es419, et, fa, fi, frCA, gu, hi, hr, hu, hy, id, is, ka, kk, kn, ko, lt, zhHans, ur, uk, ptBR, ptPT, pl, sk, ro, nb, ml, ru, pa, mr, tr, sw, te, tl, th, bn, ms, so, nl, sv, lv, mk, sq, sl, sr, mn, my, ta];
 var TOOL_IDS = ["web_search", "deep_research", "create_image"];
+var MODE_OPTION_IDS = [
+  "latest",
+  "instant",
+  "thinking",
+  "extended",
+  "medium",
+  "high",
+  "extraHigh",
+  "pro"
+];
 function flattenKey(localeList, key) {
   const seen = /* @__PURE__ */ new Set();
   const result = [];
@@ -1618,6 +2021,24 @@ function flattenTool(localeList, toolId) {
     const tools = locale["tools"];
     if (tools === void 0 || tools === null) continue;
     const value = tools[toolId];
+    if (value === void 0 || value === null) continue;
+    const candidates = typeof value === "string" ? [value] : value;
+    for (const candidate of candidates) {
+      if (candidate.length > 0 && !seen.has(candidate)) {
+        seen.add(candidate);
+        result.push(candidate);
+      }
+    }
+  }
+  return result;
+}
+function flattenModeOption(localeList, optionId) {
+  const seen = /* @__PURE__ */ new Set();
+  const result = [];
+  for (const locale of localeList) {
+    const modeOptions = locale["modeOptions"];
+    if (modeOptions === void 0 || modeOptions === null) continue;
+    const value = modeOptions[optionId];
     if (value === void 0 || value === null) continue;
     const candidates = typeof value === "string" ? [value] : value;
     for (const candidate of candidates) {
@@ -1662,8 +2083,12 @@ var builtLabels = Object.fromEntries(
 var builtTools = Object.fromEntries(
   TOOL_IDS.map((id2) => [id2, flattenTool(locales, id2)])
 );
+var builtModeOptions = Object.fromEntries(
+  MODE_OPTION_IDS.map((id2) => [id2, flattenModeOption(locales, id2)])
+);
 var localeLabels = {
   ...builtLabels,
+  modeOptions: builtModeOptions,
   tools: builtTools
 };
 function escapeRegExp(value) {
@@ -1675,8 +2100,17 @@ function anyLabelPattern(candidates) {
 
 // src/browser/page-state.ts
 function parseConversationId(url) {
-  const match = /\/c\/([A-Za-z0-9-]+)/.exec(url);
-  return match?.[1];
+  let parsed;
+  try {
+    parsed = new URL(url, "https://chatgpt.com");
+  } catch {
+    return void 0;
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments[0] !== "c" || segments[1] === void 0 || segments[1].length === 0) {
+    return void 0;
+  }
+  return segments[1];
 }
 async function readPageState(page) {
   const rawUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
@@ -2780,7 +3214,7 @@ async function contextFromPage(page, partial = {}) {
     return { timestamp: (/* @__PURE__ */ new Date()).toISOString(), ...partial };
   }
   const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => partial.url) : partial.url;
-  const title = typeof page.title === "function" ? await page.title().catch(() => void 0) : partial.title;
+  const title = typeof page.title === "function" ? await withTimeout(page.title(), 1e3, "Timed out while reading page title.").catch(() => partial.title) : partial.title;
   const [turnCount, assistantTurnCount] = await Promise.all([
     withTimeout(countPageMessages(page), 1e3, "Timed out while counting page messages.").catch(() => partial.turnCount),
     withTimeout(countPageMessages(page, "assistant"), 1e3, "Timed out while counting assistant messages.").catch(() => partial.assistantTurnCount)
@@ -5335,6 +5769,7 @@ var REQUIRED_LOCALE_KEYS = [
   "rateLimitBlocker"
 ];
 var REQUIRED_TOOL_IDS = ["web_search", "deep_research", "create_image"];
+var REQUIRED_MODE_OPTION_IDS = ["latest", "instant", "thinking", "extended", "medium", "high", "extraHigh", "pro"];
 async function doctor(env, args = {}) {
   const wanted = args.check ?? DEFAULT_CHECKS;
   const checks = {};
@@ -5534,19 +5969,23 @@ async function filePreflightCheck(env, args) {
 function localizationCheck(env) {
   const requiredKeysMissing = REQUIRED_LOCALE_KEYS.filter((key) => localeLabels[key].length === 0);
   const missingToolIds = REQUIRED_TOOL_IDS.filter((id2) => (localeLabels.tools[id2]?.length ?? 0) === 0);
+  const missingModeOptionIds = REQUIRED_MODE_OPTION_IDS.filter((id2) => (localeLabels.modeOptions[id2]?.length ?? 0) === 0);
   const toolIds = Object.keys(localeLabels.tools);
-  const englishCanonicalPresent = localeLabels.composerTextbox[0] === "Chat with ChatGPT" && localeLabels.sendButton[0] === "Send prompt" && localeLabels.modeLabels.includes("Thinking") && localeLabels.tools.web_search?.[0] === "Web search";
-  const labelCandidateCount = REQUIRED_LOCALE_KEYS.reduce((total, key) => total + localeLabels[key].length, 0) + Object.values(localeLabels.tools).reduce((total, values) => total + values.length, 0);
+  const modeOptionIds = Object.keys(localeLabels.modeOptions);
+  const englishCanonicalPresent = localeLabels.composerTextbox[0] === "Chat with ChatGPT" && localeLabels.sendButton[0] === "Send prompt" && localeLabels.modeLabels.includes("Thinking") && localeLabels.modeOptions.pro?.[0] === "Pro" && localeLabels.tools.web_search?.[0] === "Web search";
+  const labelCandidateCount = REQUIRED_LOCALE_KEYS.reduce((total, key) => total + localeLabels[key].length, 0) + Object.values(localeLabels.tools).reduce((total, values) => total + values.length, 0) + Object.values(localeLabels.modeOptions).reduce((total, values) => total + values.length, 0);
   const details = {
     englishCanonicalPresent,
     requiredKeysMissing,
     missingToolIds,
+    missingModeOptionIds,
     toolIds,
+    modeOptionIds,
     labelCandidateCount,
     pageAvailable: env.page !== void 0,
     runtimeSelectorCoverage: "registry_only_stage_2"
   };
-  if (englishCanonicalPresent && requiredKeysMissing.length === 0 && missingToolIds.length === 0) {
+  if (englishCanonicalPresent && requiredKeysMissing.length === 0 && missingToolIds.length === 0 && missingModeOptionIds.length === 0) {
     return unknown("The locale registry is loaded; localized runtime selector coverage is registry-only in Stage 2 and not fully proven.", void 0, details);
   }
   return blocked(
@@ -5737,6 +6176,22 @@ function generationStateFromText(text) {
   };
 }
 
+// src/commands/deadline.ts
+function createDeadline(timeoutMs, startedAtMs = Date.now()) {
+  const safeTimeoutMs = Math.max(0, timeoutMs);
+  return {
+    startedAtMs,
+    timeoutMs: safeTimeoutMs,
+    expiresAtMs: startedAtMs + safeTimeoutMs
+  };
+}
+function remainingMs(deadline, nowMs = Date.now()) {
+  return Math.max(0, deadline.expiresAtMs - nowMs);
+}
+function childTimeoutMs(deadline, capMs, nowMs = Date.now()) {
+  return Math.max(0, Math.min(Math.max(0, capMs), remainingMs(deadline, nowMs)));
+}
+
 // src/commands/output.ts
 function commandOutputText(data) {
   if (!isRecord2(data)) return void 0;
@@ -5762,6 +6217,69 @@ function withCommandOutputText(result) {
 function isRecord2(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+// src/commands/probes.ts
+function createSingleFlightProbe(name, probe) {
+  let inFlight;
+  return async (arg, deadline, options) => {
+    if (inFlight !== void 0) {
+      return {
+        ok: false,
+        skipped: true,
+        warnings: [`Skipped ${name} DOM probe because previous browser-side work is still in flight.`]
+      };
+    }
+    const timeoutMs = childTimeoutMs(deadline, options.timeoutMs);
+    if (timeoutMs <= 0) {
+      return {
+        ok: false,
+        timedOut: true,
+        warnings: [`Skipped ${name} DOM probe because no deadline budget remained.`]
+      };
+    }
+    const current = probe(arg);
+    inFlight = current;
+    current.finally(() => {
+      if (inFlight === current) {
+        inFlight = void 0;
+      }
+    }).catch(() => void 0);
+    let timeout;
+    try {
+      const value = await Promise.race([
+        current,
+        new Promise((_resolve, reject) => {
+          timeout = setTimeout(() => reject(new ProbeTimeoutError(timeoutMs)), timeoutMs);
+        })
+      ]);
+      return { ok: true, value, warnings: [] };
+    } catch (error) {
+      if (error instanceof ProbeTimeoutError) {
+        return {
+          ok: false,
+          timedOut: true,
+          warnings: [`Timed out waiting ${timeoutMs}ms for ${name} DOM probe; this stopped SDK waiting but did not cancel browser-side work.`]
+        };
+      }
+      return {
+        ok: false,
+        warnings: [`${name} DOM probe failed: ${error instanceof Error ? error.message : String(error)}`]
+      };
+    } finally {
+      if (timeout !== void 0) {
+        clearTimeout(timeout);
+      }
+    }
+  };
+}
+var ProbeTimeoutError = class extends Error {
+  constructor(timeoutMs) {
+    super(`Probe timed out after ${timeoutMs}ms.`);
+    this.timeoutMs = timeoutMs;
+    this.name = "ProbeTimeoutError";
+  }
+  timeoutMs;
+};
 
 // src/commands/messages.ts
 function isResponseComplete(snapshot) {
@@ -6000,21 +6518,20 @@ async function waitForMessage(env, args = {}) {
   const stableMs = args.stableMs ?? (args.mode === "deep_research" ? 1e4 : 2e3);
   const pollMs = args.pollMs ?? 750;
   const started = Date.now();
+  const deadline = createDeadline(timeoutMs, started);
+  const probeTimeoutMs = Math.max(50, Math.min(1e3, Math.max(pollMs, Math.floor(timeoutMs / 4))));
+  const waitWarnings = /* @__PURE__ */ new Set();
+  const assistantProgressProbe = createSingleFlightProbe("assistant progress", readAssistantProgressSnapshot);
+  const pageStateProbe = createSingleFlightProbe("page state", readPageState);
+  const generationStateProbe = createSingleFlightProbe("assistant generation state", readAssistantGenerationState);
+  const responseActionsProbe = createSingleFlightProbe("assistant response actions", latestAssistantTurnHasResponseActions);
   let lastTargetText = "";
   let lastChangedAt = Date.now();
   let latestAssistantCount = await countPageMessages(page, "assistant").catch(() => 0);
   while (Date.now() - started < timeoutMs) {
-    const state = await readPageState(page).catch(() => void 0);
-    if (state?.blocker !== void 0 && state.blocker.kind !== "modal") {
-      return {
-        ok: false,
-        status: "blocked",
-        warnings: [],
-        blocker: state.blocker,
-        context: await contextFromPage(page)
-      };
-    }
-    const progress = await readAssistantProgressSnapshot(page).catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
+    const progressResult = await assistantProgressProbe(page, deadline, { timeoutMs: probeTimeoutMs });
+    addWarnings(waitWarnings, progressResult.warnings);
+    const progress = await progressSnapshotFromProbeResult(page, progressResult, latestAssistantCount);
     latestAssistantCount = progress.assistantTurnCount;
     const targetReached = waitTargetReached(args, progress);
     const latestText = targetReached ? normalizeWhitespace(progress.latestText ?? "") : "";
@@ -6022,12 +6539,22 @@ async function waitForMessage(env, args = {}) {
       lastTargetText = latestText;
       lastChangedAt = Date.now();
     }
+    const state = await pageStateFromProbe(pageStateProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings);
+    if (state?.blocker !== void 0 && state.blocker.kind !== "modal") {
+      return {
+        ok: false,
+        status: "blocked",
+        warnings: [...waitWarnings],
+        blocker: state.blocker,
+        context: await contextFromPage(page)
+      };
+    }
     const snapshot = {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      generation: await readAssistantGenerationState(page),
-      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
+      generation: await generationStateFromProbe(generationStateProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings),
+      hasResponseActions: await responseActionsFromProbe(responseActionsProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings)
     };
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
       return withCommandOutputText({
@@ -6040,6 +6567,7 @@ async function waitForMessage(env, args = {}) {
           elapsedMs: Date.now() - started
         },
         warnings: [
+          ...waitWarnings,
           "ChatGPT generation appears to have been stopped or interrupted before completion.",
           ...snapshot.generation.signals.map((signal) => `Generation state signal: ${signal}`)
         ],
@@ -6049,7 +6577,8 @@ async function waitForMessage(env, args = {}) {
     if (targetReached && isResponseComplete(snapshot)) {
       return withCommandOutputText(resultOk(
         { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
-        await contextFromPage(page)
+        await contextFromPage(page),
+        [...waitWarnings]
       ));
     }
     await sleep2(page, pollMs);
@@ -6064,14 +6593,14 @@ async function waitForMessage(env, args = {}) {
         assistantTurnCount: latestAssistantCount,
         elapsedMs: Date.now() - started
       },
-      warnings: ["Timed out after receiving partial assistant text."],
+      warnings: [...waitWarnings, "Timed out after receiving partial assistant text."],
       context: await contextFromPage(page)
     });
   }
   return {
     ok: false,
     status: "timeout",
-    warnings: [],
+    warnings: [...waitWarnings],
     error: {
       name: "WaitTimeout",
       message: "No assistant response appeared before the timeout.",
@@ -6079,6 +6608,35 @@ async function waitForMessage(env, args = {}) {
     },
     context: await contextFromPage(page)
   };
+}
+async function pageStateFromProbe(probe, warnings) {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : void 0;
+}
+async function progressSnapshotFromProbeResult(page, result, previousAssistantTurnCount) {
+  if (result.ok) {
+    return result.value;
+  }
+  if (result.timedOut === true || result.skipped === true) {
+    return { assistantTurnCount: previousAssistantTurnCount };
+  }
+  return fallbackAssistantProgressSnapshot(page, previousAssistantTurnCount);
+}
+async function generationStateFromProbe(probe, warnings) {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : EMPTY_GENERATION_STATE;
+}
+async function responseActionsFromProbe(probe, warnings) {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : false;
+}
+function addWarnings(target, warnings) {
+  for (const warning of warnings) {
+    target.add(warning);
+  }
 }
 async function readLatest(env, args = {}) {
   const boot = await ensurePage3(env);
@@ -6438,6 +6996,31 @@ function forwardFailure(result) {
   return forwarded;
 }
 
+// src/dom/label-match.ts
+function normalizeForLabelMatch(text) {
+  return normalizeWhitespace(text.normalize("NFKC")).toLocaleLowerCase();
+}
+function visibleLabelMatches(label, wanted) {
+  const normalizedLabel = normalizeForLabelMatch(label);
+  const normalizedWanted = normalizeForLabelMatch(wanted);
+  if (normalizedWanted.length === 0) {
+    return false;
+  }
+  if (normalizedLabel === normalizedWanted) {
+    return true;
+  }
+  if (isShortLatinToken(normalizedWanted)) {
+    return new RegExp(`(^|[^\\p{L}\\p{N}])${escapeRegExp2(normalizedWanted)}([^\\p{L}\\p{N}]|$)`, "iu").test(normalizedLabel);
+  }
+  return normalizedLabel.includes(normalizedWanted);
+}
+function isShortLatinToken(value) {
+  return value.length <= 3 && /^[a-z0-9]+$/i.test(value);
+}
+function escapeRegExp2(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 // src/dom/menus.ts
 function extractMenuItemsFromText(text) {
   return text.split(/\n| {2,}| • /).map((label) => normalizeWhitespace(label)).filter(Boolean).map((label) => ({ label, normalized: normalizeLabel(label) }));
@@ -6481,13 +7064,16 @@ function findUniqueMenuItem(items, wanted) {
   if (exact.length === 1) {
     return exact[0];
   }
-  const fuzzy = items.filter((item) => item.normalized.includes(normalized));
+  const fuzzy = items.filter((item) => visibleLabelMatches(item.label, wanted));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
 }
 
 // src/commands/modes.ts
 var DEFAULT_MODE_EFFORT = "Thinking";
-var CURRENT_MODE_LABELS = [...localeLabels.modeLabels];
+var CURRENT_MODE_LABELS = dedupeLabels([
+  ...localeLabels.modeLabels,
+  ...Object.values(localeLabels.modeOptions).flat()
+]);
 var MODE_OPENER_LABELS = [...CURRENT_MODE_LABELS.filter((label) => label !== "Pro"), ...localeLabels.modeOpenerExtra];
 var MODEL_VERSION_FAMILY_PATTERN = /^gpt[\s-]/i;
 var MODEL_VERSION_LABEL_PATTERN = /^(?:o\d+|\d+(?:\.\d+)?)$/i;
@@ -6495,8 +7081,36 @@ var CANONICAL_INTELLIGENCE_ORDER = /* @__PURE__ */ new Map([
   ["instant", 0],
   ["medium", 1],
   ["high", 2],
-  ["extra high", 3],
+  ["extraHigh", 3],
   ["pro", 4]
+]);
+var MODE_OPTION_IDS2 = [
+  "latest",
+  "instant",
+  "thinking",
+  "extended",
+  "medium",
+  "high",
+  "extraHigh",
+  "pro"
+];
+var MODE_ID_ALIASES = {
+  latest: ["latest"],
+  instant: ["instant"],
+  thinking: ["thinking"],
+  extended: ["extended"],
+  medium: ["medium"],
+  high: ["high"],
+  extraHigh: ["extra high", "extra-high", "extra_high", "extrahigh"],
+  pro: ["pro"]
+};
+var THREAD_ACTION_MENU_LABELS = /* @__PURE__ */ new Set([
+  "archive",
+  "copy link",
+  "delete",
+  "move to project",
+  "rename",
+  "share"
 ]);
 async function setMode(env, args) {
   const boot = await ensurePage4(env);
@@ -6505,9 +7119,9 @@ async function setMode(env, args) {
   }
   const page = env.page;
   try {
-    const requested = requestedModeLabels(args);
+    const requested = requestedModeSelections(args);
     const requestedVersion = requestedModelVersion(args);
-    const requestedForOpening = requestedVersion === void 0 ? requested : [...requested, requestedVersion];
+    const requestedForOpening = requestedVersion === void 0 ? requested : [...requested, requestedModeSelection(requestedVersion)];
     const opened = await waitForModeMenu(page, requestedForOpening, args.timeoutMs ?? 3e4);
     if (requestedVersion === void 0 && opened.alreadySelected.length === requested.length) {
       return resultOk({ selected: opened.alreadySelected, candidates: opened.modeButtons }, await contextFromPage(page));
@@ -6518,15 +7132,25 @@ async function setMode(env, args) {
     await page.waitForTimeout?.(250);
     const candidates = await enumerateVisibleMenuItems(page);
     const selected = [];
-    for (const item of requested) {
-      const match = findModeMenuItem(candidates, item);
+    if (requested.length > 0 && shouldRejectAsWrongModeMenu(candidates)) {
+      const candidateLabels2 = candidates.map((candidate) => candidate.label);
+      return {
+        ok: false,
+        status: "unsupported",
+        warnings: [],
+        blocker: selectorDriftBlocker("Visible menu appears to be a thread/action menu, not the ChatGPT mode menu.", candidateLabels2),
+        context: await contextFromPage(page)
+      };
+    }
+    for (const request of requested) {
+      const match = findModeMenuItem(candidates, request);
       if (match === void 0) {
         const candidateLabels2 = candidates.map((candidate) => candidate.label);
         return {
           ok: false,
           status: "unsupported",
           warnings: [],
-          blocker: selectorDriftBlocker(`Mode option "${item}" was not found or was ambiguous.`, candidateLabels2),
+          blocker: selectorDriftBlocker(`Mode option "${request.requested}" was not found or was ambiguous.`, candidateLabels2),
           context: await contextFromPage(page)
         };
       }
@@ -6651,6 +7275,27 @@ function looksLikeModeMenu(labels) {
     return CURRENT_MODE_LABELS.some((modeLabel) => visibleLabelMatches(normalized, normalizeLabel(modeLabel)));
   });
 }
+function shouldRejectAsWrongModeMenu(items) {
+  if (items.length === 0) {
+    return false;
+  }
+  const hasPositiveModeEvidence = items.some((item) => {
+    if (item.testId?.startsWith("model-switcher-") === true) {
+      return true;
+    }
+    if (MODEL_VERSION_FAMILY_PATTERN.test(item.label) || MODEL_VERSION_LABEL_PATTERN.test(item.label)) {
+      return true;
+    }
+    if (item.role === "menuitemradio" && CURRENT_MODE_LABELS.some((label) => visibleLabelMatches(item.label, label))) {
+      return true;
+    }
+    return CURRENT_MODE_LABELS.some((label) => visibleLabelMatches(item.label, label));
+  });
+  if (hasPositiveModeEvidence) {
+    return false;
+  }
+  return items.some((item) => THREAD_ACTION_MENU_LABELS.has(normalizeForLabelMatch(item.label)));
+}
 async function clickMenuItem(page, label) {
   if (await clickModelSwitcherMenuItem(page, label)) {
     return true;
@@ -6737,12 +7382,14 @@ function toolLabels(tool) {
   const known = localeLabels.tools[tool];
   return known !== void 0 ? [...known] : [tool];
 }
-function findModeMenuItem(candidates, wanted) {
-  const exact = findUniqueMenuItem(candidates, wanted);
-  if (exact !== void 0) {
-    return exact;
+function findModeMenuItem(candidates, request) {
+  for (const wanted of request.labels) {
+    const exact = findUniqueMenuItem(candidates, wanted);
+    if (exact !== void 0) {
+      return exact;
+    }
   }
-  const wantedIndex = CANONICAL_INTELLIGENCE_ORDER.get(normalizeLabel(wanted));
+  const wantedIndex = request.modeId === void 0 ? void 0 : CANONICAL_INTELLIGENCE_ORDER.get(request.modeId);
   if (wantedIndex === void 0) {
     return void 0;
   }
@@ -6751,12 +7398,39 @@ function findModeMenuItem(candidates, wanted) {
   );
   return intelligenceItems.length >= CANONICAL_INTELLIGENCE_ORDER.size ? intelligenceItems[wantedIndex] : void 0;
 }
-function requestedModeLabels(args) {
+function requestedModeSelections(args) {
   const requested = [args.model, args.intelligence, args.effort].filter((value) => value !== void 0);
   if (requestedModelVersion(args) !== void 0 && requested.length === 0) {
     return [];
   }
-  return requested.length > 0 ? requested : [DEFAULT_MODE_EFFORT];
+  return (requested.length > 0 ? requested : [DEFAULT_MODE_EFFORT]).map(requestedModeSelection);
+}
+function requestedModeSelection(requested) {
+  const modeId = modeOptionIdFor(requested);
+  const labels = modeId === void 0 ? [requested] : localeLabels.modeOptions[modeId];
+  const request = {
+    requested,
+    labels: labels.length > 0 ? [...labels] : [requested]
+  };
+  if (modeId !== void 0) {
+    request.modeId = modeId;
+  }
+  return request;
+}
+function modeOptionIdFor(value) {
+  const normalized = normalizeModeLookupKey(value);
+  for (const id2 of MODE_OPTION_IDS2) {
+    if (MODE_ID_ALIASES[id2].some((alias) => normalizeModeLookupKey(alias) === normalized)) {
+      return id2;
+    }
+    if (localeLabels.modeOptions[id2].some((label) => normalizeModeLookupKey(label) === normalized)) {
+      return id2;
+    }
+  }
+  return void 0;
+}
+function normalizeModeLookupKey(value) {
+  return normalizeForLabelMatch(value).replace(/[_-]+/g, " ");
 }
 function requestedModelVersion(args) {
   return args.modelVersion ?? args.version;
@@ -6770,25 +7444,25 @@ function findUniqueVisibleLabel(labels, wanted) {
   const fuzzy = labels.filter((label) => visibleLabelMatches(normalizeLabel(label), normalized));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
 }
-function visibleLabelMatches(label, wanted) {
-  if (wanted.length <= 3) {
-    return new RegExp(`(^|[^a-z0-9])${escapeRegExp2(wanted)}([^a-z0-9]|$)`, "i").test(label);
-  }
-  return label.includes(wanted);
-}
-function escapeRegExp2(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 function escapeAttributeValue(value) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 function findAlreadySelectedModes(visibleButtons, requested) {
-  return requested.map((label) => findUniqueVisibleLabel(visibleButtons, label)).filter((label) => label !== void 0);
+  return requested.map((request) => findUniqueVisibleLabelForRequest(visibleButtons, request)).filter((label) => label !== void 0);
+}
+function findUniqueVisibleLabelForRequest(labels, request) {
+  for (const label of request.labels) {
+    const found = findUniqueVisibleLabel(labels, label);
+    if (found !== void 0) {
+      return found;
+    }
+  }
+  return void 0;
 }
 async function selectModelVersion(page, requestedVersion, currentCandidates, timeoutMs) {
   let candidates = await enumerateVisibleMenuItems(page);
   if (!looksLikeModeMenu(candidates.map((candidate) => candidate.label))) {
-    const opened2 = await waitForModeMenu(page, [requestedVersion], timeoutMs);
+    const opened2 = await waitForModeMenu(page, [{ requested: requestedVersion, labels: [requestedVersion] }], timeoutMs);
     if (opened2.opened) {
       await page.waitForTimeout?.(250);
       candidates = await enumerateVisibleMenuItems(page);
@@ -7788,8 +8462,51 @@ function cloneDescriptor(descriptor) {
   };
 }
 
-// src/commands/threads.ts
+// src/commands/conversation.ts
 var CHATGPT_HOME2 = "https://chatgpt.com/";
+async function ensureConversationTarget(page, target, options) {
+  const targetUrl = absoluteConversationUrl(target);
+  const expectedConversationId = parseConversationId(targetUrl);
+  const currentUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+  if (expectedConversationId !== void 0 && parseConversationId(typeof currentUrl === "string" ? currentUrl : "") === expectedConversationId) {
+    await waitForConversationHydrated(page, options.timeoutMs, expectedConversationId);
+    return ensureResult(false, targetUrl, expectedConversationId);
+  }
+  await page.goto?.(targetUrl, { waitUntil: "domcontentloaded", timeout: options.timeoutMs });
+  await waitForConversationHydrated(page, options.timeoutMs, expectedConversationId);
+  return ensureResult(true, targetUrl, expectedConversationId);
+}
+async function waitForConversationHydrated(page, timeoutMs, expectedConversationId) {
+  const started = Date.now();
+  do {
+    const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+    const urlMatches2 = expectedConversationId === void 0 || parseConversationId(typeof url === "string" ? url : "") === expectedConversationId;
+    const count = await countPageMessages(page).catch(() => 0);
+    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => void 0);
+    const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
+    if (urlMatches2 && ((latestAssistantText?.trim().length ?? 0) > 0 || count > 0 && title.length > 0 && title !== "ChatGPT")) {
+      await page.waitForTimeout?.(250);
+      return;
+    }
+    await page.waitForTimeout?.(500);
+  } while (Date.now() - started < timeoutMs);
+}
+function absoluteConversationUrl(target) {
+  if (target.href !== void 0 && target.href.startsWith("/")) {
+    return new URL(target.href, CHATGPT_HOME2).toString();
+  }
+  return target.href ?? target.url;
+}
+function ensureResult(navigated, targetUrl, expectedConversationId) {
+  const result = { navigated, targetUrl };
+  if (expectedConversationId !== void 0) {
+    result.expectedConversationId = expectedConversationId;
+  }
+  return result;
+}
+
+// src/commands/threads.ts
+var CHATGPT_HOME3 = "https://chatgpt.com/";
 function extractThreadSearchResultsFromHtml(html) {
   const anchors = html.matchAll(/<a\b(?<attrs>[^>]*\bhref=["'](?<href>\/c\/[^"']+)["'][^>]*)>(?<body>[\s\S]*?)<\/a>/gi);
   const results = [];
@@ -7850,7 +8567,7 @@ async function newThread(env, args = {}) {
     try {
       await newChatButton(page).click?.();
     } catch {
-      await page.goto?.(CHATGPT_HOME2, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+      await page.goto?.(CHATGPT_HOME3, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
     }
     await page.waitForTimeout?.(500);
     const state = await readPageState(page);
@@ -7879,12 +8596,7 @@ async function openThread(env, args, previousResults) {
         context: await contextFromPage(page)
       };
     }
-    if (target.href !== void 0 && target.href.startsWith("/")) {
-      await page.goto?.(new URL(target.href, CHATGPT_HOME2).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
-    } else {
-      await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
-    }
-    await waitForThreadHydrated(page, args.timeoutMs ?? 3e4, parseConversationId(target.url));
+    await ensureConversationTarget(page, target, { timeoutMs: args.timeoutMs ?? 3e4 });
     const state = await readPageState(page);
     return resultOk(
       openThreadData(state.url, state.conversationId, state.title ?? target.title),
@@ -7905,21 +8617,21 @@ async function resolveOpenTarget(env, args, previousResults) {
     return { url: args.url };
   }
   if (args.conversationId !== void 0) {
-    return { url: new URL(`/c/${args.conversationId}`, CHATGPT_HOME2).toString() };
+    return { url: new URL(`/c/${args.conversationId}`, CHATGPT_HOME3).toString() };
   }
   if (args.fromStep !== void 0 && previousResults !== void 0) {
     const previous = previousResults.get(args.fromStep);
     const data = previous?.data;
     const selected = selectSearchResult(data?.results ?? [], args.select ?? "first");
     if (selected !== void 0) {
-      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME2).toString(), title: selected.title };
+      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME3).toString(), title: selected.title };
     }
   }
   if (args.title !== void 0) {
     const search = await searchThreads(env, { query: args.title, limit: 10 });
     const selected = selectSearchResult(search.data?.results ?? [], { title: args.title }) ?? search.data?.results[0];
     if (selected !== void 0) {
-      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME2).toString(), title: selected.title };
+      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME3).toString(), title: selected.title };
     }
   }
   return void 0;
@@ -8051,22 +8763,6 @@ function filterResultsByQuery(results, query) {
     const haystack = normalizeForMatch(`${result.title} ${result.snippet ?? ""}`);
     return haystack.includes(wanted) || wanted.includes(normalizeForMatch(result.title));
   });
-}
-async function waitForThreadHydrated(page, timeoutMs, expectedConversationId) {
-  const started = Date.now();
-  await page.waitForTimeout?.(1e3);
-  while (Date.now() - started < timeoutMs) {
-    const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
-    const urlMatches2 = expectedConversationId === void 0 || url.includes(expectedConversationId);
-    const count = await countPageMessages(page).catch(() => 0);
-    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => void 0);
-    const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
-    if (urlMatches2 && ((latestAssistantText?.trim().length ?? 0) > 0 || count > 0 && title.length > 0 && title !== "ChatGPT")) {
-      await page.waitForTimeout?.(250);
-      return;
-    }
-    await page.waitForTimeout?.(500);
-  }
 }
 
 // src/commands/sequence.ts

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
@@ -418,6 +418,16 @@ var en = {
   imageContainerHint: ["image"],
   // --- Mode switcher (also the canonical public API keys) ---
   modeLabels: ["Latest", "Instant", "Thinking", "Extended", "Medium", "High", "Extra High", "Pro"],
+  modeOptions: {
+    latest: ["Latest"],
+    instant: ["Instant"],
+    thinking: ["Thinking"],
+    extended: ["Extended"],
+    medium: ["Medium"],
+    high: ["High"],
+    extraHigh: ["Extra High"],
+    pro: ["Pro", "Pro Extended", "Extended Pro"]
+  },
   /** Extra openers that surface the mode menu but are not selectable modes themselves. */
   modeOpenerExtra: ["Configure"],
   // --- Tool menu items, keyed by logical tool id ---
@@ -458,6 +468,12 @@ var de = {
   addPhotosFilesMenuItem: ["Fotos und Dateien hinzuf\xFCgen"],
   copyResponse: ["Antwort kopieren"],
   modeLabels: ["Sofort", "Mittel", "Hoch", "Extra hoch"],
+  modeOptions: {
+    instant: ["Sofort"],
+    medium: ["Mittel"],
+    high: ["Hoch"],
+    extraHigh: ["Extra hoch"]
+  },
   modeOpenerExtra: ["Konfigurieren"],
   tools: {
     web_search: ["Websuche"],
@@ -479,6 +495,12 @@ var esES = {
   addPhotosFilesMenuItem: ["A\xF1adir fotos y archivos"],
   copyResponse: ["Copiar respuesta"],
   modeLabels: ["Instant\xE1nea", "Media", "Alta", "Muy alta"],
+  modeOptions: {
+    instant: ["Instant\xE1nea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Muy alta"]
+  },
   modeOpenerExtra: ["Configurar"],
   tools: {
     web_search: ["B\xFAsqueda en Internet"],
@@ -501,6 +523,11 @@ var frFR = {
   addPhotosFilesMenuItem: ["Ajouter des photos et fichiers"],
   copyResponse: ["Copier la r\xE9ponse"],
   modeLabels: ["Moyen", "Avanc\xE9", "Tr\xE8s \xE9lev\xE9"],
+  modeOptions: {
+    medium: ["Moyen"],
+    high: ["Avanc\xE9"],
+    extraHigh: ["Tr\xE8s \xE9lev\xE9"]
+  },
   modeOpenerExtra: ["Configurer"],
   tools: {
     web_search: ["Recherche sur le Web"],
@@ -523,6 +550,13 @@ var zhHK = {
   addPhotosFilesMenuItem: ["\u52A0\u5165\u76F8\u7247\u548C\u6A94\u6848"],
   copyResponse: ["\u8907\u88FD\u56DE\u8986"],
   modeLabels: ["\u5373\u6642", "\u5747\u8861", "\u9AD8", "\u6975\u9AD8", "\u5C08\u696D"],
+  modeOptions: {
+    instant: ["\u5373\u6642"],
+    medium: ["\u5747\u8861"],
+    high: ["\u9AD8"],
+    extraHigh: ["\u6975\u9AD8"],
+    pro: ["\u5C08\u696D"]
+  },
   modeOpenerExtra: ["\u8A2D\u5B9A"],
   tools: {
     web_search: ["\u7DB2\u7D61\u641C\u5C0B"],
@@ -545,6 +579,13 @@ var zhTW = {
   addPhotosFilesMenuItem: ["\u65B0\u589E\u7167\u7247\u548C\u6A94\u6848"],
   copyResponse: ["\u8907\u88FD\u56DE\u61C9"],
   modeLabels: ["\u5373\u6642", "\u4E2D\u7B49", "\u9AD8", "\u8D85\u9AD8", "\u5C08\u696D"],
+  modeOptions: {
+    instant: ["\u5373\u6642"],
+    medium: ["\u4E2D\u7B49"],
+    high: ["\u9AD8"],
+    extraHigh: ["\u8D85\u9AD8"],
+    pro: ["\u5C08\u696D"]
+  },
   modeOpenerExtra: ["\u8A2D\u5B9A"],
   tools: {
     web_search: ["\u7DB2\u9801\u641C\u5C0B"],
@@ -567,6 +608,12 @@ var ja = {
   addPhotosFilesMenuItem: ["\u5199\u771F\u3068\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0"],
   copyResponse: ["\u56DE\u7B54\u3092\u30B3\u30D4\u30FC\u3059\u308B"],
   modeLabels: ["\u6700\u901F", "\u6A19\u6E96", "\u9AD8", "\u6700\u9AD8"],
+  modeOptions: {
+    instant: ["\u6700\u901F"],
+    medium: ["\u6A19\u6E96"],
+    high: ["\u9AD8"],
+    extraHigh: ["\u6700\u9AD8"]
+  },
   modeOpenerExtra: ["\u8A2D\u5B9A\u3059\u308B"],
   tools: {
     web_search: ["\u30A6\u30A7\u30D6\u691C\u7D22"],
@@ -588,6 +635,12 @@ var it = {
   addPhotosFilesMenuItem: ["Aggiungi foto e file"],
   copyResponse: ["Copia risposta"],
   modeLabels: ["Istantanea", "Media", "Alta", "Extra elevata"],
+  modeOptions: {
+    instant: ["Istantanea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Extra elevata"]
+  },
   modeOpenerExtra: ["Configura"],
   tools: {
     web_search: ["Ricerca sul web"],
@@ -609,6 +662,12 @@ var vi = {
   addPhotosFilesMenuItem: ["Th\xEAm \u1EA3nh v\xE0 t\u1EC7p"],
   copyResponse: ["Sao ch\xE9p ph\u1EA3n h\u1ED3i"],
   modeLabels: ["T\u1EE9c th\xEC", "Trung b\xECnh", "Cao", "R\u1EA5t cao"],
+  modeOptions: {
+    instant: ["T\u1EE9c th\xEC"],
+    medium: ["Trung b\xECnh"],
+    high: ["Cao"],
+    extraHigh: ["R\u1EA5t cao"]
+  },
   modeOpenerExtra: ["\u0110\u1ECBnh c\u1EA5u h\xECnh"],
   tools: {
     web_search: ["T\xECm ki\u1EBFm tr\xEAn m\u1EA1ng"],
@@ -631,6 +690,12 @@ var am = {
   addPhotosFilesMenuItem: ["\u134E\u1276\u12CE\u127D\u1295 \u12A5\u1293 \u134B\u12ED\u120E\u127D\u1295 \u12EB\u12AD\u1209"],
   copyResponse: ["\u121D\u120B\u1239\u1295 \u12ED\u1245\u12F1"],
   modeLabels: ["\u1348\u1323\u1295", "\u1218\u12AB\u12A8\u1208\u129B", "\u12A8\u134D\u1270\u129B", "\u12A5\u1305\u130D \u12A8\u134D\u1270\u129B"],
+  modeOptions: {
+    instant: ["\u1348\u1323\u1295"],
+    medium: ["\u1218\u12AB\u12A8\u1208\u129B"],
+    high: ["\u12A8\u134D\u1270\u129B"],
+    extraHigh: ["\u12A5\u1305\u130D \u12A8\u134D\u1270\u129B"]
+  },
   modeOpenerExtra: ["\u12EB\u12CB\u1245\u1229"],
   tools: {
     web_search: ["\u12E8\u12F5\u122D \u134D\u1208\u130B"],
@@ -653,6 +718,13 @@ var ar = {
   addPhotosFilesMenuItem: ["\u0625\u0636\u0627\u0641\u0629 \u0635\u0648\u0631 \u0648\u0645\u0644\u0641\u0627\u062A"],
   copyResponse: ["\u0646\u0633\u062E \u0625\u062C\u0627\u0628\u0629"],
   modeLabels: ["\u0641\u0648\u0631\u064A", "\u0645\u062A\u0648\u0633\u0637", "\u0639\u0627\u0644\u064A", "\u0645\u0643\u062B\u0641 \u062C\u062F\u064B\u0627", "\u0627\u062D\u062A\u0631\u0627\u0641\u064A"],
+  modeOptions: {
+    instant: ["\u0641\u0648\u0631\u064A"],
+    medium: ["\u0645\u062A\u0648\u0633\u0637"],
+    high: ["\u0639\u0627\u0644\u064A"],
+    extraHigh: ["\u0645\u0643\u062B\u0641 \u062C\u062F\u064B\u0627"],
+    pro: ["\u0627\u062D\u062A\u0631\u0627\u0641\u064A"]
+  },
   modeOpenerExtra: ["\u062A\u0643\u0648\u064A\u0646"],
   tools: {
     web_search: ["\u0627\u0644\u0628\u062D\u062B \u0641\u064A \u0627\u0644\u0648\u064A\u0628"],
@@ -675,6 +747,13 @@ var bg = {
   addPhotosFilesMenuItem: ["\u0414\u043E\u0431\u0430\u0432\u044F\u043D\u0435 \u043D\u0430 \u0441\u043D\u0438\u043C\u043A\u0438 \u0438 \u0444\u0430\u0439\u043B\u043E\u0432\u0435"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u0430\u0439\u0442\u0435 \u043E\u0442\u0433\u043E\u0432\u043E\u0440\u0430"],
   modeLabels: ["\u041C\u0438\u0433\u043D\u043E\u0432\u0435\u043D", "\u0421\u0440\u0435\u0434\u0435\u043D", "\u0412\u0438\u0441\u043E\u043A", "\u041C\u043D\u043E\u0433\u043E \u0432\u0438\u0441\u043E\u043A\u043E", "\u041F\u0440\u043E"],
+  modeOptions: {
+    instant: ["\u041C\u0438\u0433\u043D\u043E\u0432\u0435\u043D"],
+    medium: ["\u0421\u0440\u0435\u0434\u0435\u043D"],
+    high: ["\u0412\u0438\u0441\u043E\u043A"],
+    extraHigh: ["\u041C\u043D\u043E\u0433\u043E \u0432\u0438\u0441\u043E\u043A\u043E"],
+    pro: ["\u041F\u0440\u043E"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0438\u0440\u0430\u0439\u0442\u0435"],
   tools: {
     web_search: ["\u0422\u044A\u0440\u0441\u0435\u043D\u0435 \u0432 \u0438\u043D\u0442\u0435\u0440\u043D\u0435\u0442"],
@@ -697,6 +776,12 @@ var bs = {
   addPhotosFilesMenuItem: ["Dodaj slike i datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Brzo", "Srednji", "Visoko", "Vrlo visoko"],
+  modeOptions: {
+    instant: ["Brzo"],
+    medium: ["Srednji"],
+    high: ["Visoko"],
+    extraHigh: ["Vrlo visoko"]
+  },
   modeOpenerExtra: ["Podesi"],
   tools: {
     web_search: ["Internet pretraga"],
@@ -719,6 +804,12 @@ var ca = {
   addPhotosFilesMenuItem: ["Afegeix fotos i fitxers"],
   copyResponse: ["Copia la resposta"],
   modeLabels: ["Instantani", "Mitj\xE0", "Alt", "Molt alt"],
+  modeOptions: {
+    instant: ["Instantani"],
+    medium: ["Mitj\xE0"],
+    high: ["Alt"],
+    extraHigh: ["Molt alt"]
+  },
   modeOpenerExtra: ["Configura\u2026"],
   tools: {
     web_search: ["Cerca a la xarxa"],
@@ -741,6 +832,12 @@ var cs = {
   addPhotosFilesMenuItem: ["P\u0159idat fotografie a soubory"],
   copyResponse: ["Zkop\xEDrovat odpov\u011B\u010F"],
   modeLabels: ["Okam\u017Eit\xE1", "St\u0159edn\xED", "Vysok\xE1", "Velmi vysok\xE1"],
+  modeOptions: {
+    instant: ["Okam\u017Eit\xE1"],
+    medium: ["St\u0159edn\xED"],
+    high: ["Vysok\xE1"],
+    extraHigh: ["Velmi vysok\xE1"]
+  },
   modeOpenerExtra: ["Konfigurovat\u2026"],
   tools: {
     web_search: ["Vyhled\xE1v\xE1n\xED na webu"],
@@ -763,6 +860,11 @@ var da = {
   addPhotosFilesMenuItem: ["Tilf\xF8j billeder og filer"],
   copyResponse: ["Kopi\xE9r svar"],
   modeLabels: ["\xD8jeblikkeligt", "H\xF8j", "Ekstra h\xF8j"],
+  modeOptions: {
+    instant: ["\xD8jeblikkeligt"],
+    high: ["H\xF8j"],
+    extraHigh: ["Ekstra h\xF8j"]
+  },
   modeOpenerExtra: ["Konfigurer ..."],
   tools: {
     web_search: ["Internets\xF8gning"],
@@ -785,6 +887,12 @@ var el = {
   addPhotosFilesMenuItem: ["\u03A0\u03C1\u03BF\u03C3\u03B8\u03AE\u03BA\u03B7 \u03C6\u03C9\u03C4\u03BF\u03B3\u03C1\u03B1\u03C6\u03B9\u03CE\u03BD & \u03B1\u03C1\u03C7\u03B5\u03AF\u03C9\u03BD"],
   copyResponse: ["\u0391\u03BD\u03C4\u03B9\u03B3\u03C1\u03B1\u03C6\u03AE \u03B1\u03C0\u03AC\u03BD\u03C4\u03B7\u03C3\u03B7\u03C2"],
   modeLabels: ["\u0386\u03BC\u03B5\u03C3\u03B7", "\u039C\u03B5\u03C3\u03B1\u03AF\u03B1", "\u03A5\u03C8\u03B7\u03BB\u03AE", "\u03A0\u03BF\u03BB\u03CD \u03C5\u03C8\u03B7\u03BB\u03CC"],
+  modeOptions: {
+    instant: ["\u0386\u03BC\u03B5\u03C3\u03B7"],
+    medium: ["\u039C\u03B5\u03C3\u03B1\u03AF\u03B1"],
+    high: ["\u03A5\u03C8\u03B7\u03BB\u03AE"],
+    extraHigh: ["\u03A0\u03BF\u03BB\u03CD \u03C5\u03C8\u03B7\u03BB\u03CC"]
+  },
   modeOpenerExtra: ["\u0394\u03B9\u03B1\u03BC\u03CC\u03C1\u03C6\u03C9\u03C3\u03B7\u2026"],
   tools: {
     web_search: ["\u0391\u03BD\u03B1\u03B6\u03AE\u03C4\u03B7\u03C3\u03B7 \u03C3\u03C4\u03BF\u03BD \u03B9\u03C3\u03C4\u03CC"],
@@ -807,6 +915,12 @@ var es419 = {
   addPhotosFilesMenuItem: ["Agregar fotos y archivos"],
   copyResponse: ["Copiar respuesta"],
   modeLabels: ["Instant\xE1nea", "Media", "Alta", "Muy alta"],
+  modeOptions: {
+    instant: ["Instant\xE1nea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Muy alta"]
+  },
   modeOpenerExtra: ["Configurar..."],
   tools: {
     web_search: ["Busca en la web"],
@@ -829,6 +943,12 @@ var et = {
   addPhotosFilesMenuItem: ["Lisa fotosid ja faile"],
   copyResponse: ["Kopeeri vastus"],
   modeLabels: ["Kohene", "Keskmine", "K\xF5rge", "V\xE4ga k\xF5rge"],
+  modeOptions: {
+    instant: ["Kohene"],
+    medium: ["Keskmine"],
+    high: ["K\xF5rge"],
+    extraHigh: ["V\xE4ga k\xF5rge"]
+  },
   modeOpenerExtra: ["Konfigureeri..."],
   tools: {
     web_search: ["Veebiotsing"],
@@ -851,6 +971,13 @@ var fa = {
   addPhotosFilesMenuItem: ["\u0627\u0641\u0632\u0648\u062F\u0646 \u062A\u0635\u0627\u0648\u06CC\u0631 \u0648 \u0641\u0627\u06CC\u0644\u200C\u0647\u0627"],
   copyResponse: ["\u06A9\u067E\u06CC \u06A9\u0631\u062F\u0646 \u067E\u0627\u0633\u062E"],
   modeLabels: ["\u0641\u0648\u0631\u06CC", "\u0645\u062A\u0648\u0633\u0637", "\u0628\u0627\u0644\u0627", "\u0628\u0633\u06CC\u0627\u0631 \u0632\u06CC\u0627\u062F", "\u062D\u0631\u0641\u0647\u200C\u0627\u06CC"],
+  modeOptions: {
+    instant: ["\u0641\u0648\u0631\u06CC"],
+    medium: ["\u0645\u062A\u0648\u0633\u0637"],
+    high: ["\u0628\u0627\u0644\u0627"],
+    extraHigh: ["\u0628\u0633\u06CC\u0627\u0631 \u0632\u06CC\u0627\u062F"],
+    pro: ["\u062D\u0631\u0641\u0647\u200C\u0627\u06CC"]
+  },
   modeOpenerExtra: ["\u067E\u06CC\u06A9\u0631\u0628\u0646\u062F\u06CC..."],
   tools: {
     web_search: ["\u062C\u0633\u062A\u062C\u0648\u06CC \u0648\u0628"],
@@ -873,6 +1000,12 @@ var fi = {
   addPhotosFilesMenuItem: ["Lis\xE4\xE4 valokuvia & tiedostoja"],
   copyResponse: ["Kopioi vastaus"],
   modeLabels: ["V\xE4lit\xF6n", "Keskitaso", "Korkea", "Eritt\xE4in korkea"],
+  modeOptions: {
+    instant: ["V\xE4lit\xF6n"],
+    medium: ["Keskitaso"],
+    high: ["Korkea"],
+    extraHigh: ["Eritt\xE4in korkea"]
+  },
   modeOpenerExtra: ["M\xE4\xE4rit\xE4..."],
   tools: {
     web_search: ["Verkkohaku"],
@@ -895,6 +1028,12 @@ var frCA = {
   addPhotosFilesMenuItem: ["Ajouter des photos et des fichiers"],
   copyResponse: ["Copier la r\xE9ponse"],
   modeLabels: ["Instantan\xE9", "Moyen", "\xC9lev\xE9", "Tr\xE8s \xE9lev\xE9"],
+  modeOptions: {
+    instant: ["Instantan\xE9"],
+    medium: ["Moyen"],
+    high: ["\xC9lev\xE9"],
+    extraHigh: ["Tr\xE8s \xE9lev\xE9"]
+  },
   modeOpenerExtra: ["Configurer..."],
   tools: {
     web_search: ["Recherche sur Internet"],
@@ -917,6 +1056,12 @@ var gu = {
   addPhotosFilesMenuItem: ["\u0AAB\u0ACB\u0A9F\u0ABE \u0A85\u0AA8\u0AC7 \u0AAB\u0ABE\u0A87\u0AB2\u0ACB \u0A89\u0AAE\u0AC7\u0AB0\u0ACB"],
   copyResponse: ["\u0AAA\u0ACD\u0AB0\u0AA4\u0ABF\u0AAD\u0ABE\u0AB5 \u0A95\u0AC9\u0AAA\u0ABF \u0A95\u0AB0\u0ACB"],
   modeLabels: ["\u0AA4\u0AB0\u0AA4", "\u0AAE\u0AA7\u0ACD\u0AAF\u0AAE", "\u0A89\u0A9A\u0ACD\u0A9A", "\u0A85\u0AA4\u0ABF \u0A89\u0A9A\u0ACD\u0A9A"],
+  modeOptions: {
+    instant: ["\u0AA4\u0AB0\u0AA4"],
+    medium: ["\u0AAE\u0AA7\u0ACD\u0AAF\u0AAE"],
+    high: ["\u0A89\u0A9A\u0ACD\u0A9A"],
+    extraHigh: ["\u0A85\u0AA4\u0ABF \u0A89\u0A9A\u0ACD\u0A9A"]
+  },
   modeOpenerExtra: ["\u0A95\u0AA8\u0ACD\u0AAB\u0ABF\u0A97\u0AB0 \u0A95\u0AB0\u0ACB..."],
   tools: {
     web_search: ["\u0AB5\u0AC7\u0AAC \u0AB6\u0ACB\u0AA7"],
@@ -939,6 +1084,12 @@ var hi = {
   addPhotosFilesMenuItem: ["\u092B\u093C\u094B\u091F\u094B \u0914\u0930 \u092B\u093C\u093E\u0907\u0932\u0947\u0902 \u091C\u094B\u0921\u093C\u0947\u0902"],
   copyResponse: ["\u091C\u0935\u093E\u092C \u0915\u094B \u0915\u0949\u092A\u0940 \u0915\u0930\u0947\u0902"],
   modeLabels: ["\u0924\u0941\u0930\u0902\u0924", "\u092E\u0927\u094D\u092F\u092E", "\u0909\u091A\u094D\u091A", "\u092C\u0939\u0941\u0924 \u0909\u091A\u094D\u091A"],
+  modeOptions: {
+    instant: ["\u0924\u0941\u0930\u0902\u0924"],
+    medium: ["\u092E\u0927\u094D\u092F\u092E"],
+    high: ["\u0909\u091A\u094D\u091A"],
+    extraHigh: ["\u092C\u0939\u0941\u0924 \u0909\u091A\u094D\u091A"]
+  },
   modeOpenerExtra: ["\u0915\u0949\u0928\u094D\u092B\u093C\u093F\u0917\u0930 \u0915\u0930\u0947\u0902..."],
   tools: {
     web_search: ["\u0935\u0947\u092C \u0938\u0930\u094D\u091A"],
@@ -961,6 +1112,11 @@ var hr = {
   addPhotosFilesMenuItem: ["Dodaj fotografije i datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Srednje", "Visoko", "Vrlo visoka"],
+  modeOptions: {
+    medium: ["Srednje"],
+    high: ["Visoko"],
+    extraHigh: ["Vrlo visoka"]
+  },
   modeOpenerExtra: ["Konfiguriraj\u2026"],
   tools: {
     web_search: ["Mre\u017Eno pretra\u017Eivanje"],
@@ -983,6 +1139,12 @@ var hu = {
   addPhotosFilesMenuItem: ["Fot\xF3k \xE9s f\xE1jlok hozz\xE1ad\xE1sa"],
   copyResponse: ["V\xE1lasz m\xE1sol\xE1sa"],
   modeLabels: ["Azonnali", "K\xF6zepes", "Magas", "Kiemelked\u0151en magas"],
+  modeOptions: {
+    instant: ["Azonnali"],
+    medium: ["K\xF6zepes"],
+    high: ["Magas"],
+    extraHigh: ["Kiemelked\u0151en magas"]
+  },
   modeOpenerExtra: ["Konfigur\xE1l\xE1s..."],
   tools: {
     web_search: ["Internetes keres\xE9s"],
@@ -1005,6 +1167,13 @@ var hy = {
   addPhotosFilesMenuItem: ["\u0531\u057E\u0565\u056C\u0561\u0581\u0576\u0565\u056C \u056C\u0578\u0582\u057D\u0561\u0576\u056F\u0561\u0580\u0576\u0565\u0580 \u0587 \u0586\u0561\u0575\u056C\u0565\u0580"],
   copyResponse: ["\u054A\u0561\u057F\u0573\u0565\u0576\u0565\u056C \u057A\u0561\u057F\u0561\u057D\u056D\u0561\u0576\u0568"],
   modeLabels: ["\u0531\u056F\u0576\u0569\u0561\u0580\u0569\u0561\u0575\u056B\u0576", "\u0544\u056B\u057B\u056B\u0576", "\u0532\u0561\u0580\u0571\u0580", "\u0547\u0561\u057F \u0562\u0561\u0580\u0571\u0580", "\u054A\u0580\u0578"],
+  modeOptions: {
+    instant: ["\u0531\u056F\u0576\u0569\u0561\u0580\u0569\u0561\u0575\u056B\u0576"],
+    medium: ["\u0544\u056B\u057B\u056B\u0576"],
+    high: ["\u0532\u0561\u0580\u0571\u0580"],
+    extraHigh: ["\u0547\u0561\u057F \u0562\u0561\u0580\u0571\u0580"],
+    pro: ["\u054A\u0580\u0578"]
+  },
   modeOpenerExtra: ["\u053F\u0561\u0566\u0574\u0561\u0571\u0587\u0565\u056C\u2024\u2024\u2024"],
   tools: {
     web_search: ["\u054E\u0565\u0562 \u0578\u0580\u0578\u0576\u0578\u0582\u0574"],
@@ -1027,6 +1196,12 @@ var id = {
   addPhotosFilesMenuItem: ["Tambah foto & file"],
   copyResponse: ["Salin respons"],
   modeLabels: ["Instan", "Sedang", "Tinggi", "Sangat Tinggi"],
+  modeOptions: {
+    instant: ["Instan"],
+    medium: ["Sedang"],
+    high: ["Tinggi"],
+    extraHigh: ["Sangat Tinggi"]
+  },
   modeOpenerExtra: ["Konfigurasi..."],
   tools: {
     web_search: ["Pencarian web"],
@@ -1049,6 +1224,12 @@ var is = {
   addPhotosFilesMenuItem: ["B\xE6ta myndum og skr\xE1m vi\xF0"],
   copyResponse: ["Afrita svar"],
   modeLabels: ["Strax", "Mi\xF0lungs", "H\xE1tt", "Mj\xF6g h\xE1tt"],
+  modeOptions: {
+    instant: ["Strax"],
+    medium: ["Mi\xF0lungs"],
+    high: ["H\xE1tt"],
+    extraHigh: ["Mj\xF6g h\xE1tt"]
+  },
   modeOpenerExtra: ["Stillir\u2026"],
   tools: {
     web_search: ["Vefleit"],
@@ -1071,6 +1252,12 @@ var ka = {
   addPhotosFilesMenuItem: ["\u10E4\u10DD\u10E2\u10DD\u10D4\u10D1\u10D8\u10E1 \u10D3\u10D0 \u10E4\u10D0\u10D8\u10DA\u10D4\u10D1\u10D8\u10E1 \u10D3\u10D0\u10DB\u10D0\u10E2\u10D4\u10D1\u10D0"],
   copyResponse: ["\u10DE\u10D0\u10E1\u10E3\u10EE\u10D8\u10E1 \u10D9\u10DD\u10DE\u10D8\u10E0\u10D4\u10D1\u10D0"],
   modeLabels: ["\u10DB\u10E7\u10D8\u10E1\u10D8\u10D4\u10E0\u10D8", "\u10E1\u10D0\u10E8\u10E3\u10D0\u10DA\u10DD", "\u10DB\u10D0\u10E6\u10D0\u10DA\u10D8", "\u10EB\u10D0\u10DA\u10D8\u10D0\u10DC \u10DB\u10D0\u10E6\u10D0\u10DA\u10D8"],
+  modeOptions: {
+    instant: ["\u10DB\u10E7\u10D8\u10E1\u10D8\u10D4\u10E0\u10D8"],
+    medium: ["\u10E1\u10D0\u10E8\u10E3\u10D0\u10DA\u10DD"],
+    high: ["\u10DB\u10D0\u10E6\u10D0\u10DA\u10D8"],
+    extraHigh: ["\u10EB\u10D0\u10DA\u10D8\u10D0\u10DC \u10DB\u10D0\u10E6\u10D0\u10DA\u10D8"]
+  },
   modeOpenerExtra: ["\u10D9\u10DD\u10DC\u10E4\u10D8\u10D2\u10E3\u10E0\u10D8\u10E0\u10D4\u10D1\u10D0\u2026"],
   tools: {
     web_search: ["\u10D5\u10D4\u10D1\u10E8\u10D8 \u10EB\u10D8\u10D4\u10D1\u10D0"],
@@ -1093,6 +1280,12 @@ var kk = {
   addPhotosFilesMenuItem: ["\u0424\u043E\u0442\u043E\u0441\u0443\u0440\u0435\u0442\u0442\u0435\u0440 \u043C\u0435\u043D \u0444\u0430\u0439\u043B\u0434\u0430\u0440 \u049B\u043E\u0441\u0443"],
   copyResponse: ["\u0416\u0430\u0443\u0430\u043F\u0442\u044B \u043A\u04E9\u0448\u0456\u0440\u0443"],
   modeLabels: ["\u0416\u0435\u0434\u0435\u043B", "\u041E\u0440\u0442\u0430\u0448\u0430", "\u0416\u043E\u0493\u0430\u0440\u044B", "\u0410\u0441\u0430 \u0436\u043E\u0493\u0430\u0440\u044B"],
+  modeOptions: {
+    instant: ["\u0416\u0435\u0434\u0435\u043B"],
+    medium: ["\u041E\u0440\u0442\u0430\u0448\u0430"],
+    high: ["\u0416\u043E\u0493\u0430\u0440\u044B"],
+    extraHigh: ["\u0410\u0441\u0430 \u0436\u043E\u0493\u0430\u0440\u044B"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F\u043B\u0430\u0443..."],
   tools: {
     web_search: ["\u0406\u0437\u0434\u0435\u0443"],
@@ -1115,6 +1308,13 @@ var kn = {
   addPhotosFilesMenuItem: ["\u0CAB\u0CCB\u0C9F\u0CCA \u0CAE\u0CA4\u0CCD\u0CA4\u0CC1 \u0CAB\u0CC8\u0CB2\u0CCD\u200C\u0C97\u0CB3\u0CA8\u0CCD\u0CA8\u0CC1 \u0CB8\u0CC7\u0CB0\u0CBF\u0CB8\u0CBF"],
   copyResponse: ["\u0CAA\u0CCD\u0CB0\u0CA4\u0CBF\u0C95\u0CCD\u0CB0\u0CBF\u0CAF\u0CC6\u0CAF\u0CA8\u0CCD\u0CA8\u0CC1 \u0CA8\u0C95\u0CB2\u0CBF\u0CB8\u0CBF"],
   modeLabels: ["\u0CA4\u0C95\u0CCD\u0CB7\u0CA3", "\u0CAE\u0CA7\u0CCD\u0CAF\u0CAE", "\u0C89\u0CA8\u0CCD\u0CA8\u0CA4", "\u0C85\u0CA4\u0CBF \u0CB9\u0CC6\u0C9A\u0CCD\u0C9A\u0CC1", "\u0CAA\u0CCD\u0CB0\u0CCA"],
+  modeOptions: {
+    instant: ["\u0CA4\u0C95\u0CCD\u0CB7\u0CA3"],
+    medium: ["\u0CAE\u0CA7\u0CCD\u0CAF\u0CAE"],
+    high: ["\u0C89\u0CA8\u0CCD\u0CA8\u0CA4"],
+    extraHigh: ["\u0C85\u0CA4\u0CBF \u0CB9\u0CC6\u0C9A\u0CCD\u0C9A\u0CC1"],
+    pro: ["\u0CAA\u0CCD\u0CB0\u0CCA"]
+  },
   modeOpenerExtra: ["\u0C95\u0CBE\u0CA8\u0CCD\u0CAB\u0CBF\u0C97\u0CB0\u0CCD \u0CAE\u0CBE\u0CA1\u0CBF..."],
   tools: {
     web_search: ["\u0CB5\u0CC6\u0CAC\u0CCD \u0CB8\u0CB0\u0CCD\u0C9A\u0CCD"],
@@ -1137,6 +1337,12 @@ var ko = {
   addPhotosFilesMenuItem: ["\uC0AC\uC9C4 \uBC0F \uD30C\uC77C \uCD94\uAC00"],
   copyResponse: ["\uC751\uB2F5 \uBCF5\uC0AC"],
   modeLabels: ["\uC989\uC2DC", "\uC911\uAC04", "\uB192\uC74C", "\uB9E4\uC6B0 \uB192\uC74C"],
+  modeOptions: {
+    instant: ["\uC989\uC2DC"],
+    medium: ["\uC911\uAC04"],
+    high: ["\uB192\uC74C"],
+    extraHigh: ["\uB9E4\uC6B0 \uB192\uC74C"]
+  },
   modeOpenerExtra: ["\uAD6C\uC131\u2026"],
   tools: {
     web_search: ["\uC6F9 \uAC80\uC0C9"],
@@ -1159,6 +1365,13 @@ var lt = {
   addPhotosFilesMenuItem: ["Prid\u0117ti nuotrauk\u0173 ir fail\u0173"],
   copyResponse: ["Kopijuoti atsakym\u0105"],
   modeLabels: ["Momentinis", "Vidutinis", "Auk\u0161tas", "Ypa\u010D didelis", "Profesionalus"],
+  modeOptions: {
+    instant: ["Momentinis"],
+    medium: ["Vidutinis"],
+    high: ["Auk\u0161tas"],
+    extraHigh: ["Ypa\u010D didelis"],
+    pro: ["Profesionalus"]
+  },
   modeOpenerExtra: ["Konfig\u016Bruoti..."],
   tools: {
     web_search: ["\u017Diniatinklio paie\u0161ka"],
@@ -1181,6 +1394,13 @@ var zhHans = {
   addPhotosFilesMenuItem: ["\u6DFB\u52A0\u7167\u7247\u548C\u6587\u4EF6"],
   copyResponse: ["\u590D\u5236\u56DE\u590D"],
   modeLabels: ["\u6781\u901F", "\u5747\u8861", "\u9AD8\u7EA7", "\u8D85\u9AD8", "\u4E13\u4E1A"],
+  modeOptions: {
+    instant: ["\u6781\u901F"],
+    medium: ["\u5747\u8861"],
+    high: ["\u9AD8\u7EA7"],
+    extraHigh: ["\u8D85\u9AD8"],
+    pro: ["\u4E13\u4E1A"]
+  },
   modeOpenerExtra: ["\u914D\u7F6E\u2026"],
   tools: {
     web_search: ["\u7F51\u9875\u641C\u7D22"],
@@ -1203,6 +1423,12 @@ var ur = {
   addPhotosFilesMenuItem: ["\u062A\u0635\u0648\u06CC\u0631\u06CC\u06BA \u0627\u0648\u0631 \u0641\u0627\u0626\u0644\u06CC\u06BA \u0634\u0627\u0645\u0644 \u06A9\u0631\u06CC\u06BA"],
   copyResponse: ["\u062C\u0648\u0627\u0628 \u06A9\u0627\u067E\u06CC \u06A9\u0631\u06CC\u06BA"],
   modeLabels: ["\u0641\u0648\u0631\u06CC", "\u0627\u0648\u0633\u0637", "\u0627\u0639\u0644\u06CC\u0670", "\u0627\u0646\u062A\u06C1\u0627\u0626\u06CC \u0627\u0639\u0644\u06CC\u0670"],
+  modeOptions: {
+    instant: ["\u0641\u0648\u0631\u06CC"],
+    medium: ["\u0627\u0648\u0633\u0637"],
+    high: ["\u0627\u0639\u0644\u06CC\u0670"],
+    extraHigh: ["\u0627\u0646\u062A\u06C1\u0627\u0626\u06CC \u0627\u0639\u0644\u06CC\u0670"]
+  },
   modeOpenerExtra: ["\u06A9\u0646\u0641\u06CC\u06AF\u0631 \u06A9\u0631\u06CC\u06BA..."],
   tools: {
     web_search: ["\u0648\u06CC\u0628 \u067E\u0631 \u062A\u0644\u0627\u0634"],
@@ -1225,6 +1451,12 @@ var uk = {
   addPhotosFilesMenuItem: ["\u0414\u043E\u0434\u0430\u0442\u0438 \u0441\u0432\u0456\u0442\u043B\u0438\u043D\u0438 \u0442\u0430 \u0444\u0430\u0439\u043B\u0438"],
   copyResponse: ["\u041A\u043E\u043F\u0456\u044E\u0432\u0430\u0442\u0438 \u0432\u0456\u0434\u043F\u043E\u0432\u0456\u0434\u044C"],
   modeLabels: ["\u041C\u0438\u0442\u0442\u0454\u0432\u0438\u0439", "\u0421\u0435\u0440\u0435\u0434\u043D\u0456\u0439", "\u0412\u0438\u0441\u043E\u043A\u0438\u0439", "\u0414\u0443\u0436\u0435 \u0432\u0438\u0441\u043E\u043A\u0438\u0439"],
+  modeOptions: {
+    instant: ["\u041C\u0438\u0442\u0442\u0454\u0432\u0438\u0439"],
+    medium: ["\u0421\u0435\u0440\u0435\u0434\u043D\u0456\u0439"],
+    high: ["\u0412\u0438\u0441\u043E\u043A\u0438\u0439"],
+    extraHigh: ["\u0414\u0443\u0436\u0435 \u0432\u0438\u0441\u043E\u043A\u0438\u0439"]
+  },
   modeOpenerExtra: ["\u041D\u0430\u043B\u0430\u0448\u0442\u0443\u0432\u0430\u0442\u0438\u2026"],
   tools: {
     web_search: ["\u041F\u043E\u0448\u0443\u043A \u0432 \u0406\u043D\u0442\u0435\u0440\u043D\u0435\u0442\u0456"],
@@ -1247,6 +1479,12 @@ var ptBR = {
   addPhotosFilesMenuItem: ["Carregar fotos e arquivos"],
   copyResponse: ["Copiar resposta"],
   modeLabels: ["Instant\xE2neo", "M\xE9dio", "Alto", "Muito alta"],
+  modeOptions: {
+    instant: ["Instant\xE2neo"],
+    medium: ["M\xE9dio"],
+    high: ["Alto"],
+    extraHigh: ["Muito alta"]
+  },
   modeOpenerExtra: ["Configurar\u2026"],
   tools: {
     web_search: ["Busca na web"],
@@ -1269,6 +1507,12 @@ var ptPT = {
   addPhotosFilesMenuItem: ["Carregar fotos e ficheiros"],
   copyResponse: ["Copiar resposta"],
   modeLabels: ["Instant\xE2neo", "M\xE9dia", "Alta", "M\xE1ximo"],
+  modeOptions: {
+    instant: ["Instant\xE2neo"],
+    medium: ["M\xE9dia"],
+    high: ["Alta"],
+    extraHigh: ["M\xE1ximo"]
+  },
   modeOpenerExtra: ["Configurar..."],
   tools: {
     web_search: ["Procurar na web"],
@@ -1291,6 +1535,12 @@ var pl = {
   addPhotosFilesMenuItem: ["Prze\u015Blij zdj\u0119cia i pliki"],
   copyResponse: ["Kopiuj odpowied\u017A"],
   modeLabels: ["B\u0142yskawiczny", "\u015Aredni", "Zaawansowana", "Bardzo wysoki"],
+  modeOptions: {
+    instant: ["B\u0142yskawiczny"],
+    medium: ["\u015Aredni"],
+    high: ["Zaawansowana"],
+    extraHigh: ["Bardzo wysoki"]
+  },
   modeOpenerExtra: ["Skonfiguruj..."],
   tools: {
     web_search: ["Wyszukiwanie w sieci"],
@@ -1313,6 +1563,12 @@ var sk = {
   addPhotosFilesMenuItem: ["Nahra\u0165 fotografie a s\xFAbory"],
   copyResponse: ["Kop\xEDrova\u0165 odpove\u010F"],
   modeLabels: ["Okam\u017Eit\xE1", "Stredn\xE1", "Vysok\xE1", "Extra vysok\xE1"],
+  modeOptions: {
+    instant: ["Okam\u017Eit\xE1"],
+    medium: ["Stredn\xE1"],
+    high: ["Vysok\xE1"],
+    extraHigh: ["Extra vysok\xE1"]
+  },
   modeOpenerExtra: ["Konfigurova\u0165..."],
   tools: {
     web_search: ["Preh\u013Ead\xE1vaj web"],
@@ -1335,6 +1591,11 @@ var ro = {
   addPhotosFilesMenuItem: ["\xCEncarc\u0103 fotografii \u0219i fi\u0219iere"],
   copyResponse: ["Copiaz\u0103 r\u0103spunsul"],
   modeLabels: ["Mediu", "Ridicat", "Foarte ridicat\u0103"],
+  modeOptions: {
+    medium: ["Mediu"],
+    high: ["Ridicat"],
+    extraHigh: ["Foarte ridicat\u0103"]
+  },
   modeOpenerExtra: ["Configureaz\u0103..."],
   tools: {
     web_search: ["C\u0103utare pe internet"],
@@ -1357,6 +1618,12 @@ var nb = {
   addPhotosFilesMenuItem: ["Last opp bilder og filer"],
   copyResponse: ["Kopier svar"],
   modeLabels: ["\xD8yeblikkelig", "Middels", "H\xF8y", "Ekstra h\xF8y"],
+  modeOptions: {
+    instant: ["\xD8yeblikkelig"],
+    medium: ["Middels"],
+    high: ["H\xF8y"],
+    extraHigh: ["Ekstra h\xF8y"]
+  },
   modeOpenerExtra: ["Konfigurer \u2026"],
   tools: {
     web_search: ["Netts\xF8k"],
@@ -1379,6 +1646,13 @@ var ml = {
   addPhotosFilesMenuItem: ["\u0D2B\u0D4B\u0D1F\u0D4D\u0D1F\u0D4B\u0D15\u0D33\u0D41\u0D02 \u0D2B\u0D2F\u0D32\u0D41\u0D15\u0D33\u0D41\u0D02 \u0D05\u0D2A\u0D4D\u200C\u0D32\u0D4B\u0D21\u0D4D \u0D1A\u0D46\u0D2F\u0D4D\u0D2F\u0D41\u0D15"],
   copyResponse: ["\u0D2E\u0D31\u0D41\u0D2A\u0D1F\u0D3F \u0D15\u0D4B\u0D2A\u0D4D\u0D2A\u0D3F \u0D1A\u0D46\u0D2F\u0D4D\u0D2F\u0D41\u0D15"],
   modeLabels: ["\u0D24\u0D7D\u0D15\u0D4D\u0D37\u0D23\u0D02", "\u0D07\u0D1F\u0D24\u0D4D\u0D24\u0D30\u0D02", "\u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28\u0D24\u0D4D", "\u0D35\u0D33\u0D30\u0D46 \u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28", "\u0D2A\u0D4D\u0D30\u0D4B"],
+  modeOptions: {
+    instant: ["\u0D24\u0D7D\u0D15\u0D4D\u0D37\u0D23\u0D02"],
+    medium: ["\u0D07\u0D1F\u0D24\u0D4D\u0D24\u0D30\u0D02"],
+    high: ["\u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28\u0D24\u0D4D"],
+    extraHigh: ["\u0D35\u0D33\u0D30\u0D46 \u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28"],
+    pro: ["\u0D2A\u0D4D\u0D30\u0D4B"]
+  },
   modeOpenerExtra: ["\u0D15\u0D4B\u0D7A\u0D2B\u0D3F\u0D17\u0D7C \u0D1A\u0D46\u0D2F\u0D4D\u0D2F\u0D41\u0D15\u2026"],
   tools: {
     web_search: ["\u0D35\u0D46\u0D2C\u0D4D \u0D24\u0D3F\u0D30\u0D2F\u0D7D"],
@@ -1401,6 +1675,9 @@ var ru = {
   addPhotosFilesMenuItem: ["\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0444\u043E\u0442\u043E\u0433\u0440\u0430\u0444\u0438\u0438 \u0438 \u0444\u0430\u0439\u043B\u044B"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u043E\u0432\u0430\u0442\u044C \u043E\u0442\u0432\u0435\u0442"],
   modeLabels: ["\u041E\u0447\u0435\u043D\u044C \u0432\u044B\u0441\u043E\u043A\u0438\u0439"],
+  modeOptions: {
+    extraHigh: ["\u041E\u0447\u0435\u043D\u044C \u0432\u044B\u0441\u043E\u043A\u0438\u0439"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F..."],
   tools: {
     web_search: ["\u041F\u043E\u0438\u0441\u043A \u0432 \u0441\u0435\u0442\u0438"],
@@ -1423,6 +1700,13 @@ var pa = {
   addPhotosFilesMenuItem: ["\u0A2B\u0A3C\u0A4B\u0A1F\u0A4B\u0A06\u0A02 \u0A05\u0A24\u0A47 \u0A2B\u0A3C\u0A3E\u0A08\u0A32\u0A3E\u0A02 \u0A05\u0A71\u0A2A\u0A32\u0A4B\u0A21 \u0A15\u0A30\u0A4B"],
   copyResponse: ["\u0A1C\u0A35\u0A3E\u0A2C \u0A15\u0A3E\u0A2A\u0A40 \u0A15\u0A30\u0A4B"],
   modeLabels: ["\u0A24\u0A41\u0A30\u0A70\u0A24", "\u0A2E\u0A71\u0A27\u0A2E", "\u0A09\u0A71\u0A1A", "\u0A05\u0A24\u0A3F \u0A09\u0A71\u0A1A", "\u0A2A\u0A4D\u0A30\u0A4B"],
+  modeOptions: {
+    instant: ["\u0A24\u0A41\u0A30\u0A70\u0A24"],
+    medium: ["\u0A2E\u0A71\u0A27\u0A2E"],
+    high: ["\u0A09\u0A71\u0A1A"],
+    extraHigh: ["\u0A05\u0A24\u0A3F \u0A09\u0A71\u0A1A"],
+    pro: ["\u0A2A\u0A4D\u0A30\u0A4B"]
+  },
   modeOpenerExtra: ["\u0A15\u0A4C\u0A28\u0A2B\u0A3F\u0A17\u0A30..."],
   tools: {
     web_search: ["\u0A35\u0A48\u0A71\u0A2C \u0A16\u0A4B\u0A1C"],
@@ -1445,6 +1729,13 @@ var mr = {
   addPhotosFilesMenuItem: ["\u092B\u094B\u091F\u094B \u0906\u0923\u093F \u092B\u093E\u0907\u0932\u094D\u0938 \u0905\u092A\u0932\u094B\u0921 \u0915\u0930\u093E"],
   copyResponse: ["\u092A\u094D\u0930\u0924\u093F\u0938\u093E\u0926 \u0915\u0949\u092A\u0940 \u0915\u0930\u093E"],
   modeLabels: ["\u091D\u091F\u092A\u091F", "\u092E\u0927\u094D\u092F\u092E", "\u0909\u091A\u094D\u091A", "\u0905\u0924\u093F\u0909\u091A\u094D\u091A", "\u092A\u094D\u0930\u094B"],
+  modeOptions: {
+    instant: ["\u091D\u091F\u092A\u091F"],
+    medium: ["\u092E\u0927\u094D\u092F\u092E"],
+    high: ["\u0909\u091A\u094D\u091A"],
+    extraHigh: ["\u0905\u0924\u093F\u0909\u091A\u094D\u091A"],
+    pro: ["\u092A\u094D\u0930\u094B"]
+  },
   modeOpenerExtra: ["\u0915\u0949\u0928\u094D\u092B\u093F\u0917\u0930 \u0915\u0930\u093E..."],
   tools: {
     web_search: ["\u0935\u0947\u092C\u0935\u0930 \u0936\u094B\u0927"],
@@ -1467,6 +1758,12 @@ var tr = {
   addPhotosFilesMenuItem: ["Foto\u011Fraf ve dosya y\xFCkle"],
   copyResponse: ["Yan\u0131t\u0131 kopyala"],
   modeLabels: ["An\u0131nda", "Orta", "Y\xFCksek", "\xC7ok Y\xFCksek"],
+  modeOptions: {
+    instant: ["An\u0131nda"],
+    medium: ["Orta"],
+    high: ["Y\xFCksek"],
+    extraHigh: ["\xC7ok Y\xFCksek"]
+  },
   modeOpenerExtra: ["Yap\u0131land\u0131r..."],
   tools: {
     web_search: ["Web aramas\u0131"],
@@ -1489,6 +1786,12 @@ var sw = {
   addPhotosFilesMenuItem: ["Pakia picha na mafaili"],
   copyResponse: ["Nakili jibu"],
   modeLabels: ["Papo hapo", "Wastani", "Juu", "Juu Zaidi"],
+  modeOptions: {
+    instant: ["Papo hapo"],
+    medium: ["Wastani"],
+    high: ["Juu"],
+    extraHigh: ["Juu Zaidi"]
+  },
   modeOpenerExtra: ["Sanidi..."],
   tools: {
     web_search: ["Utafutaji wa wavuti"],
@@ -1511,6 +1814,13 @@ var te = {
   addPhotosFilesMenuItem: ["\u0C2B\u0C4B\u0C1F\u0C4B\u0C32\u0C41 & \u0C2B\u0C48\u0C32\u0C4D\u200C\u0C32\u0C28\u0C41 \u0C05\u0C2A\u0C4D\u200C\u0C32\u0C4B\u0C21\u0C4D \u0C1A\u0C47\u0C2F\u0C02\u0C21\u0C3F"],
   copyResponse: ["\u0C2A\u0C4D\u0C30\u0C24\u0C3F\u0C38\u0C4D\u0C2A\u0C02\u0C26\u0C28\u0C28\u0C41 \u0C15\u0C3E\u0C2A\u0C40 \u0C1A\u0C47\u0C2F\u0C02\u0C21\u0C3F"],
   modeLabels: ["\u0C24\u0C15\u0C4D\u0C37\u0C23\u0C02", "\u0C2E\u0C27\u0C4D\u0C2F\u0C38\u0C4D\u0C25", "\u0C05\u0C27\u0C3F\u0C15", "\u0C05\u0C24\u0C4D\u0C2F\u0C27\u0C3F\u0C15", "\u0C2A\u0C4D\u0C30\u0C4B"],
+  modeOptions: {
+    instant: ["\u0C24\u0C15\u0C4D\u0C37\u0C23\u0C02"],
+    medium: ["\u0C2E\u0C27\u0C4D\u0C2F\u0C38\u0C4D\u0C25"],
+    high: ["\u0C05\u0C27\u0C3F\u0C15"],
+    extraHigh: ["\u0C05\u0C24\u0C4D\u0C2F\u0C27\u0C3F\u0C15"],
+    pro: ["\u0C2A\u0C4D\u0C30\u0C4B"]
+  },
   modeOpenerExtra: ["\u0C15\u0C3E\u0C28\u0C4D\u0C2B\u0C3F\u0C17\u0C30\u0C4D \u0C1A\u0C47\u0C2F\u0C02\u0C21\u0C3F"],
   tools: {
     web_search: ["\u0C35\u0C46\u0C2C\u0C4D\u200C\u0C32\u0C4B \u0C35\u0C46\u0C24\u0C15\u0C21\u0C02"],
@@ -1553,6 +1863,12 @@ var th = {
   addPhotosFilesMenuItem: ["\u0E2D\u0E31\u0E1B\u0E42\u0E2B\u0E25\u0E14\u0E23\u0E39\u0E1B\u0E41\u0E25\u0E30\u0E44\u0E1F\u0E25\u0E4C"],
   copyResponse: ["\u0E04\u0E31\u0E14\u0E25\u0E2D\u0E01\u0E04\u0E33\u0E15\u0E2D\u0E1A"],
   modeLabels: ["\u0E17\u0E31\u0E19\u0E17\u0E35", "\u0E1B\u0E32\u0E19\u0E01\u0E25\u0E32\u0E07", "\u0E2A\u0E39\u0E07", "\u0E2A\u0E39\u0E07\u0E21\u0E32\u0E01"],
+  modeOptions: {
+    instant: ["\u0E17\u0E31\u0E19\u0E17\u0E35"],
+    medium: ["\u0E1B\u0E32\u0E19\u0E01\u0E25\u0E32\u0E07"],
+    high: ["\u0E2A\u0E39\u0E07"],
+    extraHigh: ["\u0E2A\u0E39\u0E07\u0E21\u0E32\u0E01"]
+  },
   modeOpenerExtra: ["\u0E01\u0E33\u0E2B\u0E19\u0E14\u0E04\u0E48\u0E32..."],
   tools: {
     web_search: ["\u0E04\u0E49\u0E19\u0E2B\u0E32\u0E40\u0E27\u0E47\u0E1A"],
@@ -1575,6 +1891,13 @@ var bn = {
   addPhotosFilesMenuItem: ["\u09AB\u099F\u09CB \u098F\u09AC\u0982 \u09AB\u09BE\u0987\u09B2 \u0986\u09AA\u09B2\u09CB\u09A1 \u0995\u09B0\u09C1\u09A8"],
   copyResponse: ["\u0989\u09A4\u09CD\u09A4\u09B0 \u0995\u09AA\u09BF \u0995\u09B0\u09C1\u09A8"],
   modeLabels: ["\u09A4\u09BE\u09CE\u0995\u09CD\u09B7\u09A3\u09BF\u0995", "\u09AE\u09BE\u099D\u09BE\u09B0\u09BF", "\u0989\u099A\u09CD\u099A", "\u0985\u09A4\u09BF \u0989\u099A\u09CD\u099A", "\u09AA\u09CD\u09B0\u09CB"],
+  modeOptions: {
+    instant: ["\u09A4\u09BE\u09CE\u0995\u09CD\u09B7\u09A3\u09BF\u0995"],
+    medium: ["\u09AE\u09BE\u099D\u09BE\u09B0\u09BF"],
+    high: ["\u0989\u099A\u09CD\u099A"],
+    extraHigh: ["\u0985\u09A4\u09BF \u0989\u099A\u09CD\u099A"],
+    pro: ["\u09AA\u09CD\u09B0\u09CB"]
+  },
   modeOpenerExtra: ["\u0995\u09A8\u09AB\u09BF\u0997\u09BE\u09B0 \u0995\u09B0\u09C1\u09A8..."],
   tools: {
     web_search: ["\u0993\u09AF\u09BC\u09C7\u09AC \u09B8\u09A8\u09CD\u09A7\u09BE\u09A8"],
@@ -1597,6 +1920,12 @@ var ms = {
   addPhotosFilesMenuItem: ["Muat naik foto & fail"],
   copyResponse: ["Salin tindak balas"],
   modeLabels: ["Segera", "Sederhana", "Tinggi", "Sangat Tinggi"],
+  modeOptions: {
+    instant: ["Segera"],
+    medium: ["Sederhana"],
+    high: ["Tinggi"],
+    extraHigh: ["Sangat Tinggi"]
+  },
   modeOpenerExtra: ["Konfigurasikan\u2026"],
   tools: {
     web_search: ["Carian web"],
@@ -1619,6 +1948,12 @@ var so = {
   addPhotosFilesMenuItem: ["Soo geli sawirada & faylasha"],
   copyResponse: ["Koobiyee jawaabta"],
   modeLabels: ["Degdeg", "Dhexdhexaad", "Sare", "Aad u sarreeya"],
+  modeOptions: {
+    instant: ["Degdeg"],
+    medium: ["Dhexdhexaad"],
+    high: ["Sare"],
+    extraHigh: ["Aad u sarreeya"]
+  },
   modeOpenerExtra: ["Ku xidh..."],
   tools: {
     web_search: ["Raadi shakabada"],
@@ -1641,6 +1976,12 @@ var nl = {
   addPhotosFilesMenuItem: ["Foto's en bestanden uploaden"],
   copyResponse: ["Reactie kopi\xEBren"],
   modeLabels: ["Direct", "Gemiddeld", "Hoog", "Extra hoog"],
+  modeOptions: {
+    instant: ["Direct"],
+    medium: ["Gemiddeld"],
+    high: ["Hoog"],
+    extraHigh: ["Extra hoog"]
+  },
   modeOpenerExtra: ["Configureren..."],
   tools: {
     web_search: ["Zoeken op internet"],
@@ -1663,6 +2004,12 @@ var sv = {
   addPhotosFilesMenuItem: ["Ladda upp foton och filer"],
   copyResponse: ["Kopiera svar"],
   modeLabels: ["Direkt", "Balanserad", "H\xF6g", "Extra h\xF6g"],
+  modeOptions: {
+    instant: ["Direkt"],
+    medium: ["Balanserad"],
+    high: ["H\xF6g"],
+    extraHigh: ["Extra h\xF6g"]
+  },
   modeOpenerExtra: ["Konfigurera \u2026"],
   tools: {
     web_search: ["Webbs\xF6kning"],
@@ -1685,6 +2032,12 @@ var lv = {
   addPhotosFilesMenuItem: ["Aug\u0161upiel\u0101d\u0113t foto un failus"],
   copyResponse: ["Kop\u0113t atbildi"],
   modeLabels: ["T\u016Bl\u012Bt\u0113js", "Vid\u0113js", "Augsts", "\u013Boti augsts"],
+  modeOptions: {
+    instant: ["T\u016Bl\u012Bt\u0113js"],
+    medium: ["Vid\u0113js"],
+    high: ["Augsts"],
+    extraHigh: ["\u013Boti augsts"]
+  },
   modeOpenerExtra: ["Konfigur\u0113t..."],
   tools: {
     web_search: ["Mekl\u0113\u0161ana t\u012Bmekl\u012B"],
@@ -1707,6 +2060,11 @@ var mk = {
   addPhotosFilesMenuItem: ["\u041F\u043E\u0441\u0442\u0430\u0432\u0438 \u0444\u043E\u0442\u043E\u0433\u0440\u0430\u0444\u0438\u0438 \u0438 \u0434\u0430\u0442\u043E\u0442\u0435\u043A\u0438"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u0430\u0458 \u043E\u0434\u0433\u043E\u0432\u043E\u0440"],
   modeLabels: ["\u0421\u0440\u0435\u0434\u043D\u043E", "\u0412\u0438\u0441\u043E\u043A\u043E", "\u041C\u043D\u043E\u0433\u0443 \u0432\u0438\u0441\u043E\u043A\u043E"],
+  modeOptions: {
+    medium: ["\u0421\u0440\u0435\u0434\u043D\u043E"],
+    high: ["\u0412\u0438\u0441\u043E\u043A\u043E"],
+    extraHigh: ["\u041C\u043D\u043E\u0433\u0443 \u0432\u0438\u0441\u043E\u043A\u043E"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0438\u0440\u0430\u0458..."],
   tools: {
     web_search: ["\u041F\u0440\u0435\u0431\u0430\u0440\u0443\u0432\u0430\u045A\u0435 \u043D\u0430 \u0438\u043D\u0442\u0435\u0440\u043D\u0435\u0442"],
@@ -1729,6 +2087,12 @@ var sq = {
   addPhotosFilesMenuItem: ["Ngarko foto dhe skedar\xEB"],
   copyResponse: ["Kopjo p\xEBrgjigjen"],
   modeLabels: ["I menj\xEBhersh\xEBm", "Mesatar", "Lart\xEB", "Shum\xEB i lart\xEB"],
+  modeOptions: {
+    instant: ["I menj\xEBhersh\xEBm"],
+    medium: ["Mesatar"],
+    high: ["Lart\xEB"],
+    extraHigh: ["Shum\xEB i lart\xEB"]
+  },
   modeOpenerExtra: ["Konfiguro..."],
   tools: {
     web_search: ["K\xEBrkim n\xEB ueb"],
@@ -1751,6 +2115,12 @@ var sl = {
   addPhotosFilesMenuItem: ["Nalo\u017Ei fotografije in datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Takoj", "Srednja", "Visoka", "Zelo visoko"],
+  modeOptions: {
+    instant: ["Takoj"],
+    medium: ["Srednja"],
+    high: ["Visoka"],
+    extraHigh: ["Zelo visoko"]
+  },
   modeOpenerExtra: ["Konfiguracija \u2026"],
   tools: {
     web_search: ["Iskanje po spletu"],
@@ -1773,6 +2143,9 @@ var sr = {
   addPhotosFilesMenuItem: ["\u041E\u0442\u043F\u0440\u0435\u043C\u0438 \u0444\u043E\u0442\u043E\u0433\u0440\u0430\u0444\u0438\u0458\u0435 \u0438 \u0434\u0430\u0442\u043E\u0442\u0435\u043A\u0435"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u0430\u0458 \u043E\u0434\u0433\u043E\u0432\u043E\u0440"],
   modeLabels: ["\u0412\u0435\u043E\u043C\u0430 \u0432\u0438\u0441\u043E\u043A\u043E"],
+  modeOptions: {
+    extraHigh: ["\u0412\u0435\u043E\u043C\u0430 \u0432\u0438\u0441\u043E\u043A\u043E"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0438\u0448\u0438..."],
   tools: {
     web_search: ["\u041F\u0440\u0435\u0442\u0440\u0430\u0433\u0430 \u0432\u0435\u0431\u0430"],
@@ -1795,6 +2168,13 @@ var mn = {
   addPhotosFilesMenuItem: ["\u0417\u0443\u0440\u0430\u0433 \u0431\u0430 \u0444\u0430\u0439\u043B \u0431\u0430\u0439\u0440\u0448\u0443\u0443\u043B\u0430\u0445"],
   copyResponse: ["\u0425\u0430\u0440\u0438\u0443\u043B\u0442 \u0445\u0443\u0443\u043B\u0430\u0445"],
   modeLabels: ["\u0428\u0443\u0443\u0440\u0445\u0430\u0439", "\u0414\u0443\u043D\u0434", "\u04E8\u043D\u0434\u04E9\u0440", "\u041C\u0430\u0448 \u04E9\u043D\u0434\u04E9\u0440", "\u041F\u0440\u043E"],
+  modeOptions: {
+    instant: ["\u0428\u0443\u0443\u0440\u0445\u0430\u0439"],
+    medium: ["\u0414\u0443\u043D\u0434"],
+    high: ["\u04E8\u043D\u0434\u04E9\u0440"],
+    extraHigh: ["\u041C\u0430\u0448 \u04E9\u043D\u0434\u04E9\u0440"],
+    pro: ["\u041F\u0440\u043E"]
+  },
   modeOpenerExtra: ["\u0422\u043E\u0445\u0438\u0440\u0443\u0443\u043B\u0430\u0445..."],
   tools: {
     web_search: ["\u0412\u0435\u0431 \u0445\u0430\u0439\u043B\u0442"],
@@ -1817,6 +2197,12 @@ var my = {
   addPhotosFilesMenuItem: ["\u1013\u102C\u1010\u103A\u1015\u102F\u1036\u1019\u103B\u102C\u1038\u1014\u103E\u1004\u1037\u103A \u1016\u102D\u102F\u1004\u103A\u1019\u103B\u102C\u1038\u1000\u102D\u102F \u1010\u1004\u103A\u1015\u102B"],
   copyResponse: ["\u1010\u102F\u1036\u1037\u1015\u103C\u1014\u103A\u1019\u103E\u102F \u1000\u1030\u1038\u101A\u1030\u101B\u1014\u103A"],
   modeLabels: ["\u1001\u103B\u1000\u103A\u1001\u103B\u1004\u103A\u1038", "\u1021\u101C\u101A\u103A\u1021\u101C\u1010\u103A", "\u1019\u103C\u1004\u1037\u103A", "\u1021\u101C\u103D\u1014\u103A\u1019\u103C\u1004\u1037\u103A"],
+  modeOptions: {
+    instant: ["\u1001\u103B\u1000\u103A\u1001\u103B\u1004\u103A\u1038"],
+    medium: ["\u1021\u101C\u101A\u103A\u1021\u101C\u1010\u103A"],
+    high: ["\u1019\u103C\u1004\u1037\u103A"],
+    extraHigh: ["\u1021\u101C\u103D\u1014\u103A\u1019\u103C\u1004\u1037\u103A"]
+  },
   modeOpenerExtra: ["\u1015\u103C\u102F\u1015\u103C\u1004\u103A\u1019\u103D\u1019\u103A\u1038\u1019\u1036\u101B\u1014\u103A"],
   tools: {
     web_search: ["\u101D\u1018\u103A\u101B\u103E\u102C\u1016\u103D\u1031\u101B\u1014\u103A"],
@@ -1839,6 +2225,13 @@ var ta = {
   addPhotosFilesMenuItem: ["\u0BAA\u0B9F\u0B99\u0BCD\u0B95\u0BB3\u0BCD \u0BAE\u0BB1\u0BCD\u0BB1\u0BC1\u0BAE\u0BCD \u0B83\u0BAA\u0BC8\u0BB2\u0BCD\u0B95\u0BB3\u0BC8\u0BAA\u0BCD \u0BAA\u0BA4\u0BBF\u0BB5\u0BC7\u0BB1\u0BCD\u0BB1\u0BC1"],
   copyResponse: ["\u0BAA\u0BA4\u0BBF\u0BB2\u0BC8 \u0BA8\u0B95\u0BB2\u0BC6\u0B9F\u0BC1\u0B95\u0BCD\u0B95\u0BB2\u0BBE\u0BAE\u0BCD"],
   modeLabels: ["\u0B89\u0B9F\u0BA9\u0B9F\u0BBF", "\u0BA8\u0B9F\u0BC1\u0BA4\u0BCD\u0BA4\u0BB0", "\u0B89\u0BAF\u0BB0\u0BCD", "\u0BAE\u0BBF\u0B95 \u0B89\u0BAF\u0BB0\u0BCD\u0BB5\u0BC1", "\u0BAA\u0BCD\u0BB0\u0BCB"],
+  modeOptions: {
+    instant: ["\u0B89\u0B9F\u0BA9\u0B9F\u0BBF"],
+    medium: ["\u0BA8\u0B9F\u0BC1\u0BA4\u0BCD\u0BA4\u0BB0"],
+    high: ["\u0B89\u0BAF\u0BB0\u0BCD"],
+    extraHigh: ["\u0BAE\u0BBF\u0B95 \u0B89\u0BAF\u0BB0\u0BCD\u0BB5\u0BC1"],
+    pro: ["\u0BAA\u0BCD\u0BB0\u0BCB"]
+  },
   modeOpenerExtra: ["\u0B95\u0B9F\u0BCD\u0B9F\u0BAE\u0BC8\u0B95\u0BCD\u0B95\u0BB5\u0BC1\u0BAE\u0BCD..."],
   tools: {
     web_search: ["\u0B87\u0BA3\u0BC8\u0BAF \u0BA4\u0BC7\u0B9F\u0BB2\u0BCD"],
@@ -1852,6 +2245,16 @@ var ta = {
 // src/dom/locale/index.ts
 var locales = [en, de, esES, frFR, zhHK, zhTW, ja, it, vi, am, ar, bg, bs, ca, cs, da, el, es419, et, fa, fi, frCA, gu, hi, hr, hu, hy, id, is, ka, kk, kn, ko, lt, zhHans, ur, uk, ptBR, ptPT, pl, sk, ro, nb, ml, ru, pa, mr, tr, sw, te, tl, th, bn, ms, so, nl, sv, lv, mk, sq, sl, sr, mn, my, ta];
 var TOOL_IDS = ["web_search", "deep_research", "create_image"];
+var MODE_OPTION_IDS = [
+  "latest",
+  "instant",
+  "thinking",
+  "extended",
+  "medium",
+  "high",
+  "extraHigh",
+  "pro"
+];
 function flattenKey(localeList, key) {
   const seen = /* @__PURE__ */ new Set();
   const result = [];
@@ -1875,6 +2278,24 @@ function flattenTool(localeList, toolId) {
     const tools = locale["tools"];
     if (tools === void 0 || tools === null) continue;
     const value = tools[toolId];
+    if (value === void 0 || value === null) continue;
+    const candidates = typeof value === "string" ? [value] : value;
+    for (const candidate of candidates) {
+      if (candidate.length > 0 && !seen.has(candidate)) {
+        seen.add(candidate);
+        result.push(candidate);
+      }
+    }
+  }
+  return result;
+}
+function flattenModeOption(localeList, optionId) {
+  const seen = /* @__PURE__ */ new Set();
+  const result = [];
+  for (const locale of localeList) {
+    const modeOptions = locale["modeOptions"];
+    if (modeOptions === void 0 || modeOptions === null) continue;
+    const value = modeOptions[optionId];
     if (value === void 0 || value === null) continue;
     const candidates = typeof value === "string" ? [value] : value;
     for (const candidate of candidates) {
@@ -1919,8 +2340,12 @@ var builtLabels = Object.fromEntries(
 var builtTools = Object.fromEntries(
   TOOL_IDS.map((id2) => [id2, flattenTool(locales, id2)])
 );
+var builtModeOptions = Object.fromEntries(
+  MODE_OPTION_IDS.map((id2) => [id2, flattenModeOption(locales, id2)])
+);
 var localeLabels = {
   ...builtLabels,
+  modeOptions: builtModeOptions,
   tools: builtTools
 };
 function escapeRegExp(value) {
@@ -1950,8 +2375,17 @@ function localGuardTimeout(timeoutMs, capMs) {
 
 // src/browser/page-state.ts
 function parseConversationId(url) {
-  const match = /\/c\/([A-Za-z0-9-]+)/.exec(url);
-  return match?.[1];
+  let parsed;
+  try {
+    parsed = new URL(url, "https://chatgpt.com");
+  } catch {
+    return void 0;
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments[0] !== "c" || segments[1] === void 0 || segments[1].length === 0) {
+    return void 0;
+  }
+  return segments[1];
 }
 async function readPageState(page) {
   const rawUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
@@ -3983,7 +4417,7 @@ async function contextFromPage(page, partial = {}) {
     return { timestamp: (/* @__PURE__ */ new Date()).toISOString(), ...partial };
   }
   const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => partial.url) : partial.url;
-  const title = typeof page.title === "function" ? await page.title().catch(() => void 0) : partial.title;
+  const title = typeof page.title === "function" ? await withTimeout2(page.title(), 1e3, "Timed out while reading page title.").catch(() => partial.title) : partial.title;
   const [turnCount, assistantTurnCount] = await Promise.all([
     withTimeout2(countPageMessages(page), 1e3, "Timed out while counting page messages.").catch(() => partial.turnCount),
     withTimeout2(countPageMessages(page, "assistant"), 1e3, "Timed out while counting assistant messages.").catch(() => partial.assistantTurnCount)
@@ -4031,8 +4465,51 @@ async function bootstrap(env, args = {}) {
   }
 }
 
-// src/commands/threads.ts
+// src/commands/conversation.ts
 var CHATGPT_HOME2 = "https://chatgpt.com/";
+async function ensureConversationTarget(page, target, options) {
+  const targetUrl = absoluteConversationUrl(target);
+  const expectedConversationId = parseConversationId(targetUrl);
+  const currentUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+  if (expectedConversationId !== void 0 && parseConversationId(typeof currentUrl === "string" ? currentUrl : "") === expectedConversationId) {
+    await waitForConversationHydrated(page, options.timeoutMs, expectedConversationId);
+    return ensureResult(false, targetUrl, expectedConversationId);
+  }
+  await page.goto?.(targetUrl, { waitUntil: "domcontentloaded", timeout: options.timeoutMs });
+  await waitForConversationHydrated(page, options.timeoutMs, expectedConversationId);
+  return ensureResult(true, targetUrl, expectedConversationId);
+}
+async function waitForConversationHydrated(page, timeoutMs, expectedConversationId) {
+  const started = Date.now();
+  do {
+    const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+    const urlMatches2 = expectedConversationId === void 0 || parseConversationId(typeof url === "string" ? url : "") === expectedConversationId;
+    const count = await countPageMessages(page).catch(() => 0);
+    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => void 0);
+    const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
+    if (urlMatches2 && ((latestAssistantText?.trim().length ?? 0) > 0 || count > 0 && title.length > 0 && title !== "ChatGPT")) {
+      await page.waitForTimeout?.(250);
+      return;
+    }
+    await page.waitForTimeout?.(500);
+  } while (Date.now() - started < timeoutMs);
+}
+function absoluteConversationUrl(target) {
+  if (target.href !== void 0 && target.href.startsWith("/")) {
+    return new URL(target.href, CHATGPT_HOME2).toString();
+  }
+  return target.href ?? target.url;
+}
+function ensureResult(navigated, targetUrl, expectedConversationId) {
+  const result = { navigated, targetUrl };
+  if (expectedConversationId !== void 0) {
+    result.expectedConversationId = expectedConversationId;
+  }
+  return result;
+}
+
+// src/commands/threads.ts
+var CHATGPT_HOME3 = "https://chatgpt.com/";
 function extractThreadSearchResultsFromHtml(html) {
   const anchors = html.matchAll(/<a\b(?<attrs>[^>]*\bhref=["'](?<href>\/c\/[^"']+)["'][^>]*)>(?<body>[\s\S]*?)<\/a>/gi);
   const results = [];
@@ -4093,7 +4570,7 @@ async function newThread(env, args = {}) {
     try {
       await newChatButton(page).click?.();
     } catch {
-      await page.goto?.(CHATGPT_HOME2, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+      await page.goto?.(CHATGPT_HOME3, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
     }
     await page.waitForTimeout?.(500);
     const state = await readPageState(page);
@@ -4122,12 +4599,7 @@ async function openThread(env, args, previousResults) {
         context: await contextFromPage(page)
       };
     }
-    if (target.href !== void 0 && target.href.startsWith("/")) {
-      await page.goto?.(new URL(target.href, CHATGPT_HOME2).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
-    } else {
-      await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
-    }
-    await waitForThreadHydrated(page, args.timeoutMs ?? 3e4, parseConversationId(target.url));
+    await ensureConversationTarget(page, target, { timeoutMs: args.timeoutMs ?? 3e4 });
     const state = await readPageState(page);
     return resultOk(
       openThreadData(state.url, state.conversationId, state.title ?? target.title),
@@ -4148,21 +4620,21 @@ async function resolveOpenTarget(env, args, previousResults) {
     return { url: args.url };
   }
   if (args.conversationId !== void 0) {
-    return { url: new URL(`/c/${args.conversationId}`, CHATGPT_HOME2).toString() };
+    return { url: new URL(`/c/${args.conversationId}`, CHATGPT_HOME3).toString() };
   }
   if (args.fromStep !== void 0 && previousResults !== void 0) {
     const previous = previousResults.get(args.fromStep);
     const data = previous?.data;
     const selected = selectSearchResult(data?.results ?? [], args.select ?? "first");
     if (selected !== void 0) {
-      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME2).toString(), title: selected.title };
+      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME3).toString(), title: selected.title };
     }
   }
   if (args.title !== void 0) {
     const search = await searchThreads(env, { query: args.title, limit: 10 });
     const selected = selectSearchResult(search.data?.results ?? [], { title: args.title }) ?? search.data?.results[0];
     if (selected !== void 0) {
-      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME2).toString(), title: selected.title };
+      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME3).toString(), title: selected.title };
     }
   }
   return void 0;
@@ -4295,22 +4767,6 @@ function filterResultsByQuery(results, query) {
     return haystack.includes(wanted) || wanted.includes(normalizeForMatch(result.title));
   });
 }
-async function waitForThreadHydrated(page, timeoutMs, expectedConversationId) {
-  const started = Date.now();
-  await page.waitForTimeout?.(1e3);
-  while (Date.now() - started < timeoutMs) {
-    const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
-    const urlMatches2 = expectedConversationId === void 0 || url.includes(expectedConversationId);
-    const count = await countPageMessages(page).catch(() => 0);
-    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => void 0);
-    const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
-    if (urlMatches2 && ((latestAssistantText?.trim().length ?? 0) > 0 || count > 0 && title.length > 0 && title !== "ChatGPT")) {
-      await page.waitForTimeout?.(250);
-      return;
-    }
-    await page.waitForTimeout?.(500);
-  }
-}
 
 // src/dom/generation-state.ts
 var EMPTY_GENERATION_STATE = {
@@ -4403,6 +4859,22 @@ function generationStateFromText(text) {
   };
 }
 
+// src/commands/deadline.ts
+function createDeadline(timeoutMs, startedAtMs = Date.now()) {
+  const safeTimeoutMs = Math.max(0, timeoutMs);
+  return {
+    startedAtMs,
+    timeoutMs: safeTimeoutMs,
+    expiresAtMs: startedAtMs + safeTimeoutMs
+  };
+}
+function remainingMs(deadline, nowMs = Date.now()) {
+  return Math.max(0, deadline.expiresAtMs - nowMs);
+}
+function childTimeoutMs(deadline, capMs, nowMs = Date.now()) {
+  return Math.max(0, Math.min(Math.max(0, capMs), remainingMs(deadline, nowMs)));
+}
+
 // src/commands/output.ts
 function commandOutputText(data) {
   if (!isRecord(data)) return void 0;
@@ -4428,6 +4900,69 @@ function withCommandOutputText(result) {
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+// src/commands/probes.ts
+function createSingleFlightProbe(name, probe) {
+  let inFlight;
+  return async (arg, deadline, options) => {
+    if (inFlight !== void 0) {
+      return {
+        ok: false,
+        skipped: true,
+        warnings: [`Skipped ${name} DOM probe because previous browser-side work is still in flight.`]
+      };
+    }
+    const timeoutMs = childTimeoutMs(deadline, options.timeoutMs);
+    if (timeoutMs <= 0) {
+      return {
+        ok: false,
+        timedOut: true,
+        warnings: [`Skipped ${name} DOM probe because no deadline budget remained.`]
+      };
+    }
+    const current = probe(arg);
+    inFlight = current;
+    current.finally(() => {
+      if (inFlight === current) {
+        inFlight = void 0;
+      }
+    }).catch(() => void 0);
+    let timeout;
+    try {
+      const value = await Promise.race([
+        current,
+        new Promise((_resolve, reject) => {
+          timeout = setTimeout(() => reject(new ProbeTimeoutError(timeoutMs)), timeoutMs);
+        })
+      ]);
+      return { ok: true, value, warnings: [] };
+    } catch (error) {
+      if (error instanceof ProbeTimeoutError) {
+        return {
+          ok: false,
+          timedOut: true,
+          warnings: [`Timed out waiting ${timeoutMs}ms for ${name} DOM probe; this stopped SDK waiting but did not cancel browser-side work.`]
+        };
+      }
+      return {
+        ok: false,
+        warnings: [`${name} DOM probe failed: ${error instanceof Error ? error.message : String(error)}`]
+      };
+    } finally {
+      if (timeout !== void 0) {
+        clearTimeout(timeout);
+      }
+    }
+  };
+}
+var ProbeTimeoutError = class extends Error {
+  constructor(timeoutMs) {
+    super(`Probe timed out after ${timeoutMs}ms.`);
+    this.timeoutMs = timeoutMs;
+    this.name = "ProbeTimeoutError";
+  }
+  timeoutMs;
+};
 
 // src/commands/messages.ts
 function isResponseComplete(snapshot) {
@@ -4666,21 +5201,20 @@ async function waitForMessage(env, args = {}) {
   const stableMs = args.stableMs ?? (args.mode === "deep_research" ? 1e4 : 2e3);
   const pollMs = args.pollMs ?? 750;
   const started = Date.now();
+  const deadline = createDeadline(timeoutMs, started);
+  const probeTimeoutMs = Math.max(50, Math.min(1e3, Math.max(pollMs, Math.floor(timeoutMs / 4))));
+  const waitWarnings = /* @__PURE__ */ new Set();
+  const assistantProgressProbe = createSingleFlightProbe("assistant progress", readAssistantProgressSnapshot);
+  const pageStateProbe = createSingleFlightProbe("page state", readPageState);
+  const generationStateProbe = createSingleFlightProbe("assistant generation state", readAssistantGenerationState);
+  const responseActionsProbe = createSingleFlightProbe("assistant response actions", latestAssistantTurnHasResponseActions);
   let lastTargetText = "";
   let lastChangedAt = Date.now();
   let latestAssistantCount = await countPageMessages(page, "assistant").catch(() => 0);
   while (Date.now() - started < timeoutMs) {
-    const state = await readPageState(page).catch(() => void 0);
-    if (state?.blocker !== void 0 && state.blocker.kind !== "modal") {
-      return {
-        ok: false,
-        status: "blocked",
-        warnings: [],
-        blocker: state.blocker,
-        context: await contextFromPage(page)
-      };
-    }
-    const progress = await readAssistantProgressSnapshot(page).catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
+    const progressResult = await assistantProgressProbe(page, deadline, { timeoutMs: probeTimeoutMs });
+    addWarnings(waitWarnings, progressResult.warnings);
+    const progress = await progressSnapshotFromProbeResult(page, progressResult, latestAssistantCount);
     latestAssistantCount = progress.assistantTurnCount;
     const targetReached = waitTargetReached(args, progress);
     const latestText = targetReached ? normalizeWhitespace(progress.latestText ?? "") : "";
@@ -4688,12 +5222,22 @@ async function waitForMessage(env, args = {}) {
       lastTargetText = latestText;
       lastChangedAt = Date.now();
     }
+    const state = await pageStateFromProbe(pageStateProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings);
+    if (state?.blocker !== void 0 && state.blocker.kind !== "modal") {
+      return {
+        ok: false,
+        status: "blocked",
+        warnings: [...waitWarnings],
+        blocker: state.blocker,
+        context: await contextFromPage(page)
+      };
+    }
     const snapshot = {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      generation: await readAssistantGenerationState(page),
-      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
+      generation: await generationStateFromProbe(generationStateProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings),
+      hasResponseActions: await responseActionsFromProbe(responseActionsProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings)
     };
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
       return withCommandOutputText({
@@ -4706,6 +5250,7 @@ async function waitForMessage(env, args = {}) {
           elapsedMs: Date.now() - started
         },
         warnings: [
+          ...waitWarnings,
           "ChatGPT generation appears to have been stopped or interrupted before completion.",
           ...snapshot.generation.signals.map((signal) => `Generation state signal: ${signal}`)
         ],
@@ -4715,7 +5260,8 @@ async function waitForMessage(env, args = {}) {
     if (targetReached && isResponseComplete(snapshot)) {
       return withCommandOutputText(resultOk(
         { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
-        await contextFromPage(page)
+        await contextFromPage(page),
+        [...waitWarnings]
       ));
     }
     await sleep(page, pollMs);
@@ -4730,14 +5276,14 @@ async function waitForMessage(env, args = {}) {
         assistantTurnCount: latestAssistantCount,
         elapsedMs: Date.now() - started
       },
-      warnings: ["Timed out after receiving partial assistant text."],
+      warnings: [...waitWarnings, "Timed out after receiving partial assistant text."],
       context: await contextFromPage(page)
     });
   }
   return {
     ok: false,
     status: "timeout",
-    warnings: [],
+    warnings: [...waitWarnings],
     error: {
       name: "WaitTimeout",
       message: "No assistant response appeared before the timeout.",
@@ -4745,6 +5291,35 @@ async function waitForMessage(env, args = {}) {
     },
     context: await contextFromPage(page)
   };
+}
+async function pageStateFromProbe(probe, warnings) {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : void 0;
+}
+async function progressSnapshotFromProbeResult(page, result, previousAssistantTurnCount) {
+  if (result.ok) {
+    return result.value;
+  }
+  if (result.timedOut === true || result.skipped === true) {
+    return { assistantTurnCount: previousAssistantTurnCount };
+  }
+  return fallbackAssistantProgressSnapshot(page, previousAssistantTurnCount);
+}
+async function generationStateFromProbe(probe, warnings) {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : EMPTY_GENERATION_STATE;
+}
+async function responseActionsFromProbe(probe, warnings) {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : false;
+}
+function addWarnings(target, warnings) {
+  for (const warning of warnings) {
+    target.add(warning);
+  }
 }
 async function readLatest(env, args = {}) {
   const boot2 = await ensurePage2(env);
@@ -6919,6 +7494,31 @@ async function ensurePage5(env) {
   return bootstrap(env, { preferExistingTab: true });
 }
 
+// src/dom/label-match.ts
+function normalizeForLabelMatch(text) {
+  return normalizeWhitespace(text.normalize("NFKC")).toLocaleLowerCase();
+}
+function visibleLabelMatches(label, wanted) {
+  const normalizedLabel = normalizeForLabelMatch(label);
+  const normalizedWanted = normalizeForLabelMatch(wanted);
+  if (normalizedWanted.length === 0) {
+    return false;
+  }
+  if (normalizedLabel === normalizedWanted) {
+    return true;
+  }
+  if (isShortLatinToken(normalizedWanted)) {
+    return new RegExp(`(^|[^\\p{L}\\p{N}])${escapeRegExp2(normalizedWanted)}([^\\p{L}\\p{N}]|$)`, "iu").test(normalizedLabel);
+  }
+  return normalizedLabel.includes(normalizedWanted);
+}
+function isShortLatinToken(value) {
+  return value.length <= 3 && /^[a-z0-9]+$/i.test(value);
+}
+function escapeRegExp2(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 // src/dom/menus.ts
 function extractMenuItemsFromText(text) {
   return text.split(/\n| {2,}| • /).map((label) => normalizeWhitespace(label)).filter(Boolean).map((label) => ({ label, normalized: normalizeLabel(label) }));
@@ -6962,13 +7562,16 @@ function findUniqueMenuItem(items, wanted) {
   if (exact.length === 1) {
     return exact[0];
   }
-  const fuzzy = items.filter((item) => item.normalized.includes(normalized));
+  const fuzzy = items.filter((item) => visibleLabelMatches(item.label, wanted));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
 }
 
 // src/commands/modes.ts
 var DEFAULT_MODE_EFFORT = "Thinking";
-var CURRENT_MODE_LABELS = [...localeLabels.modeLabels];
+var CURRENT_MODE_LABELS = dedupeLabels([
+  ...localeLabels.modeLabels,
+  ...Object.values(localeLabels.modeOptions).flat()
+]);
 var MODE_OPENER_LABELS = [...CURRENT_MODE_LABELS.filter((label) => label !== "Pro"), ...localeLabels.modeOpenerExtra];
 var MODEL_VERSION_FAMILY_PATTERN = /^gpt[\s-]/i;
 var MODEL_VERSION_LABEL_PATTERN = /^(?:o\d+|\d+(?:\.\d+)?)$/i;
@@ -6976,8 +7579,36 @@ var CANONICAL_INTELLIGENCE_ORDER = /* @__PURE__ */ new Map([
   ["instant", 0],
   ["medium", 1],
   ["high", 2],
-  ["extra high", 3],
+  ["extraHigh", 3],
   ["pro", 4]
+]);
+var MODE_OPTION_IDS2 = [
+  "latest",
+  "instant",
+  "thinking",
+  "extended",
+  "medium",
+  "high",
+  "extraHigh",
+  "pro"
+];
+var MODE_ID_ALIASES = {
+  latest: ["latest"],
+  instant: ["instant"],
+  thinking: ["thinking"],
+  extended: ["extended"],
+  medium: ["medium"],
+  high: ["high"],
+  extraHigh: ["extra high", "extra-high", "extra_high", "extrahigh"],
+  pro: ["pro"]
+};
+var THREAD_ACTION_MENU_LABELS = /* @__PURE__ */ new Set([
+  "archive",
+  "copy link",
+  "delete",
+  "move to project",
+  "rename",
+  "share"
 ]);
 async function setMode(env, args) {
   const boot2 = await ensurePage6(env);
@@ -6986,9 +7617,9 @@ async function setMode(env, args) {
   }
   const page = env.page;
   try {
-    const requested = requestedModeLabels(args);
+    const requested = requestedModeSelections(args);
     const requestedVersion = requestedModelVersion(args);
-    const requestedForOpening = requestedVersion === void 0 ? requested : [...requested, requestedVersion];
+    const requestedForOpening = requestedVersion === void 0 ? requested : [...requested, requestedModeSelection(requestedVersion)];
     const opened = await waitForModeMenu(page, requestedForOpening, args.timeoutMs ?? 3e4);
     if (requestedVersion === void 0 && opened.alreadySelected.length === requested.length) {
       return resultOk({ selected: opened.alreadySelected, candidates: opened.modeButtons }, await contextFromPage(page));
@@ -6999,15 +7630,25 @@ async function setMode(env, args) {
     await page.waitForTimeout?.(250);
     const candidates = await enumerateVisibleMenuItems(page);
     const selected = [];
-    for (const item of requested) {
-      const match = findModeMenuItem(candidates, item);
+    if (requested.length > 0 && shouldRejectAsWrongModeMenu(candidates)) {
+      const candidateLabels2 = candidates.map((candidate) => candidate.label);
+      return {
+        ok: false,
+        status: "unsupported",
+        warnings: [],
+        blocker: selectorDriftBlocker("Visible menu appears to be a thread/action menu, not the ChatGPT mode menu.", candidateLabels2),
+        context: await contextFromPage(page)
+      };
+    }
+    for (const request of requested) {
+      const match = findModeMenuItem(candidates, request);
       if (match === void 0) {
         const candidateLabels2 = candidates.map((candidate) => candidate.label);
         return {
           ok: false,
           status: "unsupported",
           warnings: [],
-          blocker: selectorDriftBlocker(`Mode option "${item}" was not found or was ambiguous.`, candidateLabels2),
+          blocker: selectorDriftBlocker(`Mode option "${request.requested}" was not found or was ambiguous.`, candidateLabels2),
           context: await contextFromPage(page)
         };
       }
@@ -7132,6 +7773,27 @@ function looksLikeModeMenu(labels) {
     return CURRENT_MODE_LABELS.some((modeLabel) => visibleLabelMatches(normalized, normalizeLabel(modeLabel)));
   });
 }
+function shouldRejectAsWrongModeMenu(items) {
+  if (items.length === 0) {
+    return false;
+  }
+  const hasPositiveModeEvidence = items.some((item) => {
+    if (item.testId?.startsWith("model-switcher-") === true) {
+      return true;
+    }
+    if (MODEL_VERSION_FAMILY_PATTERN.test(item.label) || MODEL_VERSION_LABEL_PATTERN.test(item.label)) {
+      return true;
+    }
+    if (item.role === "menuitemradio" && CURRENT_MODE_LABELS.some((label) => visibleLabelMatches(item.label, label))) {
+      return true;
+    }
+    return CURRENT_MODE_LABELS.some((label) => visibleLabelMatches(item.label, label));
+  });
+  if (hasPositiveModeEvidence) {
+    return false;
+  }
+  return items.some((item) => THREAD_ACTION_MENU_LABELS.has(normalizeForLabelMatch(item.label)));
+}
 async function clickMenuItem(page, label) {
   if (await clickModelSwitcherMenuItem(page, label)) {
     return true;
@@ -7218,12 +7880,14 @@ function toolLabels(tool) {
   const known = localeLabels.tools[tool];
   return known !== void 0 ? [...known] : [tool];
 }
-function findModeMenuItem(candidates, wanted) {
-  const exact = findUniqueMenuItem(candidates, wanted);
-  if (exact !== void 0) {
-    return exact;
+function findModeMenuItem(candidates, request) {
+  for (const wanted of request.labels) {
+    const exact = findUniqueMenuItem(candidates, wanted);
+    if (exact !== void 0) {
+      return exact;
+    }
   }
-  const wantedIndex = CANONICAL_INTELLIGENCE_ORDER.get(normalizeLabel(wanted));
+  const wantedIndex = request.modeId === void 0 ? void 0 : CANONICAL_INTELLIGENCE_ORDER.get(request.modeId);
   if (wantedIndex === void 0) {
     return void 0;
   }
@@ -7232,12 +7896,39 @@ function findModeMenuItem(candidates, wanted) {
   );
   return intelligenceItems.length >= CANONICAL_INTELLIGENCE_ORDER.size ? intelligenceItems[wantedIndex] : void 0;
 }
-function requestedModeLabels(args) {
+function requestedModeSelections(args) {
   const requested = [args.model, args.intelligence, args.effort].filter((value) => value !== void 0);
   if (requestedModelVersion(args) !== void 0 && requested.length === 0) {
     return [];
   }
-  return requested.length > 0 ? requested : [DEFAULT_MODE_EFFORT];
+  return (requested.length > 0 ? requested : [DEFAULT_MODE_EFFORT]).map(requestedModeSelection);
+}
+function requestedModeSelection(requested) {
+  const modeId = modeOptionIdFor(requested);
+  const labels = modeId === void 0 ? [requested] : localeLabels.modeOptions[modeId];
+  const request = {
+    requested,
+    labels: labels.length > 0 ? [...labels] : [requested]
+  };
+  if (modeId !== void 0) {
+    request.modeId = modeId;
+  }
+  return request;
+}
+function modeOptionIdFor(value) {
+  const normalized = normalizeModeLookupKey(value);
+  for (const id2 of MODE_OPTION_IDS2) {
+    if (MODE_ID_ALIASES[id2].some((alias) => normalizeModeLookupKey(alias) === normalized)) {
+      return id2;
+    }
+    if (localeLabels.modeOptions[id2].some((label) => normalizeModeLookupKey(label) === normalized)) {
+      return id2;
+    }
+  }
+  return void 0;
+}
+function normalizeModeLookupKey(value) {
+  return normalizeForLabelMatch(value).replace(/[_-]+/g, " ");
 }
 function requestedModelVersion(args) {
   return args.modelVersion ?? args.version;
@@ -7251,25 +7942,25 @@ function findUniqueVisibleLabel(labels, wanted) {
   const fuzzy = labels.filter((label) => visibleLabelMatches(normalizeLabel(label), normalized));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
 }
-function visibleLabelMatches(label, wanted) {
-  if (wanted.length <= 3) {
-    return new RegExp(`(^|[^a-z0-9])${escapeRegExp2(wanted)}([^a-z0-9]|$)`, "i").test(label);
-  }
-  return label.includes(wanted);
-}
-function escapeRegExp2(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 function escapeAttributeValue(value) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 function findAlreadySelectedModes(visibleButtons, requested) {
-  return requested.map((label) => findUniqueVisibleLabel(visibleButtons, label)).filter((label) => label !== void 0);
+  return requested.map((request) => findUniqueVisibleLabelForRequest(visibleButtons, request)).filter((label) => label !== void 0);
+}
+function findUniqueVisibleLabelForRequest(labels, request) {
+  for (const label of request.labels) {
+    const found = findUniqueVisibleLabel(labels, label);
+    if (found !== void 0) {
+      return found;
+    }
+  }
+  return void 0;
 }
 async function selectModelVersion(page, requestedVersion, currentCandidates, timeoutMs) {
   let candidates = await enumerateVisibleMenuItems(page);
   if (!looksLikeModeMenu(candidates.map((candidate) => candidate.label))) {
-    const opened2 = await waitForModeMenu(page, [requestedVersion], timeoutMs);
+    const opened2 = await waitForModeMenu(page, [{ requested: requestedVersion, labels: [requestedVersion] }], timeoutMs);
     if (opened2.opened) {
       await page.waitForTimeout?.(250);
       candidates = await enumerateVisibleMenuItems(page);
@@ -7759,6 +8450,7 @@ var REQUIRED_LOCALE_KEYS = [
   "rateLimitBlocker"
 ];
 var REQUIRED_TOOL_IDS = ["web_search", "deep_research", "create_image"];
+var REQUIRED_MODE_OPTION_IDS = ["latest", "instant", "thinking", "extended", "medium", "high", "extraHigh", "pro"];
 async function doctor(env, args = {}) {
   const wanted = args.check ?? DEFAULT_CHECKS;
   const checks = {};
@@ -7958,19 +8650,23 @@ async function filePreflightCheck(env, args) {
 function localizationCheck(env) {
   const requiredKeysMissing = REQUIRED_LOCALE_KEYS.filter((key) => localeLabels[key].length === 0);
   const missingToolIds = REQUIRED_TOOL_IDS.filter((id2) => (localeLabels.tools[id2]?.length ?? 0) === 0);
+  const missingModeOptionIds = REQUIRED_MODE_OPTION_IDS.filter((id2) => (localeLabels.modeOptions[id2]?.length ?? 0) === 0);
   const toolIds = Object.keys(localeLabels.tools);
-  const englishCanonicalPresent = localeLabels.composerTextbox[0] === "Chat with ChatGPT" && localeLabels.sendButton[0] === "Send prompt" && localeLabels.modeLabels.includes("Thinking") && localeLabels.tools.web_search?.[0] === "Web search";
-  const labelCandidateCount = REQUIRED_LOCALE_KEYS.reduce((total, key) => total + localeLabels[key].length, 0) + Object.values(localeLabels.tools).reduce((total, values) => total + values.length, 0);
+  const modeOptionIds = Object.keys(localeLabels.modeOptions);
+  const englishCanonicalPresent = localeLabels.composerTextbox[0] === "Chat with ChatGPT" && localeLabels.sendButton[0] === "Send prompt" && localeLabels.modeLabels.includes("Thinking") && localeLabels.modeOptions.pro?.[0] === "Pro" && localeLabels.tools.web_search?.[0] === "Web search";
+  const labelCandidateCount = REQUIRED_LOCALE_KEYS.reduce((total, key) => total + localeLabels[key].length, 0) + Object.values(localeLabels.tools).reduce((total, values) => total + values.length, 0) + Object.values(localeLabels.modeOptions).reduce((total, values) => total + values.length, 0);
   const details = {
     englishCanonicalPresent,
     requiredKeysMissing,
     missingToolIds,
+    missingModeOptionIds,
     toolIds,
+    modeOptionIds,
     labelCandidateCount,
     pageAvailable: env.page !== void 0,
     runtimeSelectorCoverage: "registry_only_stage_2"
   };
-  if (englishCanonicalPresent && requiredKeysMissing.length === 0 && missingToolIds.length === 0) {
+  if (englishCanonicalPresent && requiredKeysMissing.length === 0 && missingToolIds.length === 0 && missingModeOptionIds.length === 0) {
     return unknown("The locale registry is loaded; localized runtime selector coverage is registry-only in Stage 2 and not fully proven.", void 0, details);
   }
   return blocked(

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
@@ -251,6 +251,16 @@ var en = {
   imageContainerHint: ["image"],
   // --- Mode switcher (also the canonical public API keys) ---
   modeLabels: ["Latest", "Instant", "Thinking", "Extended", "Medium", "High", "Extra High", "Pro"],
+  modeOptions: {
+    latest: ["Latest"],
+    instant: ["Instant"],
+    thinking: ["Thinking"],
+    extended: ["Extended"],
+    medium: ["Medium"],
+    high: ["High"],
+    extraHigh: ["Extra High"],
+    pro: ["Pro", "Pro Extended", "Extended Pro"]
+  },
   /** Extra openers that surface the mode menu but are not selectable modes themselves. */
   modeOpenerExtra: ["Configure"],
   // --- Tool menu items, keyed by logical tool id ---
@@ -291,6 +301,12 @@ var de = {
   addPhotosFilesMenuItem: ["Fotos und Dateien hinzuf\xFCgen"],
   copyResponse: ["Antwort kopieren"],
   modeLabels: ["Sofort", "Mittel", "Hoch", "Extra hoch"],
+  modeOptions: {
+    instant: ["Sofort"],
+    medium: ["Mittel"],
+    high: ["Hoch"],
+    extraHigh: ["Extra hoch"]
+  },
   modeOpenerExtra: ["Konfigurieren"],
   tools: {
     web_search: ["Websuche"],
@@ -312,6 +328,12 @@ var esES = {
   addPhotosFilesMenuItem: ["A\xF1adir fotos y archivos"],
   copyResponse: ["Copiar respuesta"],
   modeLabels: ["Instant\xE1nea", "Media", "Alta", "Muy alta"],
+  modeOptions: {
+    instant: ["Instant\xE1nea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Muy alta"]
+  },
   modeOpenerExtra: ["Configurar"],
   tools: {
     web_search: ["B\xFAsqueda en Internet"],
@@ -334,6 +356,11 @@ var frFR = {
   addPhotosFilesMenuItem: ["Ajouter des photos et fichiers"],
   copyResponse: ["Copier la r\xE9ponse"],
   modeLabels: ["Moyen", "Avanc\xE9", "Tr\xE8s \xE9lev\xE9"],
+  modeOptions: {
+    medium: ["Moyen"],
+    high: ["Avanc\xE9"],
+    extraHigh: ["Tr\xE8s \xE9lev\xE9"]
+  },
   modeOpenerExtra: ["Configurer"],
   tools: {
     web_search: ["Recherche sur le Web"],
@@ -356,6 +383,13 @@ var zhHK = {
   addPhotosFilesMenuItem: ["\u52A0\u5165\u76F8\u7247\u548C\u6A94\u6848"],
   copyResponse: ["\u8907\u88FD\u56DE\u8986"],
   modeLabels: ["\u5373\u6642", "\u5747\u8861", "\u9AD8", "\u6975\u9AD8", "\u5C08\u696D"],
+  modeOptions: {
+    instant: ["\u5373\u6642"],
+    medium: ["\u5747\u8861"],
+    high: ["\u9AD8"],
+    extraHigh: ["\u6975\u9AD8"],
+    pro: ["\u5C08\u696D"]
+  },
   modeOpenerExtra: ["\u8A2D\u5B9A"],
   tools: {
     web_search: ["\u7DB2\u7D61\u641C\u5C0B"],
@@ -378,6 +412,13 @@ var zhTW = {
   addPhotosFilesMenuItem: ["\u65B0\u589E\u7167\u7247\u548C\u6A94\u6848"],
   copyResponse: ["\u8907\u88FD\u56DE\u61C9"],
   modeLabels: ["\u5373\u6642", "\u4E2D\u7B49", "\u9AD8", "\u8D85\u9AD8", "\u5C08\u696D"],
+  modeOptions: {
+    instant: ["\u5373\u6642"],
+    medium: ["\u4E2D\u7B49"],
+    high: ["\u9AD8"],
+    extraHigh: ["\u8D85\u9AD8"],
+    pro: ["\u5C08\u696D"]
+  },
   modeOpenerExtra: ["\u8A2D\u5B9A"],
   tools: {
     web_search: ["\u7DB2\u9801\u641C\u5C0B"],
@@ -400,6 +441,12 @@ var ja = {
   addPhotosFilesMenuItem: ["\u5199\u771F\u3068\u30D5\u30A1\u30A4\u30EB\u3092\u8FFD\u52A0"],
   copyResponse: ["\u56DE\u7B54\u3092\u30B3\u30D4\u30FC\u3059\u308B"],
   modeLabels: ["\u6700\u901F", "\u6A19\u6E96", "\u9AD8", "\u6700\u9AD8"],
+  modeOptions: {
+    instant: ["\u6700\u901F"],
+    medium: ["\u6A19\u6E96"],
+    high: ["\u9AD8"],
+    extraHigh: ["\u6700\u9AD8"]
+  },
   modeOpenerExtra: ["\u8A2D\u5B9A\u3059\u308B"],
   tools: {
     web_search: ["\u30A6\u30A7\u30D6\u691C\u7D22"],
@@ -421,6 +468,12 @@ var it = {
   addPhotosFilesMenuItem: ["Aggiungi foto e file"],
   copyResponse: ["Copia risposta"],
   modeLabels: ["Istantanea", "Media", "Alta", "Extra elevata"],
+  modeOptions: {
+    instant: ["Istantanea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Extra elevata"]
+  },
   modeOpenerExtra: ["Configura"],
   tools: {
     web_search: ["Ricerca sul web"],
@@ -442,6 +495,12 @@ var vi = {
   addPhotosFilesMenuItem: ["Th\xEAm \u1EA3nh v\xE0 t\u1EC7p"],
   copyResponse: ["Sao ch\xE9p ph\u1EA3n h\u1ED3i"],
   modeLabels: ["T\u1EE9c th\xEC", "Trung b\xECnh", "Cao", "R\u1EA5t cao"],
+  modeOptions: {
+    instant: ["T\u1EE9c th\xEC"],
+    medium: ["Trung b\xECnh"],
+    high: ["Cao"],
+    extraHigh: ["R\u1EA5t cao"]
+  },
   modeOpenerExtra: ["\u0110\u1ECBnh c\u1EA5u h\xECnh"],
   tools: {
     web_search: ["T\xECm ki\u1EBFm tr\xEAn m\u1EA1ng"],
@@ -464,6 +523,12 @@ var am = {
   addPhotosFilesMenuItem: ["\u134E\u1276\u12CE\u127D\u1295 \u12A5\u1293 \u134B\u12ED\u120E\u127D\u1295 \u12EB\u12AD\u1209"],
   copyResponse: ["\u121D\u120B\u1239\u1295 \u12ED\u1245\u12F1"],
   modeLabels: ["\u1348\u1323\u1295", "\u1218\u12AB\u12A8\u1208\u129B", "\u12A8\u134D\u1270\u129B", "\u12A5\u1305\u130D \u12A8\u134D\u1270\u129B"],
+  modeOptions: {
+    instant: ["\u1348\u1323\u1295"],
+    medium: ["\u1218\u12AB\u12A8\u1208\u129B"],
+    high: ["\u12A8\u134D\u1270\u129B"],
+    extraHigh: ["\u12A5\u1305\u130D \u12A8\u134D\u1270\u129B"]
+  },
   modeOpenerExtra: ["\u12EB\u12CB\u1245\u1229"],
   tools: {
     web_search: ["\u12E8\u12F5\u122D \u134D\u1208\u130B"],
@@ -486,6 +551,13 @@ var ar = {
   addPhotosFilesMenuItem: ["\u0625\u0636\u0627\u0641\u0629 \u0635\u0648\u0631 \u0648\u0645\u0644\u0641\u0627\u062A"],
   copyResponse: ["\u0646\u0633\u062E \u0625\u062C\u0627\u0628\u0629"],
   modeLabels: ["\u0641\u0648\u0631\u064A", "\u0645\u062A\u0648\u0633\u0637", "\u0639\u0627\u0644\u064A", "\u0645\u0643\u062B\u0641 \u062C\u062F\u064B\u0627", "\u0627\u062D\u062A\u0631\u0627\u0641\u064A"],
+  modeOptions: {
+    instant: ["\u0641\u0648\u0631\u064A"],
+    medium: ["\u0645\u062A\u0648\u0633\u0637"],
+    high: ["\u0639\u0627\u0644\u064A"],
+    extraHigh: ["\u0645\u0643\u062B\u0641 \u062C\u062F\u064B\u0627"],
+    pro: ["\u0627\u062D\u062A\u0631\u0627\u0641\u064A"]
+  },
   modeOpenerExtra: ["\u062A\u0643\u0648\u064A\u0646"],
   tools: {
     web_search: ["\u0627\u0644\u0628\u062D\u062B \u0641\u064A \u0627\u0644\u0648\u064A\u0628"],
@@ -508,6 +580,13 @@ var bg = {
   addPhotosFilesMenuItem: ["\u0414\u043E\u0431\u0430\u0432\u044F\u043D\u0435 \u043D\u0430 \u0441\u043D\u0438\u043C\u043A\u0438 \u0438 \u0444\u0430\u0439\u043B\u043E\u0432\u0435"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u0430\u0439\u0442\u0435 \u043E\u0442\u0433\u043E\u0432\u043E\u0440\u0430"],
   modeLabels: ["\u041C\u0438\u0433\u043D\u043E\u0432\u0435\u043D", "\u0421\u0440\u0435\u0434\u0435\u043D", "\u0412\u0438\u0441\u043E\u043A", "\u041C\u043D\u043E\u0433\u043E \u0432\u0438\u0441\u043E\u043A\u043E", "\u041F\u0440\u043E"],
+  modeOptions: {
+    instant: ["\u041C\u0438\u0433\u043D\u043E\u0432\u0435\u043D"],
+    medium: ["\u0421\u0440\u0435\u0434\u0435\u043D"],
+    high: ["\u0412\u0438\u0441\u043E\u043A"],
+    extraHigh: ["\u041C\u043D\u043E\u0433\u043E \u0432\u0438\u0441\u043E\u043A\u043E"],
+    pro: ["\u041F\u0440\u043E"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0438\u0440\u0430\u0439\u0442\u0435"],
   tools: {
     web_search: ["\u0422\u044A\u0440\u0441\u0435\u043D\u0435 \u0432 \u0438\u043D\u0442\u0435\u0440\u043D\u0435\u0442"],
@@ -530,6 +609,12 @@ var bs = {
   addPhotosFilesMenuItem: ["Dodaj slike i datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Brzo", "Srednji", "Visoko", "Vrlo visoko"],
+  modeOptions: {
+    instant: ["Brzo"],
+    medium: ["Srednji"],
+    high: ["Visoko"],
+    extraHigh: ["Vrlo visoko"]
+  },
   modeOpenerExtra: ["Podesi"],
   tools: {
     web_search: ["Internet pretraga"],
@@ -552,6 +637,12 @@ var ca = {
   addPhotosFilesMenuItem: ["Afegeix fotos i fitxers"],
   copyResponse: ["Copia la resposta"],
   modeLabels: ["Instantani", "Mitj\xE0", "Alt", "Molt alt"],
+  modeOptions: {
+    instant: ["Instantani"],
+    medium: ["Mitj\xE0"],
+    high: ["Alt"],
+    extraHigh: ["Molt alt"]
+  },
   modeOpenerExtra: ["Configura\u2026"],
   tools: {
     web_search: ["Cerca a la xarxa"],
@@ -574,6 +665,12 @@ var cs = {
   addPhotosFilesMenuItem: ["P\u0159idat fotografie a soubory"],
   copyResponse: ["Zkop\xEDrovat odpov\u011B\u010F"],
   modeLabels: ["Okam\u017Eit\xE1", "St\u0159edn\xED", "Vysok\xE1", "Velmi vysok\xE1"],
+  modeOptions: {
+    instant: ["Okam\u017Eit\xE1"],
+    medium: ["St\u0159edn\xED"],
+    high: ["Vysok\xE1"],
+    extraHigh: ["Velmi vysok\xE1"]
+  },
   modeOpenerExtra: ["Konfigurovat\u2026"],
   tools: {
     web_search: ["Vyhled\xE1v\xE1n\xED na webu"],
@@ -596,6 +693,11 @@ var da = {
   addPhotosFilesMenuItem: ["Tilf\xF8j billeder og filer"],
   copyResponse: ["Kopi\xE9r svar"],
   modeLabels: ["\xD8jeblikkeligt", "H\xF8j", "Ekstra h\xF8j"],
+  modeOptions: {
+    instant: ["\xD8jeblikkeligt"],
+    high: ["H\xF8j"],
+    extraHigh: ["Ekstra h\xF8j"]
+  },
   modeOpenerExtra: ["Konfigurer ..."],
   tools: {
     web_search: ["Internets\xF8gning"],
@@ -618,6 +720,12 @@ var el = {
   addPhotosFilesMenuItem: ["\u03A0\u03C1\u03BF\u03C3\u03B8\u03AE\u03BA\u03B7 \u03C6\u03C9\u03C4\u03BF\u03B3\u03C1\u03B1\u03C6\u03B9\u03CE\u03BD & \u03B1\u03C1\u03C7\u03B5\u03AF\u03C9\u03BD"],
   copyResponse: ["\u0391\u03BD\u03C4\u03B9\u03B3\u03C1\u03B1\u03C6\u03AE \u03B1\u03C0\u03AC\u03BD\u03C4\u03B7\u03C3\u03B7\u03C2"],
   modeLabels: ["\u0386\u03BC\u03B5\u03C3\u03B7", "\u039C\u03B5\u03C3\u03B1\u03AF\u03B1", "\u03A5\u03C8\u03B7\u03BB\u03AE", "\u03A0\u03BF\u03BB\u03CD \u03C5\u03C8\u03B7\u03BB\u03CC"],
+  modeOptions: {
+    instant: ["\u0386\u03BC\u03B5\u03C3\u03B7"],
+    medium: ["\u039C\u03B5\u03C3\u03B1\u03AF\u03B1"],
+    high: ["\u03A5\u03C8\u03B7\u03BB\u03AE"],
+    extraHigh: ["\u03A0\u03BF\u03BB\u03CD \u03C5\u03C8\u03B7\u03BB\u03CC"]
+  },
   modeOpenerExtra: ["\u0394\u03B9\u03B1\u03BC\u03CC\u03C1\u03C6\u03C9\u03C3\u03B7\u2026"],
   tools: {
     web_search: ["\u0391\u03BD\u03B1\u03B6\u03AE\u03C4\u03B7\u03C3\u03B7 \u03C3\u03C4\u03BF\u03BD \u03B9\u03C3\u03C4\u03CC"],
@@ -640,6 +748,12 @@ var es419 = {
   addPhotosFilesMenuItem: ["Agregar fotos y archivos"],
   copyResponse: ["Copiar respuesta"],
   modeLabels: ["Instant\xE1nea", "Media", "Alta", "Muy alta"],
+  modeOptions: {
+    instant: ["Instant\xE1nea"],
+    medium: ["Media"],
+    high: ["Alta"],
+    extraHigh: ["Muy alta"]
+  },
   modeOpenerExtra: ["Configurar..."],
   tools: {
     web_search: ["Busca en la web"],
@@ -662,6 +776,12 @@ var et = {
   addPhotosFilesMenuItem: ["Lisa fotosid ja faile"],
   copyResponse: ["Kopeeri vastus"],
   modeLabels: ["Kohene", "Keskmine", "K\xF5rge", "V\xE4ga k\xF5rge"],
+  modeOptions: {
+    instant: ["Kohene"],
+    medium: ["Keskmine"],
+    high: ["K\xF5rge"],
+    extraHigh: ["V\xE4ga k\xF5rge"]
+  },
   modeOpenerExtra: ["Konfigureeri..."],
   tools: {
     web_search: ["Veebiotsing"],
@@ -684,6 +804,13 @@ var fa = {
   addPhotosFilesMenuItem: ["\u0627\u0641\u0632\u0648\u062F\u0646 \u062A\u0635\u0627\u0648\u06CC\u0631 \u0648 \u0641\u0627\u06CC\u0644\u200C\u0647\u0627"],
   copyResponse: ["\u06A9\u067E\u06CC \u06A9\u0631\u062F\u0646 \u067E\u0627\u0633\u062E"],
   modeLabels: ["\u0641\u0648\u0631\u06CC", "\u0645\u062A\u0648\u0633\u0637", "\u0628\u0627\u0644\u0627", "\u0628\u0633\u06CC\u0627\u0631 \u0632\u06CC\u0627\u062F", "\u062D\u0631\u0641\u0647\u200C\u0627\u06CC"],
+  modeOptions: {
+    instant: ["\u0641\u0648\u0631\u06CC"],
+    medium: ["\u0645\u062A\u0648\u0633\u0637"],
+    high: ["\u0628\u0627\u0644\u0627"],
+    extraHigh: ["\u0628\u0633\u06CC\u0627\u0631 \u0632\u06CC\u0627\u062F"],
+    pro: ["\u062D\u0631\u0641\u0647\u200C\u0627\u06CC"]
+  },
   modeOpenerExtra: ["\u067E\u06CC\u06A9\u0631\u0628\u0646\u062F\u06CC..."],
   tools: {
     web_search: ["\u062C\u0633\u062A\u062C\u0648\u06CC \u0648\u0628"],
@@ -706,6 +833,12 @@ var fi = {
   addPhotosFilesMenuItem: ["Lis\xE4\xE4 valokuvia & tiedostoja"],
   copyResponse: ["Kopioi vastaus"],
   modeLabels: ["V\xE4lit\xF6n", "Keskitaso", "Korkea", "Eritt\xE4in korkea"],
+  modeOptions: {
+    instant: ["V\xE4lit\xF6n"],
+    medium: ["Keskitaso"],
+    high: ["Korkea"],
+    extraHigh: ["Eritt\xE4in korkea"]
+  },
   modeOpenerExtra: ["M\xE4\xE4rit\xE4..."],
   tools: {
     web_search: ["Verkkohaku"],
@@ -728,6 +861,12 @@ var frCA = {
   addPhotosFilesMenuItem: ["Ajouter des photos et des fichiers"],
   copyResponse: ["Copier la r\xE9ponse"],
   modeLabels: ["Instantan\xE9", "Moyen", "\xC9lev\xE9", "Tr\xE8s \xE9lev\xE9"],
+  modeOptions: {
+    instant: ["Instantan\xE9"],
+    medium: ["Moyen"],
+    high: ["\xC9lev\xE9"],
+    extraHigh: ["Tr\xE8s \xE9lev\xE9"]
+  },
   modeOpenerExtra: ["Configurer..."],
   tools: {
     web_search: ["Recherche sur Internet"],
@@ -750,6 +889,12 @@ var gu = {
   addPhotosFilesMenuItem: ["\u0AAB\u0ACB\u0A9F\u0ABE \u0A85\u0AA8\u0AC7 \u0AAB\u0ABE\u0A87\u0AB2\u0ACB \u0A89\u0AAE\u0AC7\u0AB0\u0ACB"],
   copyResponse: ["\u0AAA\u0ACD\u0AB0\u0AA4\u0ABF\u0AAD\u0ABE\u0AB5 \u0A95\u0AC9\u0AAA\u0ABF \u0A95\u0AB0\u0ACB"],
   modeLabels: ["\u0AA4\u0AB0\u0AA4", "\u0AAE\u0AA7\u0ACD\u0AAF\u0AAE", "\u0A89\u0A9A\u0ACD\u0A9A", "\u0A85\u0AA4\u0ABF \u0A89\u0A9A\u0ACD\u0A9A"],
+  modeOptions: {
+    instant: ["\u0AA4\u0AB0\u0AA4"],
+    medium: ["\u0AAE\u0AA7\u0ACD\u0AAF\u0AAE"],
+    high: ["\u0A89\u0A9A\u0ACD\u0A9A"],
+    extraHigh: ["\u0A85\u0AA4\u0ABF \u0A89\u0A9A\u0ACD\u0A9A"]
+  },
   modeOpenerExtra: ["\u0A95\u0AA8\u0ACD\u0AAB\u0ABF\u0A97\u0AB0 \u0A95\u0AB0\u0ACB..."],
   tools: {
     web_search: ["\u0AB5\u0AC7\u0AAC \u0AB6\u0ACB\u0AA7"],
@@ -772,6 +917,12 @@ var hi = {
   addPhotosFilesMenuItem: ["\u092B\u093C\u094B\u091F\u094B \u0914\u0930 \u092B\u093C\u093E\u0907\u0932\u0947\u0902 \u091C\u094B\u0921\u093C\u0947\u0902"],
   copyResponse: ["\u091C\u0935\u093E\u092C \u0915\u094B \u0915\u0949\u092A\u0940 \u0915\u0930\u0947\u0902"],
   modeLabels: ["\u0924\u0941\u0930\u0902\u0924", "\u092E\u0927\u094D\u092F\u092E", "\u0909\u091A\u094D\u091A", "\u092C\u0939\u0941\u0924 \u0909\u091A\u094D\u091A"],
+  modeOptions: {
+    instant: ["\u0924\u0941\u0930\u0902\u0924"],
+    medium: ["\u092E\u0927\u094D\u092F\u092E"],
+    high: ["\u0909\u091A\u094D\u091A"],
+    extraHigh: ["\u092C\u0939\u0941\u0924 \u0909\u091A\u094D\u091A"]
+  },
   modeOpenerExtra: ["\u0915\u0949\u0928\u094D\u092B\u093C\u093F\u0917\u0930 \u0915\u0930\u0947\u0902..."],
   tools: {
     web_search: ["\u0935\u0947\u092C \u0938\u0930\u094D\u091A"],
@@ -794,6 +945,11 @@ var hr = {
   addPhotosFilesMenuItem: ["Dodaj fotografije i datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Srednje", "Visoko", "Vrlo visoka"],
+  modeOptions: {
+    medium: ["Srednje"],
+    high: ["Visoko"],
+    extraHigh: ["Vrlo visoka"]
+  },
   modeOpenerExtra: ["Konfiguriraj\u2026"],
   tools: {
     web_search: ["Mre\u017Eno pretra\u017Eivanje"],
@@ -816,6 +972,12 @@ var hu = {
   addPhotosFilesMenuItem: ["Fot\xF3k \xE9s f\xE1jlok hozz\xE1ad\xE1sa"],
   copyResponse: ["V\xE1lasz m\xE1sol\xE1sa"],
   modeLabels: ["Azonnali", "K\xF6zepes", "Magas", "Kiemelked\u0151en magas"],
+  modeOptions: {
+    instant: ["Azonnali"],
+    medium: ["K\xF6zepes"],
+    high: ["Magas"],
+    extraHigh: ["Kiemelked\u0151en magas"]
+  },
   modeOpenerExtra: ["Konfigur\xE1l\xE1s..."],
   tools: {
     web_search: ["Internetes keres\xE9s"],
@@ -838,6 +1000,13 @@ var hy = {
   addPhotosFilesMenuItem: ["\u0531\u057E\u0565\u056C\u0561\u0581\u0576\u0565\u056C \u056C\u0578\u0582\u057D\u0561\u0576\u056F\u0561\u0580\u0576\u0565\u0580 \u0587 \u0586\u0561\u0575\u056C\u0565\u0580"],
   copyResponse: ["\u054A\u0561\u057F\u0573\u0565\u0576\u0565\u056C \u057A\u0561\u057F\u0561\u057D\u056D\u0561\u0576\u0568"],
   modeLabels: ["\u0531\u056F\u0576\u0569\u0561\u0580\u0569\u0561\u0575\u056B\u0576", "\u0544\u056B\u057B\u056B\u0576", "\u0532\u0561\u0580\u0571\u0580", "\u0547\u0561\u057F \u0562\u0561\u0580\u0571\u0580", "\u054A\u0580\u0578"],
+  modeOptions: {
+    instant: ["\u0531\u056F\u0576\u0569\u0561\u0580\u0569\u0561\u0575\u056B\u0576"],
+    medium: ["\u0544\u056B\u057B\u056B\u0576"],
+    high: ["\u0532\u0561\u0580\u0571\u0580"],
+    extraHigh: ["\u0547\u0561\u057F \u0562\u0561\u0580\u0571\u0580"],
+    pro: ["\u054A\u0580\u0578"]
+  },
   modeOpenerExtra: ["\u053F\u0561\u0566\u0574\u0561\u0571\u0587\u0565\u056C\u2024\u2024\u2024"],
   tools: {
     web_search: ["\u054E\u0565\u0562 \u0578\u0580\u0578\u0576\u0578\u0582\u0574"],
@@ -860,6 +1029,12 @@ var id = {
   addPhotosFilesMenuItem: ["Tambah foto & file"],
   copyResponse: ["Salin respons"],
   modeLabels: ["Instan", "Sedang", "Tinggi", "Sangat Tinggi"],
+  modeOptions: {
+    instant: ["Instan"],
+    medium: ["Sedang"],
+    high: ["Tinggi"],
+    extraHigh: ["Sangat Tinggi"]
+  },
   modeOpenerExtra: ["Konfigurasi..."],
   tools: {
     web_search: ["Pencarian web"],
@@ -882,6 +1057,12 @@ var is = {
   addPhotosFilesMenuItem: ["B\xE6ta myndum og skr\xE1m vi\xF0"],
   copyResponse: ["Afrita svar"],
   modeLabels: ["Strax", "Mi\xF0lungs", "H\xE1tt", "Mj\xF6g h\xE1tt"],
+  modeOptions: {
+    instant: ["Strax"],
+    medium: ["Mi\xF0lungs"],
+    high: ["H\xE1tt"],
+    extraHigh: ["Mj\xF6g h\xE1tt"]
+  },
   modeOpenerExtra: ["Stillir\u2026"],
   tools: {
     web_search: ["Vefleit"],
@@ -904,6 +1085,12 @@ var ka = {
   addPhotosFilesMenuItem: ["\u10E4\u10DD\u10E2\u10DD\u10D4\u10D1\u10D8\u10E1 \u10D3\u10D0 \u10E4\u10D0\u10D8\u10DA\u10D4\u10D1\u10D8\u10E1 \u10D3\u10D0\u10DB\u10D0\u10E2\u10D4\u10D1\u10D0"],
   copyResponse: ["\u10DE\u10D0\u10E1\u10E3\u10EE\u10D8\u10E1 \u10D9\u10DD\u10DE\u10D8\u10E0\u10D4\u10D1\u10D0"],
   modeLabels: ["\u10DB\u10E7\u10D8\u10E1\u10D8\u10D4\u10E0\u10D8", "\u10E1\u10D0\u10E8\u10E3\u10D0\u10DA\u10DD", "\u10DB\u10D0\u10E6\u10D0\u10DA\u10D8", "\u10EB\u10D0\u10DA\u10D8\u10D0\u10DC \u10DB\u10D0\u10E6\u10D0\u10DA\u10D8"],
+  modeOptions: {
+    instant: ["\u10DB\u10E7\u10D8\u10E1\u10D8\u10D4\u10E0\u10D8"],
+    medium: ["\u10E1\u10D0\u10E8\u10E3\u10D0\u10DA\u10DD"],
+    high: ["\u10DB\u10D0\u10E6\u10D0\u10DA\u10D8"],
+    extraHigh: ["\u10EB\u10D0\u10DA\u10D8\u10D0\u10DC \u10DB\u10D0\u10E6\u10D0\u10DA\u10D8"]
+  },
   modeOpenerExtra: ["\u10D9\u10DD\u10DC\u10E4\u10D8\u10D2\u10E3\u10E0\u10D8\u10E0\u10D4\u10D1\u10D0\u2026"],
   tools: {
     web_search: ["\u10D5\u10D4\u10D1\u10E8\u10D8 \u10EB\u10D8\u10D4\u10D1\u10D0"],
@@ -926,6 +1113,12 @@ var kk = {
   addPhotosFilesMenuItem: ["\u0424\u043E\u0442\u043E\u0441\u0443\u0440\u0435\u0442\u0442\u0435\u0440 \u043C\u0435\u043D \u0444\u0430\u0439\u043B\u0434\u0430\u0440 \u049B\u043E\u0441\u0443"],
   copyResponse: ["\u0416\u0430\u0443\u0430\u043F\u0442\u044B \u043A\u04E9\u0448\u0456\u0440\u0443"],
   modeLabels: ["\u0416\u0435\u0434\u0435\u043B", "\u041E\u0440\u0442\u0430\u0448\u0430", "\u0416\u043E\u0493\u0430\u0440\u044B", "\u0410\u0441\u0430 \u0436\u043E\u0493\u0430\u0440\u044B"],
+  modeOptions: {
+    instant: ["\u0416\u0435\u0434\u0435\u043B"],
+    medium: ["\u041E\u0440\u0442\u0430\u0448\u0430"],
+    high: ["\u0416\u043E\u0493\u0430\u0440\u044B"],
+    extraHigh: ["\u0410\u0441\u0430 \u0436\u043E\u0493\u0430\u0440\u044B"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F\u043B\u0430\u0443..."],
   tools: {
     web_search: ["\u0406\u0437\u0434\u0435\u0443"],
@@ -948,6 +1141,13 @@ var kn = {
   addPhotosFilesMenuItem: ["\u0CAB\u0CCB\u0C9F\u0CCA \u0CAE\u0CA4\u0CCD\u0CA4\u0CC1 \u0CAB\u0CC8\u0CB2\u0CCD\u200C\u0C97\u0CB3\u0CA8\u0CCD\u0CA8\u0CC1 \u0CB8\u0CC7\u0CB0\u0CBF\u0CB8\u0CBF"],
   copyResponse: ["\u0CAA\u0CCD\u0CB0\u0CA4\u0CBF\u0C95\u0CCD\u0CB0\u0CBF\u0CAF\u0CC6\u0CAF\u0CA8\u0CCD\u0CA8\u0CC1 \u0CA8\u0C95\u0CB2\u0CBF\u0CB8\u0CBF"],
   modeLabels: ["\u0CA4\u0C95\u0CCD\u0CB7\u0CA3", "\u0CAE\u0CA7\u0CCD\u0CAF\u0CAE", "\u0C89\u0CA8\u0CCD\u0CA8\u0CA4", "\u0C85\u0CA4\u0CBF \u0CB9\u0CC6\u0C9A\u0CCD\u0C9A\u0CC1", "\u0CAA\u0CCD\u0CB0\u0CCA"],
+  modeOptions: {
+    instant: ["\u0CA4\u0C95\u0CCD\u0CB7\u0CA3"],
+    medium: ["\u0CAE\u0CA7\u0CCD\u0CAF\u0CAE"],
+    high: ["\u0C89\u0CA8\u0CCD\u0CA8\u0CA4"],
+    extraHigh: ["\u0C85\u0CA4\u0CBF \u0CB9\u0CC6\u0C9A\u0CCD\u0C9A\u0CC1"],
+    pro: ["\u0CAA\u0CCD\u0CB0\u0CCA"]
+  },
   modeOpenerExtra: ["\u0C95\u0CBE\u0CA8\u0CCD\u0CAB\u0CBF\u0C97\u0CB0\u0CCD \u0CAE\u0CBE\u0CA1\u0CBF..."],
   tools: {
     web_search: ["\u0CB5\u0CC6\u0CAC\u0CCD \u0CB8\u0CB0\u0CCD\u0C9A\u0CCD"],
@@ -970,6 +1170,12 @@ var ko = {
   addPhotosFilesMenuItem: ["\uC0AC\uC9C4 \uBC0F \uD30C\uC77C \uCD94\uAC00"],
   copyResponse: ["\uC751\uB2F5 \uBCF5\uC0AC"],
   modeLabels: ["\uC989\uC2DC", "\uC911\uAC04", "\uB192\uC74C", "\uB9E4\uC6B0 \uB192\uC74C"],
+  modeOptions: {
+    instant: ["\uC989\uC2DC"],
+    medium: ["\uC911\uAC04"],
+    high: ["\uB192\uC74C"],
+    extraHigh: ["\uB9E4\uC6B0 \uB192\uC74C"]
+  },
   modeOpenerExtra: ["\uAD6C\uC131\u2026"],
   tools: {
     web_search: ["\uC6F9 \uAC80\uC0C9"],
@@ -992,6 +1198,13 @@ var lt = {
   addPhotosFilesMenuItem: ["Prid\u0117ti nuotrauk\u0173 ir fail\u0173"],
   copyResponse: ["Kopijuoti atsakym\u0105"],
   modeLabels: ["Momentinis", "Vidutinis", "Auk\u0161tas", "Ypa\u010D didelis", "Profesionalus"],
+  modeOptions: {
+    instant: ["Momentinis"],
+    medium: ["Vidutinis"],
+    high: ["Auk\u0161tas"],
+    extraHigh: ["Ypa\u010D didelis"],
+    pro: ["Profesionalus"]
+  },
   modeOpenerExtra: ["Konfig\u016Bruoti..."],
   tools: {
     web_search: ["\u017Diniatinklio paie\u0161ka"],
@@ -1014,6 +1227,13 @@ var zhHans = {
   addPhotosFilesMenuItem: ["\u6DFB\u52A0\u7167\u7247\u548C\u6587\u4EF6"],
   copyResponse: ["\u590D\u5236\u56DE\u590D"],
   modeLabels: ["\u6781\u901F", "\u5747\u8861", "\u9AD8\u7EA7", "\u8D85\u9AD8", "\u4E13\u4E1A"],
+  modeOptions: {
+    instant: ["\u6781\u901F"],
+    medium: ["\u5747\u8861"],
+    high: ["\u9AD8\u7EA7"],
+    extraHigh: ["\u8D85\u9AD8"],
+    pro: ["\u4E13\u4E1A"]
+  },
   modeOpenerExtra: ["\u914D\u7F6E\u2026"],
   tools: {
     web_search: ["\u7F51\u9875\u641C\u7D22"],
@@ -1036,6 +1256,12 @@ var ur = {
   addPhotosFilesMenuItem: ["\u062A\u0635\u0648\u06CC\u0631\u06CC\u06BA \u0627\u0648\u0631 \u0641\u0627\u0626\u0644\u06CC\u06BA \u0634\u0627\u0645\u0644 \u06A9\u0631\u06CC\u06BA"],
   copyResponse: ["\u062C\u0648\u0627\u0628 \u06A9\u0627\u067E\u06CC \u06A9\u0631\u06CC\u06BA"],
   modeLabels: ["\u0641\u0648\u0631\u06CC", "\u0627\u0648\u0633\u0637", "\u0627\u0639\u0644\u06CC\u0670", "\u0627\u0646\u062A\u06C1\u0627\u0626\u06CC \u0627\u0639\u0644\u06CC\u0670"],
+  modeOptions: {
+    instant: ["\u0641\u0648\u0631\u06CC"],
+    medium: ["\u0627\u0648\u0633\u0637"],
+    high: ["\u0627\u0639\u0644\u06CC\u0670"],
+    extraHigh: ["\u0627\u0646\u062A\u06C1\u0627\u0626\u06CC \u0627\u0639\u0644\u06CC\u0670"]
+  },
   modeOpenerExtra: ["\u06A9\u0646\u0641\u06CC\u06AF\u0631 \u06A9\u0631\u06CC\u06BA..."],
   tools: {
     web_search: ["\u0648\u06CC\u0628 \u067E\u0631 \u062A\u0644\u0627\u0634"],
@@ -1058,6 +1284,12 @@ var uk = {
   addPhotosFilesMenuItem: ["\u0414\u043E\u0434\u0430\u0442\u0438 \u0441\u0432\u0456\u0442\u043B\u0438\u043D\u0438 \u0442\u0430 \u0444\u0430\u0439\u043B\u0438"],
   copyResponse: ["\u041A\u043E\u043F\u0456\u044E\u0432\u0430\u0442\u0438 \u0432\u0456\u0434\u043F\u043E\u0432\u0456\u0434\u044C"],
   modeLabels: ["\u041C\u0438\u0442\u0442\u0454\u0432\u0438\u0439", "\u0421\u0435\u0440\u0435\u0434\u043D\u0456\u0439", "\u0412\u0438\u0441\u043E\u043A\u0438\u0439", "\u0414\u0443\u0436\u0435 \u0432\u0438\u0441\u043E\u043A\u0438\u0439"],
+  modeOptions: {
+    instant: ["\u041C\u0438\u0442\u0442\u0454\u0432\u0438\u0439"],
+    medium: ["\u0421\u0435\u0440\u0435\u0434\u043D\u0456\u0439"],
+    high: ["\u0412\u0438\u0441\u043E\u043A\u0438\u0439"],
+    extraHigh: ["\u0414\u0443\u0436\u0435 \u0432\u0438\u0441\u043E\u043A\u0438\u0439"]
+  },
   modeOpenerExtra: ["\u041D\u0430\u043B\u0430\u0448\u0442\u0443\u0432\u0430\u0442\u0438\u2026"],
   tools: {
     web_search: ["\u041F\u043E\u0448\u0443\u043A \u0432 \u0406\u043D\u0442\u0435\u0440\u043D\u0435\u0442\u0456"],
@@ -1080,6 +1312,12 @@ var ptBR = {
   addPhotosFilesMenuItem: ["Carregar fotos e arquivos"],
   copyResponse: ["Copiar resposta"],
   modeLabels: ["Instant\xE2neo", "M\xE9dio", "Alto", "Muito alta"],
+  modeOptions: {
+    instant: ["Instant\xE2neo"],
+    medium: ["M\xE9dio"],
+    high: ["Alto"],
+    extraHigh: ["Muito alta"]
+  },
   modeOpenerExtra: ["Configurar\u2026"],
   tools: {
     web_search: ["Busca na web"],
@@ -1102,6 +1340,12 @@ var ptPT = {
   addPhotosFilesMenuItem: ["Carregar fotos e ficheiros"],
   copyResponse: ["Copiar resposta"],
   modeLabels: ["Instant\xE2neo", "M\xE9dia", "Alta", "M\xE1ximo"],
+  modeOptions: {
+    instant: ["Instant\xE2neo"],
+    medium: ["M\xE9dia"],
+    high: ["Alta"],
+    extraHigh: ["M\xE1ximo"]
+  },
   modeOpenerExtra: ["Configurar..."],
   tools: {
     web_search: ["Procurar na web"],
@@ -1124,6 +1368,12 @@ var pl = {
   addPhotosFilesMenuItem: ["Prze\u015Blij zdj\u0119cia i pliki"],
   copyResponse: ["Kopiuj odpowied\u017A"],
   modeLabels: ["B\u0142yskawiczny", "\u015Aredni", "Zaawansowana", "Bardzo wysoki"],
+  modeOptions: {
+    instant: ["B\u0142yskawiczny"],
+    medium: ["\u015Aredni"],
+    high: ["Zaawansowana"],
+    extraHigh: ["Bardzo wysoki"]
+  },
   modeOpenerExtra: ["Skonfiguruj..."],
   tools: {
     web_search: ["Wyszukiwanie w sieci"],
@@ -1146,6 +1396,12 @@ var sk = {
   addPhotosFilesMenuItem: ["Nahra\u0165 fotografie a s\xFAbory"],
   copyResponse: ["Kop\xEDrova\u0165 odpove\u010F"],
   modeLabels: ["Okam\u017Eit\xE1", "Stredn\xE1", "Vysok\xE1", "Extra vysok\xE1"],
+  modeOptions: {
+    instant: ["Okam\u017Eit\xE1"],
+    medium: ["Stredn\xE1"],
+    high: ["Vysok\xE1"],
+    extraHigh: ["Extra vysok\xE1"]
+  },
   modeOpenerExtra: ["Konfigurova\u0165..."],
   tools: {
     web_search: ["Preh\u013Ead\xE1vaj web"],
@@ -1168,6 +1424,11 @@ var ro = {
   addPhotosFilesMenuItem: ["\xCEncarc\u0103 fotografii \u0219i fi\u0219iere"],
   copyResponse: ["Copiaz\u0103 r\u0103spunsul"],
   modeLabels: ["Mediu", "Ridicat", "Foarte ridicat\u0103"],
+  modeOptions: {
+    medium: ["Mediu"],
+    high: ["Ridicat"],
+    extraHigh: ["Foarte ridicat\u0103"]
+  },
   modeOpenerExtra: ["Configureaz\u0103..."],
   tools: {
     web_search: ["C\u0103utare pe internet"],
@@ -1190,6 +1451,12 @@ var nb = {
   addPhotosFilesMenuItem: ["Last opp bilder og filer"],
   copyResponse: ["Kopier svar"],
   modeLabels: ["\xD8yeblikkelig", "Middels", "H\xF8y", "Ekstra h\xF8y"],
+  modeOptions: {
+    instant: ["\xD8yeblikkelig"],
+    medium: ["Middels"],
+    high: ["H\xF8y"],
+    extraHigh: ["Ekstra h\xF8y"]
+  },
   modeOpenerExtra: ["Konfigurer \u2026"],
   tools: {
     web_search: ["Netts\xF8k"],
@@ -1212,6 +1479,13 @@ var ml = {
   addPhotosFilesMenuItem: ["\u0D2B\u0D4B\u0D1F\u0D4D\u0D1F\u0D4B\u0D15\u0D33\u0D41\u0D02 \u0D2B\u0D2F\u0D32\u0D41\u0D15\u0D33\u0D41\u0D02 \u0D05\u0D2A\u0D4D\u200C\u0D32\u0D4B\u0D21\u0D4D \u0D1A\u0D46\u0D2F\u0D4D\u0D2F\u0D41\u0D15"],
   copyResponse: ["\u0D2E\u0D31\u0D41\u0D2A\u0D1F\u0D3F \u0D15\u0D4B\u0D2A\u0D4D\u0D2A\u0D3F \u0D1A\u0D46\u0D2F\u0D4D\u0D2F\u0D41\u0D15"],
   modeLabels: ["\u0D24\u0D7D\u0D15\u0D4D\u0D37\u0D23\u0D02", "\u0D07\u0D1F\u0D24\u0D4D\u0D24\u0D30\u0D02", "\u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28\u0D24\u0D4D", "\u0D35\u0D33\u0D30\u0D46 \u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28", "\u0D2A\u0D4D\u0D30\u0D4B"],
+  modeOptions: {
+    instant: ["\u0D24\u0D7D\u0D15\u0D4D\u0D37\u0D23\u0D02"],
+    medium: ["\u0D07\u0D1F\u0D24\u0D4D\u0D24\u0D30\u0D02"],
+    high: ["\u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28\u0D24\u0D4D"],
+    extraHigh: ["\u0D35\u0D33\u0D30\u0D46 \u0D09\u0D2F\u0D7C\u0D28\u0D4D\u0D28"],
+    pro: ["\u0D2A\u0D4D\u0D30\u0D4B"]
+  },
   modeOpenerExtra: ["\u0D15\u0D4B\u0D7A\u0D2B\u0D3F\u0D17\u0D7C \u0D1A\u0D46\u0D2F\u0D4D\u0D2F\u0D41\u0D15\u2026"],
   tools: {
     web_search: ["\u0D35\u0D46\u0D2C\u0D4D \u0D24\u0D3F\u0D30\u0D2F\u0D7D"],
@@ -1234,6 +1508,9 @@ var ru = {
   addPhotosFilesMenuItem: ["\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0444\u043E\u0442\u043E\u0433\u0440\u0430\u0444\u0438\u0438 \u0438 \u0444\u0430\u0439\u043B\u044B"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u043E\u0432\u0430\u0442\u044C \u043E\u0442\u0432\u0435\u0442"],
   modeLabels: ["\u041E\u0447\u0435\u043D\u044C \u0432\u044B\u0441\u043E\u043A\u0438\u0439"],
+  modeOptions: {
+    extraHigh: ["\u041E\u0447\u0435\u043D\u044C \u0432\u044B\u0441\u043E\u043A\u0438\u0439"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F..."],
   tools: {
     web_search: ["\u041F\u043E\u0438\u0441\u043A \u0432 \u0441\u0435\u0442\u0438"],
@@ -1256,6 +1533,13 @@ var pa = {
   addPhotosFilesMenuItem: ["\u0A2B\u0A3C\u0A4B\u0A1F\u0A4B\u0A06\u0A02 \u0A05\u0A24\u0A47 \u0A2B\u0A3C\u0A3E\u0A08\u0A32\u0A3E\u0A02 \u0A05\u0A71\u0A2A\u0A32\u0A4B\u0A21 \u0A15\u0A30\u0A4B"],
   copyResponse: ["\u0A1C\u0A35\u0A3E\u0A2C \u0A15\u0A3E\u0A2A\u0A40 \u0A15\u0A30\u0A4B"],
   modeLabels: ["\u0A24\u0A41\u0A30\u0A70\u0A24", "\u0A2E\u0A71\u0A27\u0A2E", "\u0A09\u0A71\u0A1A", "\u0A05\u0A24\u0A3F \u0A09\u0A71\u0A1A", "\u0A2A\u0A4D\u0A30\u0A4B"],
+  modeOptions: {
+    instant: ["\u0A24\u0A41\u0A30\u0A70\u0A24"],
+    medium: ["\u0A2E\u0A71\u0A27\u0A2E"],
+    high: ["\u0A09\u0A71\u0A1A"],
+    extraHigh: ["\u0A05\u0A24\u0A3F \u0A09\u0A71\u0A1A"],
+    pro: ["\u0A2A\u0A4D\u0A30\u0A4B"]
+  },
   modeOpenerExtra: ["\u0A15\u0A4C\u0A28\u0A2B\u0A3F\u0A17\u0A30..."],
   tools: {
     web_search: ["\u0A35\u0A48\u0A71\u0A2C \u0A16\u0A4B\u0A1C"],
@@ -1278,6 +1562,13 @@ var mr = {
   addPhotosFilesMenuItem: ["\u092B\u094B\u091F\u094B \u0906\u0923\u093F \u092B\u093E\u0907\u0932\u094D\u0938 \u0905\u092A\u0932\u094B\u0921 \u0915\u0930\u093E"],
   copyResponse: ["\u092A\u094D\u0930\u0924\u093F\u0938\u093E\u0926 \u0915\u0949\u092A\u0940 \u0915\u0930\u093E"],
   modeLabels: ["\u091D\u091F\u092A\u091F", "\u092E\u0927\u094D\u092F\u092E", "\u0909\u091A\u094D\u091A", "\u0905\u0924\u093F\u0909\u091A\u094D\u091A", "\u092A\u094D\u0930\u094B"],
+  modeOptions: {
+    instant: ["\u091D\u091F\u092A\u091F"],
+    medium: ["\u092E\u0927\u094D\u092F\u092E"],
+    high: ["\u0909\u091A\u094D\u091A"],
+    extraHigh: ["\u0905\u0924\u093F\u0909\u091A\u094D\u091A"],
+    pro: ["\u092A\u094D\u0930\u094B"]
+  },
   modeOpenerExtra: ["\u0915\u0949\u0928\u094D\u092B\u093F\u0917\u0930 \u0915\u0930\u093E..."],
   tools: {
     web_search: ["\u0935\u0947\u092C\u0935\u0930 \u0936\u094B\u0927"],
@@ -1300,6 +1591,12 @@ var tr = {
   addPhotosFilesMenuItem: ["Foto\u011Fraf ve dosya y\xFCkle"],
   copyResponse: ["Yan\u0131t\u0131 kopyala"],
   modeLabels: ["An\u0131nda", "Orta", "Y\xFCksek", "\xC7ok Y\xFCksek"],
+  modeOptions: {
+    instant: ["An\u0131nda"],
+    medium: ["Orta"],
+    high: ["Y\xFCksek"],
+    extraHigh: ["\xC7ok Y\xFCksek"]
+  },
   modeOpenerExtra: ["Yap\u0131land\u0131r..."],
   tools: {
     web_search: ["Web aramas\u0131"],
@@ -1322,6 +1619,12 @@ var sw = {
   addPhotosFilesMenuItem: ["Pakia picha na mafaili"],
   copyResponse: ["Nakili jibu"],
   modeLabels: ["Papo hapo", "Wastani", "Juu", "Juu Zaidi"],
+  modeOptions: {
+    instant: ["Papo hapo"],
+    medium: ["Wastani"],
+    high: ["Juu"],
+    extraHigh: ["Juu Zaidi"]
+  },
   modeOpenerExtra: ["Sanidi..."],
   tools: {
     web_search: ["Utafutaji wa wavuti"],
@@ -1344,6 +1647,13 @@ var te = {
   addPhotosFilesMenuItem: ["\u0C2B\u0C4B\u0C1F\u0C4B\u0C32\u0C41 & \u0C2B\u0C48\u0C32\u0C4D\u200C\u0C32\u0C28\u0C41 \u0C05\u0C2A\u0C4D\u200C\u0C32\u0C4B\u0C21\u0C4D \u0C1A\u0C47\u0C2F\u0C02\u0C21\u0C3F"],
   copyResponse: ["\u0C2A\u0C4D\u0C30\u0C24\u0C3F\u0C38\u0C4D\u0C2A\u0C02\u0C26\u0C28\u0C28\u0C41 \u0C15\u0C3E\u0C2A\u0C40 \u0C1A\u0C47\u0C2F\u0C02\u0C21\u0C3F"],
   modeLabels: ["\u0C24\u0C15\u0C4D\u0C37\u0C23\u0C02", "\u0C2E\u0C27\u0C4D\u0C2F\u0C38\u0C4D\u0C25", "\u0C05\u0C27\u0C3F\u0C15", "\u0C05\u0C24\u0C4D\u0C2F\u0C27\u0C3F\u0C15", "\u0C2A\u0C4D\u0C30\u0C4B"],
+  modeOptions: {
+    instant: ["\u0C24\u0C15\u0C4D\u0C37\u0C23\u0C02"],
+    medium: ["\u0C2E\u0C27\u0C4D\u0C2F\u0C38\u0C4D\u0C25"],
+    high: ["\u0C05\u0C27\u0C3F\u0C15"],
+    extraHigh: ["\u0C05\u0C24\u0C4D\u0C2F\u0C27\u0C3F\u0C15"],
+    pro: ["\u0C2A\u0C4D\u0C30\u0C4B"]
+  },
   modeOpenerExtra: ["\u0C15\u0C3E\u0C28\u0C4D\u0C2B\u0C3F\u0C17\u0C30\u0C4D \u0C1A\u0C47\u0C2F\u0C02\u0C21\u0C3F"],
   tools: {
     web_search: ["\u0C35\u0C46\u0C2C\u0C4D\u200C\u0C32\u0C4B \u0C35\u0C46\u0C24\u0C15\u0C21\u0C02"],
@@ -1386,6 +1696,12 @@ var th = {
   addPhotosFilesMenuItem: ["\u0E2D\u0E31\u0E1B\u0E42\u0E2B\u0E25\u0E14\u0E23\u0E39\u0E1B\u0E41\u0E25\u0E30\u0E44\u0E1F\u0E25\u0E4C"],
   copyResponse: ["\u0E04\u0E31\u0E14\u0E25\u0E2D\u0E01\u0E04\u0E33\u0E15\u0E2D\u0E1A"],
   modeLabels: ["\u0E17\u0E31\u0E19\u0E17\u0E35", "\u0E1B\u0E32\u0E19\u0E01\u0E25\u0E32\u0E07", "\u0E2A\u0E39\u0E07", "\u0E2A\u0E39\u0E07\u0E21\u0E32\u0E01"],
+  modeOptions: {
+    instant: ["\u0E17\u0E31\u0E19\u0E17\u0E35"],
+    medium: ["\u0E1B\u0E32\u0E19\u0E01\u0E25\u0E32\u0E07"],
+    high: ["\u0E2A\u0E39\u0E07"],
+    extraHigh: ["\u0E2A\u0E39\u0E07\u0E21\u0E32\u0E01"]
+  },
   modeOpenerExtra: ["\u0E01\u0E33\u0E2B\u0E19\u0E14\u0E04\u0E48\u0E32..."],
   tools: {
     web_search: ["\u0E04\u0E49\u0E19\u0E2B\u0E32\u0E40\u0E27\u0E47\u0E1A"],
@@ -1408,6 +1724,13 @@ var bn = {
   addPhotosFilesMenuItem: ["\u09AB\u099F\u09CB \u098F\u09AC\u0982 \u09AB\u09BE\u0987\u09B2 \u0986\u09AA\u09B2\u09CB\u09A1 \u0995\u09B0\u09C1\u09A8"],
   copyResponse: ["\u0989\u09A4\u09CD\u09A4\u09B0 \u0995\u09AA\u09BF \u0995\u09B0\u09C1\u09A8"],
   modeLabels: ["\u09A4\u09BE\u09CE\u0995\u09CD\u09B7\u09A3\u09BF\u0995", "\u09AE\u09BE\u099D\u09BE\u09B0\u09BF", "\u0989\u099A\u09CD\u099A", "\u0985\u09A4\u09BF \u0989\u099A\u09CD\u099A", "\u09AA\u09CD\u09B0\u09CB"],
+  modeOptions: {
+    instant: ["\u09A4\u09BE\u09CE\u0995\u09CD\u09B7\u09A3\u09BF\u0995"],
+    medium: ["\u09AE\u09BE\u099D\u09BE\u09B0\u09BF"],
+    high: ["\u0989\u099A\u09CD\u099A"],
+    extraHigh: ["\u0985\u09A4\u09BF \u0989\u099A\u09CD\u099A"],
+    pro: ["\u09AA\u09CD\u09B0\u09CB"]
+  },
   modeOpenerExtra: ["\u0995\u09A8\u09AB\u09BF\u0997\u09BE\u09B0 \u0995\u09B0\u09C1\u09A8..."],
   tools: {
     web_search: ["\u0993\u09AF\u09BC\u09C7\u09AC \u09B8\u09A8\u09CD\u09A7\u09BE\u09A8"],
@@ -1430,6 +1753,12 @@ var ms = {
   addPhotosFilesMenuItem: ["Muat naik foto & fail"],
   copyResponse: ["Salin tindak balas"],
   modeLabels: ["Segera", "Sederhana", "Tinggi", "Sangat Tinggi"],
+  modeOptions: {
+    instant: ["Segera"],
+    medium: ["Sederhana"],
+    high: ["Tinggi"],
+    extraHigh: ["Sangat Tinggi"]
+  },
   modeOpenerExtra: ["Konfigurasikan\u2026"],
   tools: {
     web_search: ["Carian web"],
@@ -1452,6 +1781,12 @@ var so = {
   addPhotosFilesMenuItem: ["Soo geli sawirada & faylasha"],
   copyResponse: ["Koobiyee jawaabta"],
   modeLabels: ["Degdeg", "Dhexdhexaad", "Sare", "Aad u sarreeya"],
+  modeOptions: {
+    instant: ["Degdeg"],
+    medium: ["Dhexdhexaad"],
+    high: ["Sare"],
+    extraHigh: ["Aad u sarreeya"]
+  },
   modeOpenerExtra: ["Ku xidh..."],
   tools: {
     web_search: ["Raadi shakabada"],
@@ -1474,6 +1809,12 @@ var nl = {
   addPhotosFilesMenuItem: ["Foto's en bestanden uploaden"],
   copyResponse: ["Reactie kopi\xEBren"],
   modeLabels: ["Direct", "Gemiddeld", "Hoog", "Extra hoog"],
+  modeOptions: {
+    instant: ["Direct"],
+    medium: ["Gemiddeld"],
+    high: ["Hoog"],
+    extraHigh: ["Extra hoog"]
+  },
   modeOpenerExtra: ["Configureren..."],
   tools: {
     web_search: ["Zoeken op internet"],
@@ -1496,6 +1837,12 @@ var sv = {
   addPhotosFilesMenuItem: ["Ladda upp foton och filer"],
   copyResponse: ["Kopiera svar"],
   modeLabels: ["Direkt", "Balanserad", "H\xF6g", "Extra h\xF6g"],
+  modeOptions: {
+    instant: ["Direkt"],
+    medium: ["Balanserad"],
+    high: ["H\xF6g"],
+    extraHigh: ["Extra h\xF6g"]
+  },
   modeOpenerExtra: ["Konfigurera \u2026"],
   tools: {
     web_search: ["Webbs\xF6kning"],
@@ -1518,6 +1865,12 @@ var lv = {
   addPhotosFilesMenuItem: ["Aug\u0161upiel\u0101d\u0113t foto un failus"],
   copyResponse: ["Kop\u0113t atbildi"],
   modeLabels: ["T\u016Bl\u012Bt\u0113js", "Vid\u0113js", "Augsts", "\u013Boti augsts"],
+  modeOptions: {
+    instant: ["T\u016Bl\u012Bt\u0113js"],
+    medium: ["Vid\u0113js"],
+    high: ["Augsts"],
+    extraHigh: ["\u013Boti augsts"]
+  },
   modeOpenerExtra: ["Konfigur\u0113t..."],
   tools: {
     web_search: ["Mekl\u0113\u0161ana t\u012Bmekl\u012B"],
@@ -1540,6 +1893,11 @@ var mk = {
   addPhotosFilesMenuItem: ["\u041F\u043E\u0441\u0442\u0430\u0432\u0438 \u0444\u043E\u0442\u043E\u0433\u0440\u0430\u0444\u0438\u0438 \u0438 \u0434\u0430\u0442\u043E\u0442\u0435\u043A\u0438"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u0430\u0458 \u043E\u0434\u0433\u043E\u0432\u043E\u0440"],
   modeLabels: ["\u0421\u0440\u0435\u0434\u043D\u043E", "\u0412\u0438\u0441\u043E\u043A\u043E", "\u041C\u043D\u043E\u0433\u0443 \u0432\u0438\u0441\u043E\u043A\u043E"],
+  modeOptions: {
+    medium: ["\u0421\u0440\u0435\u0434\u043D\u043E"],
+    high: ["\u0412\u0438\u0441\u043E\u043A\u043E"],
+    extraHigh: ["\u041C\u043D\u043E\u0433\u0443 \u0432\u0438\u0441\u043E\u043A\u043E"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0438\u0440\u0430\u0458..."],
   tools: {
     web_search: ["\u041F\u0440\u0435\u0431\u0430\u0440\u0443\u0432\u0430\u045A\u0435 \u043D\u0430 \u0438\u043D\u0442\u0435\u0440\u043D\u0435\u0442"],
@@ -1562,6 +1920,12 @@ var sq = {
   addPhotosFilesMenuItem: ["Ngarko foto dhe skedar\xEB"],
   copyResponse: ["Kopjo p\xEBrgjigjen"],
   modeLabels: ["I menj\xEBhersh\xEBm", "Mesatar", "Lart\xEB", "Shum\xEB i lart\xEB"],
+  modeOptions: {
+    instant: ["I menj\xEBhersh\xEBm"],
+    medium: ["Mesatar"],
+    high: ["Lart\xEB"],
+    extraHigh: ["Shum\xEB i lart\xEB"]
+  },
   modeOpenerExtra: ["Konfiguro..."],
   tools: {
     web_search: ["K\xEBrkim n\xEB ueb"],
@@ -1584,6 +1948,12 @@ var sl = {
   addPhotosFilesMenuItem: ["Nalo\u017Ei fotografije in datoteke"],
   copyResponse: ["Kopiraj odgovor"],
   modeLabels: ["Takoj", "Srednja", "Visoka", "Zelo visoko"],
+  modeOptions: {
+    instant: ["Takoj"],
+    medium: ["Srednja"],
+    high: ["Visoka"],
+    extraHigh: ["Zelo visoko"]
+  },
   modeOpenerExtra: ["Konfiguracija \u2026"],
   tools: {
     web_search: ["Iskanje po spletu"],
@@ -1606,6 +1976,9 @@ var sr = {
   addPhotosFilesMenuItem: ["\u041E\u0442\u043F\u0440\u0435\u043C\u0438 \u0444\u043E\u0442\u043E\u0433\u0440\u0430\u0444\u0438\u0458\u0435 \u0438 \u0434\u0430\u0442\u043E\u0442\u0435\u043A\u0435"],
   copyResponse: ["\u041A\u043E\u043F\u0438\u0440\u0430\u0458 \u043E\u0434\u0433\u043E\u0432\u043E\u0440"],
   modeLabels: ["\u0412\u0435\u043E\u043C\u0430 \u0432\u0438\u0441\u043E\u043A\u043E"],
+  modeOptions: {
+    extraHigh: ["\u0412\u0435\u043E\u043C\u0430 \u0432\u0438\u0441\u043E\u043A\u043E"]
+  },
   modeOpenerExtra: ["\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0438\u0448\u0438..."],
   tools: {
     web_search: ["\u041F\u0440\u0435\u0442\u0440\u0430\u0433\u0430 \u0432\u0435\u0431\u0430"],
@@ -1628,6 +2001,13 @@ var mn = {
   addPhotosFilesMenuItem: ["\u0417\u0443\u0440\u0430\u0433 \u0431\u0430 \u0444\u0430\u0439\u043B \u0431\u0430\u0439\u0440\u0448\u0443\u0443\u043B\u0430\u0445"],
   copyResponse: ["\u0425\u0430\u0440\u0438\u0443\u043B\u0442 \u0445\u0443\u0443\u043B\u0430\u0445"],
   modeLabels: ["\u0428\u0443\u0443\u0440\u0445\u0430\u0439", "\u0414\u0443\u043D\u0434", "\u04E8\u043D\u0434\u04E9\u0440", "\u041C\u0430\u0448 \u04E9\u043D\u0434\u04E9\u0440", "\u041F\u0440\u043E"],
+  modeOptions: {
+    instant: ["\u0428\u0443\u0443\u0440\u0445\u0430\u0439"],
+    medium: ["\u0414\u0443\u043D\u0434"],
+    high: ["\u04E8\u043D\u0434\u04E9\u0440"],
+    extraHigh: ["\u041C\u0430\u0448 \u04E9\u043D\u0434\u04E9\u0440"],
+    pro: ["\u041F\u0440\u043E"]
+  },
   modeOpenerExtra: ["\u0422\u043E\u0445\u0438\u0440\u0443\u0443\u043B\u0430\u0445..."],
   tools: {
     web_search: ["\u0412\u0435\u0431 \u0445\u0430\u0439\u043B\u0442"],
@@ -1650,6 +2030,12 @@ var my = {
   addPhotosFilesMenuItem: ["\u1013\u102C\u1010\u103A\u1015\u102F\u1036\u1019\u103B\u102C\u1038\u1014\u103E\u1004\u1037\u103A \u1016\u102D\u102F\u1004\u103A\u1019\u103B\u102C\u1038\u1000\u102D\u102F \u1010\u1004\u103A\u1015\u102B"],
   copyResponse: ["\u1010\u102F\u1036\u1037\u1015\u103C\u1014\u103A\u1019\u103E\u102F \u1000\u1030\u1038\u101A\u1030\u101B\u1014\u103A"],
   modeLabels: ["\u1001\u103B\u1000\u103A\u1001\u103B\u1004\u103A\u1038", "\u1021\u101C\u101A\u103A\u1021\u101C\u1010\u103A", "\u1019\u103C\u1004\u1037\u103A", "\u1021\u101C\u103D\u1014\u103A\u1019\u103C\u1004\u1037\u103A"],
+  modeOptions: {
+    instant: ["\u1001\u103B\u1000\u103A\u1001\u103B\u1004\u103A\u1038"],
+    medium: ["\u1021\u101C\u101A\u103A\u1021\u101C\u1010\u103A"],
+    high: ["\u1019\u103C\u1004\u1037\u103A"],
+    extraHigh: ["\u1021\u101C\u103D\u1014\u103A\u1019\u103C\u1004\u1037\u103A"]
+  },
   modeOpenerExtra: ["\u1015\u103C\u102F\u1015\u103C\u1004\u103A\u1019\u103D\u1019\u103A\u1038\u1019\u1036\u101B\u1014\u103A"],
   tools: {
     web_search: ["\u101D\u1018\u103A\u101B\u103E\u102C\u1016\u103D\u1031\u101B\u1014\u103A"],
@@ -1672,6 +2058,13 @@ var ta = {
   addPhotosFilesMenuItem: ["\u0BAA\u0B9F\u0B99\u0BCD\u0B95\u0BB3\u0BCD \u0BAE\u0BB1\u0BCD\u0BB1\u0BC1\u0BAE\u0BCD \u0B83\u0BAA\u0BC8\u0BB2\u0BCD\u0B95\u0BB3\u0BC8\u0BAA\u0BCD \u0BAA\u0BA4\u0BBF\u0BB5\u0BC7\u0BB1\u0BCD\u0BB1\u0BC1"],
   copyResponse: ["\u0BAA\u0BA4\u0BBF\u0BB2\u0BC8 \u0BA8\u0B95\u0BB2\u0BC6\u0B9F\u0BC1\u0B95\u0BCD\u0B95\u0BB2\u0BBE\u0BAE\u0BCD"],
   modeLabels: ["\u0B89\u0B9F\u0BA9\u0B9F\u0BBF", "\u0BA8\u0B9F\u0BC1\u0BA4\u0BCD\u0BA4\u0BB0", "\u0B89\u0BAF\u0BB0\u0BCD", "\u0BAE\u0BBF\u0B95 \u0B89\u0BAF\u0BB0\u0BCD\u0BB5\u0BC1", "\u0BAA\u0BCD\u0BB0\u0BCB"],
+  modeOptions: {
+    instant: ["\u0B89\u0B9F\u0BA9\u0B9F\u0BBF"],
+    medium: ["\u0BA8\u0B9F\u0BC1\u0BA4\u0BCD\u0BA4\u0BB0"],
+    high: ["\u0B89\u0BAF\u0BB0\u0BCD"],
+    extraHigh: ["\u0BAE\u0BBF\u0B95 \u0B89\u0BAF\u0BB0\u0BCD\u0BB5\u0BC1"],
+    pro: ["\u0BAA\u0BCD\u0BB0\u0BCB"]
+  },
   modeOpenerExtra: ["\u0B95\u0B9F\u0BCD\u0B9F\u0BAE\u0BC8\u0B95\u0BCD\u0B95\u0BB5\u0BC1\u0BAE\u0BCD..."],
   tools: {
     web_search: ["\u0B87\u0BA3\u0BC8\u0BAF \u0BA4\u0BC7\u0B9F\u0BB2\u0BCD"],
@@ -1685,6 +2078,16 @@ var ta = {
 // src/dom/locale/index.ts
 var locales = [en, de, esES, frFR, zhHK, zhTW, ja, it, vi, am, ar, bg, bs, ca, cs, da, el, es419, et, fa, fi, frCA, gu, hi, hr, hu, hy, id, is, ka, kk, kn, ko, lt, zhHans, ur, uk, ptBR, ptPT, pl, sk, ro, nb, ml, ru, pa, mr, tr, sw, te, tl, th, bn, ms, so, nl, sv, lv, mk, sq, sl, sr, mn, my, ta];
 var TOOL_IDS = ["web_search", "deep_research", "create_image"];
+var MODE_OPTION_IDS = [
+  "latest",
+  "instant",
+  "thinking",
+  "extended",
+  "medium",
+  "high",
+  "extraHigh",
+  "pro"
+];
 function flattenKey(localeList, key) {
   const seen = /* @__PURE__ */ new Set();
   const result = [];
@@ -1708,6 +2111,24 @@ function flattenTool(localeList, toolId) {
     const tools = locale["tools"];
     if (tools === void 0 || tools === null) continue;
     const value = tools[toolId];
+    if (value === void 0 || value === null) continue;
+    const candidates = typeof value === "string" ? [value] : value;
+    for (const candidate of candidates) {
+      if (candidate.length > 0 && !seen.has(candidate)) {
+        seen.add(candidate);
+        result.push(candidate);
+      }
+    }
+  }
+  return result;
+}
+function flattenModeOption(localeList, optionId) {
+  const seen = /* @__PURE__ */ new Set();
+  const result = [];
+  for (const locale of localeList) {
+    const modeOptions = locale["modeOptions"];
+    if (modeOptions === void 0 || modeOptions === null) continue;
+    const value = modeOptions[optionId];
     if (value === void 0 || value === null) continue;
     const candidates = typeof value === "string" ? [value] : value;
     for (const candidate of candidates) {
@@ -1752,8 +2173,12 @@ var builtLabels = Object.fromEntries(
 var builtTools = Object.fromEntries(
   TOOL_IDS.map((id2) => [id2, flattenTool(locales, id2)])
 );
+var builtModeOptions = Object.fromEntries(
+  MODE_OPTION_IDS.map((id2) => [id2, flattenModeOption(locales, id2)])
+);
 var localeLabels = {
   ...builtLabels,
+  modeOptions: builtModeOptions,
   tools: builtTools
 };
 function escapeRegExp(value) {
@@ -1783,8 +2208,17 @@ function localGuardTimeout(timeoutMs, capMs) {
 
 // src/browser/page-state.ts
 function parseConversationId(url) {
-  const match = /\/c\/([A-Za-z0-9-]+)/.exec(url);
-  return match?.[1];
+  let parsed;
+  try {
+    parsed = new URL(url, "https://chatgpt.com");
+  } catch {
+    return void 0;
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments[0] !== "c" || segments[1] === void 0 || segments[1].length === 0) {
+    return void 0;
+  }
+  return segments[1];
 }
 async function readPageState(page) {
   const rawUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
@@ -3928,7 +4362,7 @@ async function contextFromPage(page, partial = {}) {
     return { timestamp: (/* @__PURE__ */ new Date()).toISOString(), ...partial };
   }
   const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => partial.url) : partial.url;
-  const title = typeof page.title === "function" ? await page.title().catch(() => void 0) : partial.title;
+  const title = typeof page.title === "function" ? await withTimeout(page.title(), 1e3, "Timed out while reading page title.").catch(() => partial.title) : partial.title;
   const [turnCount, assistantTurnCount] = await Promise.all([
     withTimeout(countPageMessages(page), 1e3, "Timed out while counting page messages.").catch(() => partial.turnCount),
     withTimeout(countPageMessages(page, "assistant"), 1e3, "Timed out while counting assistant messages.").catch(() => partial.assistantTurnCount)
@@ -3976,8 +4410,51 @@ async function bootstrap(env, args = {}) {
   }
 }
 
-// src/commands/threads.ts
+// src/commands/conversation.ts
 var CHATGPT_HOME2 = "https://chatgpt.com/";
+async function ensureConversationTarget(page, target, options) {
+  const targetUrl = absoluteConversationUrl(target);
+  const expectedConversationId = parseConversationId(targetUrl);
+  const currentUrl = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+  if (expectedConversationId !== void 0 && parseConversationId(typeof currentUrl === "string" ? currentUrl : "") === expectedConversationId) {
+    await waitForConversationHydrated(page, options.timeoutMs, expectedConversationId);
+    return ensureResult(false, targetUrl, expectedConversationId);
+  }
+  await page.goto?.(targetUrl, { waitUntil: "domcontentloaded", timeout: options.timeoutMs });
+  await waitForConversationHydrated(page, options.timeoutMs, expectedConversationId);
+  return ensureResult(true, targetUrl, expectedConversationId);
+}
+async function waitForConversationHydrated(page, timeoutMs, expectedConversationId) {
+  const started = Date.now();
+  do {
+    const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
+    const urlMatches2 = expectedConversationId === void 0 || parseConversationId(typeof url === "string" ? url : "") === expectedConversationId;
+    const count = await countPageMessages(page).catch(() => 0);
+    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => void 0);
+    const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
+    if (urlMatches2 && ((latestAssistantText?.trim().length ?? 0) > 0 || count > 0 && title.length > 0 && title !== "ChatGPT")) {
+      await page.waitForTimeout?.(250);
+      return;
+    }
+    await page.waitForTimeout?.(500);
+  } while (Date.now() - started < timeoutMs);
+}
+function absoluteConversationUrl(target) {
+  if (target.href !== void 0 && target.href.startsWith("/")) {
+    return new URL(target.href, CHATGPT_HOME2).toString();
+  }
+  return target.href ?? target.url;
+}
+function ensureResult(navigated, targetUrl, expectedConversationId) {
+  const result = { navigated, targetUrl };
+  if (expectedConversationId !== void 0) {
+    result.expectedConversationId = expectedConversationId;
+  }
+  return result;
+}
+
+// src/commands/threads.ts
+var CHATGPT_HOME3 = "https://chatgpt.com/";
 function extractThreadSearchResultsFromHtml(html) {
   const anchors = html.matchAll(/<a\b(?<attrs>[^>]*\bhref=["'](?<href>\/c\/[^"']+)["'][^>]*)>(?<body>[\s\S]*?)<\/a>/gi);
   const results = [];
@@ -4038,7 +4515,7 @@ async function newThread(env, args = {}) {
     try {
       await newChatButton(page).click?.();
     } catch {
-      await page.goto?.(CHATGPT_HOME2, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
+      await page.goto?.(CHATGPT_HOME3, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
     }
     await page.waitForTimeout?.(500);
     const state = await readPageState(page);
@@ -4067,12 +4544,7 @@ async function openThread(env, args, previousResults) {
         context: await contextFromPage(page)
       };
     }
-    if (target.href !== void 0 && target.href.startsWith("/")) {
-      await page.goto?.(new URL(target.href, CHATGPT_HOME2).toString(), { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
-    } else {
-      await page.goto?.(target.href ?? target.url, { waitUntil: "domcontentloaded", timeout: args.timeoutMs ?? 3e4 });
-    }
-    await waitForThreadHydrated(page, args.timeoutMs ?? 3e4, parseConversationId(target.url));
+    await ensureConversationTarget(page, target, { timeoutMs: args.timeoutMs ?? 3e4 });
     const state = await readPageState(page);
     return resultOk(
       openThreadData(state.url, state.conversationId, state.title ?? target.title),
@@ -4093,21 +4565,21 @@ async function resolveOpenTarget(env, args, previousResults) {
     return { url: args.url };
   }
   if (args.conversationId !== void 0) {
-    return { url: new URL(`/c/${args.conversationId}`, CHATGPT_HOME2).toString() };
+    return { url: new URL(`/c/${args.conversationId}`, CHATGPT_HOME3).toString() };
   }
   if (args.fromStep !== void 0 && previousResults !== void 0) {
     const previous = previousResults.get(args.fromStep);
     const data = previous?.data;
     const selected = selectSearchResult(data?.results ?? [], args.select ?? "first");
     if (selected !== void 0) {
-      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME2).toString(), title: selected.title };
+      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME3).toString(), title: selected.title };
     }
   }
   if (args.title !== void 0) {
     const search = await searchThreads(env, { query: args.title, limit: 10 });
     const selected = selectSearchResult(search.data?.results ?? [], { title: args.title }) ?? search.data?.results[0];
     if (selected !== void 0) {
-      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME2).toString(), title: selected.title };
+      return { href: selected.href, url: new URL(selected.href, CHATGPT_HOME3).toString(), title: selected.title };
     }
   }
   return void 0;
@@ -4240,22 +4712,6 @@ function filterResultsByQuery(results, query) {
     return haystack.includes(wanted) || wanted.includes(normalizeForMatch(result.title));
   });
 }
-async function waitForThreadHydrated(page, timeoutMs, expectedConversationId) {
-  const started = Date.now();
-  await page.waitForTimeout?.(1e3);
-  while (Date.now() - started < timeoutMs) {
-    const url = typeof page.url === "function" ? await Promise.resolve(page.url()).catch(() => "") : "";
-    const urlMatches2 = expectedConversationId === void 0 || url.includes(expectedConversationId);
-    const count = await countPageMessages(page).catch(() => 0);
-    const latestAssistantText = await readLatestMessageText(page, "assistant").catch(() => void 0);
-    const title = typeof page.title === "function" ? await page.title().catch(() => "") : "";
-    if (urlMatches2 && ((latestAssistantText?.trim().length ?? 0) > 0 || count > 0 && title.length > 0 && title !== "ChatGPT")) {
-      await page.waitForTimeout?.(250);
-      return;
-    }
-    await page.waitForTimeout?.(500);
-  }
-}
 
 // src/dom/generation-state.ts
 var EMPTY_GENERATION_STATE = {
@@ -4348,6 +4804,22 @@ function generationStateFromText(text) {
   };
 }
 
+// src/commands/deadline.ts
+function createDeadline(timeoutMs, startedAtMs = Date.now()) {
+  const safeTimeoutMs = Math.max(0, timeoutMs);
+  return {
+    startedAtMs,
+    timeoutMs: safeTimeoutMs,
+    expiresAtMs: startedAtMs + safeTimeoutMs
+  };
+}
+function remainingMs(deadline, nowMs = Date.now()) {
+  return Math.max(0, deadline.expiresAtMs - nowMs);
+}
+function childTimeoutMs(deadline, capMs, nowMs = Date.now()) {
+  return Math.max(0, Math.min(Math.max(0, capMs), remainingMs(deadline, nowMs)));
+}
+
 // src/commands/output.ts
 function commandOutputText(data) {
   if (!isRecord(data)) return void 0;
@@ -4373,6 +4845,69 @@ function withCommandOutputText(result) {
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+// src/commands/probes.ts
+function createSingleFlightProbe(name, probe) {
+  let inFlight;
+  return async (arg, deadline, options) => {
+    if (inFlight !== void 0) {
+      return {
+        ok: false,
+        skipped: true,
+        warnings: [`Skipped ${name} DOM probe because previous browser-side work is still in flight.`]
+      };
+    }
+    const timeoutMs = childTimeoutMs(deadline, options.timeoutMs);
+    if (timeoutMs <= 0) {
+      return {
+        ok: false,
+        timedOut: true,
+        warnings: [`Skipped ${name} DOM probe because no deadline budget remained.`]
+      };
+    }
+    const current = probe(arg);
+    inFlight = current;
+    current.finally(() => {
+      if (inFlight === current) {
+        inFlight = void 0;
+      }
+    }).catch(() => void 0);
+    let timeout;
+    try {
+      const value = await Promise.race([
+        current,
+        new Promise((_resolve, reject) => {
+          timeout = setTimeout(() => reject(new ProbeTimeoutError(timeoutMs)), timeoutMs);
+        })
+      ]);
+      return { ok: true, value, warnings: [] };
+    } catch (error) {
+      if (error instanceof ProbeTimeoutError) {
+        return {
+          ok: false,
+          timedOut: true,
+          warnings: [`Timed out waiting ${timeoutMs}ms for ${name} DOM probe; this stopped SDK waiting but did not cancel browser-side work.`]
+        };
+      }
+      return {
+        ok: false,
+        warnings: [`${name} DOM probe failed: ${error instanceof Error ? error.message : String(error)}`]
+      };
+    } finally {
+      if (timeout !== void 0) {
+        clearTimeout(timeout);
+      }
+    }
+  };
+}
+var ProbeTimeoutError = class extends Error {
+  constructor(timeoutMs) {
+    super(`Probe timed out after ${timeoutMs}ms.`);
+    this.timeoutMs = timeoutMs;
+    this.name = "ProbeTimeoutError";
+  }
+  timeoutMs;
+};
 
 // src/commands/messages.ts
 function isResponseComplete(snapshot) {
@@ -4611,21 +5146,20 @@ async function waitForMessage(env, args = {}) {
   const stableMs = args.stableMs ?? (args.mode === "deep_research" ? 1e4 : 2e3);
   const pollMs = args.pollMs ?? 750;
   const started = Date.now();
+  const deadline = createDeadline(timeoutMs, started);
+  const probeTimeoutMs = Math.max(50, Math.min(1e3, Math.max(pollMs, Math.floor(timeoutMs / 4))));
+  const waitWarnings = /* @__PURE__ */ new Set();
+  const assistantProgressProbe = createSingleFlightProbe("assistant progress", readAssistantProgressSnapshot);
+  const pageStateProbe = createSingleFlightProbe("page state", readPageState);
+  const generationStateProbe = createSingleFlightProbe("assistant generation state", readAssistantGenerationState);
+  const responseActionsProbe = createSingleFlightProbe("assistant response actions", latestAssistantTurnHasResponseActions);
   let lastTargetText = "";
   let lastChangedAt = Date.now();
   let latestAssistantCount = await countPageMessages(page, "assistant").catch(() => 0);
   while (Date.now() - started < timeoutMs) {
-    const state = await readPageState(page).catch(() => void 0);
-    if (state?.blocker !== void 0 && state.blocker.kind !== "modal") {
-      return {
-        ok: false,
-        status: "blocked",
-        warnings: [],
-        blocker: state.blocker,
-        context: await contextFromPage(page)
-      };
-    }
-    const progress = await readAssistantProgressSnapshot(page).catch(() => fallbackAssistantProgressSnapshot(page, latestAssistantCount));
+    const progressResult = await assistantProgressProbe(page, deadline, { timeoutMs: probeTimeoutMs });
+    addWarnings(waitWarnings, progressResult.warnings);
+    const progress = await progressSnapshotFromProbeResult(page, progressResult, latestAssistantCount);
     latestAssistantCount = progress.assistantTurnCount;
     const targetReached = waitTargetReached(args, progress);
     const latestText = targetReached ? normalizeWhitespace(progress.latestText ?? "") : "";
@@ -4633,12 +5167,22 @@ async function waitForMessage(env, args = {}) {
       lastTargetText = latestText;
       lastChangedAt = Date.now();
     }
+    const state = await pageStateFromProbe(pageStateProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings);
+    if (state?.blocker !== void 0 && state.blocker.kind !== "modal") {
+      return {
+        ok: false,
+        status: "blocked",
+        warnings: [...waitWarnings],
+        blocker: state.blocker,
+        context: await contextFromPage(page)
+      };
+    }
     const snapshot = {
       latestText,
       stableMs,
       textStableForMs: Date.now() - lastChangedAt,
-      generation: await readAssistantGenerationState(page),
-      hasResponseActions: await latestAssistantTurnHasResponseActions(page)
+      generation: await generationStateFromProbe(generationStateProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings),
+      hasResponseActions: await responseActionsFromProbe(responseActionsProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings)
     };
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
       return withCommandOutputText({
@@ -4651,6 +5195,7 @@ async function waitForMessage(env, args = {}) {
           elapsedMs: Date.now() - started
         },
         warnings: [
+          ...waitWarnings,
           "ChatGPT generation appears to have been stopped or interrupted before completion.",
           ...snapshot.generation.signals.map((signal) => `Generation state signal: ${signal}`)
         ],
@@ -4660,7 +5205,8 @@ async function waitForMessage(env, args = {}) {
     if (targetReached && isResponseComplete(snapshot)) {
       return withCommandOutputText(resultOk(
         { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
-        await contextFromPage(page)
+        await contextFromPage(page),
+        [...waitWarnings]
       ));
     }
     await sleep(page, pollMs);
@@ -4675,14 +5221,14 @@ async function waitForMessage(env, args = {}) {
         assistantTurnCount: latestAssistantCount,
         elapsedMs: Date.now() - started
       },
-      warnings: ["Timed out after receiving partial assistant text."],
+      warnings: [...waitWarnings, "Timed out after receiving partial assistant text."],
       context: await contextFromPage(page)
     });
   }
   return {
     ok: false,
     status: "timeout",
-    warnings: [],
+    warnings: [...waitWarnings],
     error: {
       name: "WaitTimeout",
       message: "No assistant response appeared before the timeout.",
@@ -4690,6 +5236,35 @@ async function waitForMessage(env, args = {}) {
     },
     context: await contextFromPage(page)
   };
+}
+async function pageStateFromProbe(probe, warnings) {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : void 0;
+}
+async function progressSnapshotFromProbeResult(page, result, previousAssistantTurnCount) {
+  if (result.ok) {
+    return result.value;
+  }
+  if (result.timedOut === true || result.skipped === true) {
+    return { assistantTurnCount: previousAssistantTurnCount };
+  }
+  return fallbackAssistantProgressSnapshot(page, previousAssistantTurnCount);
+}
+async function generationStateFromProbe(probe, warnings) {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : EMPTY_GENERATION_STATE;
+}
+async function responseActionsFromProbe(probe, warnings) {
+  const result = await probe;
+  addWarnings(warnings, result.warnings);
+  return result.ok ? result.value : false;
+}
+function addWarnings(target, warnings) {
+  for (const warning of warnings) {
+    target.add(warning);
+  }
 }
 async function readLatest(env, args = {}) {
   const boot = await ensurePage2(env);
@@ -6875,6 +7450,31 @@ async function ensurePage5(env) {
   return bootstrap(env, { preferExistingTab: true });
 }
 
+// src/dom/label-match.ts
+function normalizeForLabelMatch(text) {
+  return normalizeWhitespace(text.normalize("NFKC")).toLocaleLowerCase();
+}
+function visibleLabelMatches(label, wanted) {
+  const normalizedLabel = normalizeForLabelMatch(label);
+  const normalizedWanted = normalizeForLabelMatch(wanted);
+  if (normalizedWanted.length === 0) {
+    return false;
+  }
+  if (normalizedLabel === normalizedWanted) {
+    return true;
+  }
+  if (isShortLatinToken(normalizedWanted)) {
+    return new RegExp(`(^|[^\\p{L}\\p{N}])${escapeRegExp2(normalizedWanted)}([^\\p{L}\\p{N}]|$)`, "iu").test(normalizedLabel);
+  }
+  return normalizedLabel.includes(normalizedWanted);
+}
+function isShortLatinToken(value) {
+  return value.length <= 3 && /^[a-z0-9]+$/i.test(value);
+}
+function escapeRegExp2(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 // src/dom/menus.ts
 function extractMenuItemsFromText(text) {
   return text.split(/\n| {2,}| • /).map((label) => normalizeWhitespace(label)).filter(Boolean).map((label) => ({ label, normalized: normalizeLabel(label) }));
@@ -6918,13 +7518,16 @@ function findUniqueMenuItem(items, wanted) {
   if (exact.length === 1) {
     return exact[0];
   }
-  const fuzzy = items.filter((item) => item.normalized.includes(normalized));
+  const fuzzy = items.filter((item) => visibleLabelMatches(item.label, wanted));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
 }
 
 // src/commands/modes.ts
 var DEFAULT_MODE_EFFORT = "Thinking";
-var CURRENT_MODE_LABELS = [...localeLabels.modeLabels];
+var CURRENT_MODE_LABELS = dedupeLabels([
+  ...localeLabels.modeLabels,
+  ...Object.values(localeLabels.modeOptions).flat()
+]);
 var MODE_OPENER_LABELS = [...CURRENT_MODE_LABELS.filter((label) => label !== "Pro"), ...localeLabels.modeOpenerExtra];
 var MODEL_VERSION_FAMILY_PATTERN = /^gpt[\s-]/i;
 var MODEL_VERSION_LABEL_PATTERN = /^(?:o\d+|\d+(?:\.\d+)?)$/i;
@@ -6932,8 +7535,36 @@ var CANONICAL_INTELLIGENCE_ORDER = /* @__PURE__ */ new Map([
   ["instant", 0],
   ["medium", 1],
   ["high", 2],
-  ["extra high", 3],
+  ["extraHigh", 3],
   ["pro", 4]
+]);
+var MODE_OPTION_IDS2 = [
+  "latest",
+  "instant",
+  "thinking",
+  "extended",
+  "medium",
+  "high",
+  "extraHigh",
+  "pro"
+];
+var MODE_ID_ALIASES = {
+  latest: ["latest"],
+  instant: ["instant"],
+  thinking: ["thinking"],
+  extended: ["extended"],
+  medium: ["medium"],
+  high: ["high"],
+  extraHigh: ["extra high", "extra-high", "extra_high", "extrahigh"],
+  pro: ["pro"]
+};
+var THREAD_ACTION_MENU_LABELS = /* @__PURE__ */ new Set([
+  "archive",
+  "copy link",
+  "delete",
+  "move to project",
+  "rename",
+  "share"
 ]);
 async function setMode(env, args) {
   const boot = await ensurePage6(env);
@@ -6942,9 +7573,9 @@ async function setMode(env, args) {
   }
   const page = env.page;
   try {
-    const requested = requestedModeLabels(args);
+    const requested = requestedModeSelections(args);
     const requestedVersion = requestedModelVersion(args);
-    const requestedForOpening = requestedVersion === void 0 ? requested : [...requested, requestedVersion];
+    const requestedForOpening = requestedVersion === void 0 ? requested : [...requested, requestedModeSelection(requestedVersion)];
     const opened = await waitForModeMenu(page, requestedForOpening, args.timeoutMs ?? 3e4);
     if (requestedVersion === void 0 && opened.alreadySelected.length === requested.length) {
       return resultOk({ selected: opened.alreadySelected, candidates: opened.modeButtons }, await contextFromPage(page));
@@ -6955,15 +7586,25 @@ async function setMode(env, args) {
     await page.waitForTimeout?.(250);
     const candidates = await enumerateVisibleMenuItems(page);
     const selected = [];
-    for (const item of requested) {
-      const match = findModeMenuItem(candidates, item);
+    if (requested.length > 0 && shouldRejectAsWrongModeMenu(candidates)) {
+      const candidateLabels2 = candidates.map((candidate) => candidate.label);
+      return {
+        ok: false,
+        status: "unsupported",
+        warnings: [],
+        blocker: selectorDriftBlocker("Visible menu appears to be a thread/action menu, not the ChatGPT mode menu.", candidateLabels2),
+        context: await contextFromPage(page)
+      };
+    }
+    for (const request of requested) {
+      const match = findModeMenuItem(candidates, request);
       if (match === void 0) {
         const candidateLabels2 = candidates.map((candidate) => candidate.label);
         return {
           ok: false,
           status: "unsupported",
           warnings: [],
-          blocker: selectorDriftBlocker(`Mode option "${item}" was not found or was ambiguous.`, candidateLabels2),
+          blocker: selectorDriftBlocker(`Mode option "${request.requested}" was not found or was ambiguous.`, candidateLabels2),
           context: await contextFromPage(page)
         };
       }
@@ -7088,6 +7729,27 @@ function looksLikeModeMenu(labels) {
     return CURRENT_MODE_LABELS.some((modeLabel) => visibleLabelMatches(normalized, normalizeLabel(modeLabel)));
   });
 }
+function shouldRejectAsWrongModeMenu(items) {
+  if (items.length === 0) {
+    return false;
+  }
+  const hasPositiveModeEvidence = items.some((item) => {
+    if (item.testId?.startsWith("model-switcher-") === true) {
+      return true;
+    }
+    if (MODEL_VERSION_FAMILY_PATTERN.test(item.label) || MODEL_VERSION_LABEL_PATTERN.test(item.label)) {
+      return true;
+    }
+    if (item.role === "menuitemradio" && CURRENT_MODE_LABELS.some((label) => visibleLabelMatches(item.label, label))) {
+      return true;
+    }
+    return CURRENT_MODE_LABELS.some((label) => visibleLabelMatches(item.label, label));
+  });
+  if (hasPositiveModeEvidence) {
+    return false;
+  }
+  return items.some((item) => THREAD_ACTION_MENU_LABELS.has(normalizeForLabelMatch(item.label)));
+}
 async function clickMenuItem(page, label) {
   if (await clickModelSwitcherMenuItem(page, label)) {
     return true;
@@ -7174,12 +7836,14 @@ function toolLabels(tool) {
   const known = localeLabels.tools[tool];
   return known !== void 0 ? [...known] : [tool];
 }
-function findModeMenuItem(candidates, wanted) {
-  const exact = findUniqueMenuItem(candidates, wanted);
-  if (exact !== void 0) {
-    return exact;
+function findModeMenuItem(candidates, request) {
+  for (const wanted of request.labels) {
+    const exact = findUniqueMenuItem(candidates, wanted);
+    if (exact !== void 0) {
+      return exact;
+    }
   }
-  const wantedIndex = CANONICAL_INTELLIGENCE_ORDER.get(normalizeLabel(wanted));
+  const wantedIndex = request.modeId === void 0 ? void 0 : CANONICAL_INTELLIGENCE_ORDER.get(request.modeId);
   if (wantedIndex === void 0) {
     return void 0;
   }
@@ -7188,12 +7852,39 @@ function findModeMenuItem(candidates, wanted) {
   );
   return intelligenceItems.length >= CANONICAL_INTELLIGENCE_ORDER.size ? intelligenceItems[wantedIndex] : void 0;
 }
-function requestedModeLabels(args) {
+function requestedModeSelections(args) {
   const requested = [args.model, args.intelligence, args.effort].filter((value) => value !== void 0);
   if (requestedModelVersion(args) !== void 0 && requested.length === 0) {
     return [];
   }
-  return requested.length > 0 ? requested : [DEFAULT_MODE_EFFORT];
+  return (requested.length > 0 ? requested : [DEFAULT_MODE_EFFORT]).map(requestedModeSelection);
+}
+function requestedModeSelection(requested) {
+  const modeId = modeOptionIdFor(requested);
+  const labels = modeId === void 0 ? [requested] : localeLabels.modeOptions[modeId];
+  const request = {
+    requested,
+    labels: labels.length > 0 ? [...labels] : [requested]
+  };
+  if (modeId !== void 0) {
+    request.modeId = modeId;
+  }
+  return request;
+}
+function modeOptionIdFor(value) {
+  const normalized = normalizeModeLookupKey(value);
+  for (const id2 of MODE_OPTION_IDS2) {
+    if (MODE_ID_ALIASES[id2].some((alias) => normalizeModeLookupKey(alias) === normalized)) {
+      return id2;
+    }
+    if (localeLabels.modeOptions[id2].some((label) => normalizeModeLookupKey(label) === normalized)) {
+      return id2;
+    }
+  }
+  return void 0;
+}
+function normalizeModeLookupKey(value) {
+  return normalizeForLabelMatch(value).replace(/[_-]+/g, " ");
 }
 function requestedModelVersion(args) {
   return args.modelVersion ?? args.version;
@@ -7207,25 +7898,25 @@ function findUniqueVisibleLabel(labels, wanted) {
   const fuzzy = labels.filter((label) => visibleLabelMatches(normalizeLabel(label), normalized));
   return fuzzy.length === 1 ? fuzzy[0] : void 0;
 }
-function visibleLabelMatches(label, wanted) {
-  if (wanted.length <= 3) {
-    return new RegExp(`(^|[^a-z0-9])${escapeRegExp2(wanted)}([^a-z0-9]|$)`, "i").test(label);
-  }
-  return label.includes(wanted);
-}
-function escapeRegExp2(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 function escapeAttributeValue(value) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 function findAlreadySelectedModes(visibleButtons, requested) {
-  return requested.map((label) => findUniqueVisibleLabel(visibleButtons, label)).filter((label) => label !== void 0);
+  return requested.map((request) => findUniqueVisibleLabelForRequest(visibleButtons, request)).filter((label) => label !== void 0);
+}
+function findUniqueVisibleLabelForRequest(labels, request) {
+  for (const label of request.labels) {
+    const found = findUniqueVisibleLabel(labels, label);
+    if (found !== void 0) {
+      return found;
+    }
+  }
+  return void 0;
 }
 async function selectModelVersion(page, requestedVersion, currentCandidates, timeoutMs) {
   let candidates = await enumerateVisibleMenuItems(page);
   if (!looksLikeModeMenu(candidates.map((candidate) => candidate.label))) {
-    const opened2 = await waitForModeMenu(page, [requestedVersion], timeoutMs);
+    const opened2 = await waitForModeMenu(page, [{ requested: requestedVersion, labels: [requestedVersion] }], timeoutMs);
     if (opened2.opened) {
       await page.waitForTimeout?.(250);
       candidates = await enumerateVisibleMenuItems(page);
@@ -7816,6 +8507,7 @@ var REQUIRED_LOCALE_KEYS = [
   "rateLimitBlocker"
 ];
 var REQUIRED_TOOL_IDS = ["web_search", "deep_research", "create_image"];
+var REQUIRED_MODE_OPTION_IDS = ["latest", "instant", "thinking", "extended", "medium", "high", "extraHigh", "pro"];
 async function doctor(env, args = {}) {
   const wanted = args.check ?? DEFAULT_CHECKS;
   const checks = {};
@@ -8015,19 +8707,23 @@ async function filePreflightCheck(env, args) {
 function localizationCheck(env) {
   const requiredKeysMissing = REQUIRED_LOCALE_KEYS.filter((key) => localeLabels[key].length === 0);
   const missingToolIds = REQUIRED_TOOL_IDS.filter((id2) => (localeLabels.tools[id2]?.length ?? 0) === 0);
+  const missingModeOptionIds = REQUIRED_MODE_OPTION_IDS.filter((id2) => (localeLabels.modeOptions[id2]?.length ?? 0) === 0);
   const toolIds = Object.keys(localeLabels.tools);
-  const englishCanonicalPresent = localeLabels.composerTextbox[0] === "Chat with ChatGPT" && localeLabels.sendButton[0] === "Send prompt" && localeLabels.modeLabels.includes("Thinking") && localeLabels.tools.web_search?.[0] === "Web search";
-  const labelCandidateCount = REQUIRED_LOCALE_KEYS.reduce((total, key) => total + localeLabels[key].length, 0) + Object.values(localeLabels.tools).reduce((total, values) => total + values.length, 0);
+  const modeOptionIds = Object.keys(localeLabels.modeOptions);
+  const englishCanonicalPresent = localeLabels.composerTextbox[0] === "Chat with ChatGPT" && localeLabels.sendButton[0] === "Send prompt" && localeLabels.modeLabels.includes("Thinking") && localeLabels.modeOptions.pro?.[0] === "Pro" && localeLabels.tools.web_search?.[0] === "Web search";
+  const labelCandidateCount = REQUIRED_LOCALE_KEYS.reduce((total, key) => total + localeLabels[key].length, 0) + Object.values(localeLabels.tools).reduce((total, values) => total + values.length, 0) + Object.values(localeLabels.modeOptions).reduce((total, values) => total + values.length, 0);
   const details = {
     englishCanonicalPresent,
     requiredKeysMissing,
     missingToolIds,
+    missingModeOptionIds,
     toolIds,
+    modeOptionIds,
     labelCandidateCount,
     pageAvailable: env.page !== void 0,
     runtimeSelectorCoverage: "registry_only_stage_2"
   };
-  if (englishCanonicalPresent && requiredKeysMissing.length === 0 && missingToolIds.length === 0) {
+  if (englishCanonicalPresent && requiredKeysMissing.length === 0 && missingToolIds.length === 0 && missingModeOptionIds.length === 0) {
     return unknown("The locale registry is loaded; localized runtime selector coverage is registry-only in Stage 2 and not fully proven.", void 0, details);
   }
   return blocked(


### PR DESCRIPTION
## Summary
- adopt the safe parts of #23 through the private source-of-truth exporter
- add semantic, verified-locale mode option matching so short `Pro` requests cannot match project/action rows
- centralize exact parsed conversation-id hydration and skip reloads when already on the target conversation
- add deadline-aware single-flight DOM probes for wait recovery, neutral generation-state fallback, and bounded result-context title reads
- regenerate plugin runtime bundles from the updated package source

## Notes
This public PR is generated from the private source tree. It intentionally does not include the private planning/review artifacts or raw live ChatGPT capture JSONL files.

## Verification
- private PR #25 passed deterministic-gates, node-backend-contracts, and python-parity before merge
- private PR #26 regenerated runtime bundles and passed local runtime build/check before merge
- `node tools/public-export/export-public.mjs --check --target /Users/adamallcock/Documents/Coding/codex-chatgpt-control`
- `npm run node:build`
- `npm run python:compile`
- `npm run node:contracts`
- `npm run plugin:validate`
- `npm run node:bundle`
- `npm run plugin:check`
- `npm run node:test`

## Live smoke
- ChatGPT doctor bridge/login/localization/modes passed
- German and Persian Intelligence picker captures passed; English restore passed
- `modes.set` selected Pro/high without project-row confusion
- ask/wait/read returned the exact expected response
- same-conversation `threads.open` returned without warnings