### PR TITLE
Stabilize waitAndRead polling

### DIFF
--- a/packages/node/src/backend/client.ts
+++ b/packages/node/src/backend/client.ts
@@ -38,6 +38,7 @@ import type {
   SelectToolArgs,
   SequencePlan,
   SetModeArgs,
+  WaitAndReadArgs,
   WaitArgs
 } from "../types.js";
 import {
@@ -119,7 +120,7 @@ export type ChatGPTBackendClient = {
     ask(args: { text: string; wait?: boolean | WaitArgs; read?: boolean | ReadLatestArgs; timeoutMs?: number }): Promise<CommandResult<unknown>>;
     wait(args?: WaitArgs): Promise<CommandResult<unknown>>;
     readLatest(args?: ReadLatestArgs): Promise<CommandResult<unknown>>;
-    waitAndRead(args?: WaitArgs & ReadLatestArgs): Promise<CommandResult<unknown>>;
+    waitAndRead(args?: WaitAndReadArgs): Promise<CommandResult<unknown>>;
   };
   files: {
     attach(args: { paths: string[]; timeoutMs?: number }): Promise<CommandResult<unknown>>;

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -27,6 +27,7 @@ import type {
   SequenceStep,
   SetModeArgs,
   ThreadTarget,
+  WaitAndReadArgs,
   WaitArgs
 } from "./types.js";
 import { downloadLatestArtifact, listLatestArtifacts, waitForArtifact } from "./commands/artifacts.js";
@@ -193,7 +194,7 @@ export type ChatGPTClient = {
     ask(args: AskArgs): Promise<CommandResult<unknown>>;
     wait(args?: WaitArgs): Promise<CommandResult<unknown>>;
     readLatest(args?: ReadLatestArgs): Promise<CommandResult<unknown>>;
-    waitAndRead(args?: WaitArgs & ReadLatestArgs): Promise<CommandResult<unknown>>;
+    waitAndRead(args?: WaitAndReadArgs): Promise<CommandResult<unknown>>;
   };
   files: {
     preflight(args: FilePreflightArgs): Promise<CommandResult<FilePreflightData>>;

--- a/packages/node/src/commands/messages.ts
+++ b/packages/node/src/commands/messages.ts
@@ -662,7 +662,8 @@ export async function waitAndRead(
   env: RuntimeEnv,
   args: WaitAndReadArgs = {}
 ): Promise<CommandResult<AskReadData>> {
-  const wait = await waitForMessage(env, args);
+  const waitArgs = waitAndReadWaitArgs(args);
+  const wait = await waitForMessage(env, waitArgs);
   if (!wait.ok && wait.status !== "partial") {
     return forwardFailure(wait);
   }
@@ -695,6 +696,7 @@ export async function waitAndRead(
       data,
       warnings: [
         ...warnings,
+        ...waitAndReadChunkWarnings(args, waitArgs),
         "Assistant response was read after partial wait, but completion was not confirmed."
       ],
       context: read.context
@@ -702,6 +704,28 @@ export async function waitAndRead(
   }
 
   return withCommandOutputText(resultOk(data, read.context, warnings));
+}
+
+function waitAndReadWaitArgs(args: WaitAndReadArgs = {}): WaitArgs {
+  const waitArgs: WaitArgs = { ...args };
+  const requested = finitePositiveNumber(args.timeoutMs) ?? 45000;
+  const chunk = finitePositiveNumber(args.maxWaitChunkMs) ?? 45000;
+  waitArgs.timeoutMs = Math.min(requested, chunk);
+  return waitArgs;
+}
+
+function waitAndReadChunkWarnings(args: WaitAndReadArgs = {}, waitArgs: WaitArgs = {}): string[] {
+  const requested = finitePositiveNumber(args.timeoutMs);
+  if (requested !== undefined && waitArgs.timeoutMs !== undefined && waitArgs.timeoutMs < requested) {
+    return [`waitAndRead used a bounded ${waitArgs.timeoutMs}ms wait chunk; call waitAndRead again on the same thread to continue without resubmitting.`];
+  }
+  return [];
+}
+
+function finitePositiveNumber(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? Math.max(1, numberValue) : undefined;
 }
 
 async function ensurePage(env: RuntimeEnv): Promise<CommandResult<unknown>> {

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -336,7 +336,9 @@ export type ReadLatestData = {
   sourcesAvailable?: boolean;
 };
 
-export type WaitAndReadArgs = WaitArgs & ReadLatestArgs;
+export type WaitAndReadArgs = WaitArgs & ReadLatestArgs & {
+  maxWaitChunkMs?: number;
+};
 
 export type AskArgs = {
   text: string;

--- a/packages/node/tests/unit/messages.test.ts
+++ b/packages/node/tests/unit/messages.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { askMessage, isResponseComplete, readLatest, submittedUserTurnMatches, submitMessage, waitForMessage } from "../../src/commands/messages.js";
+import { askMessage, isResponseComplete, readLatest, submittedUserTurnMatches, submitMessage, waitAndRead, waitForMessage } from "../../src/commands/messages.js";
 import { copyResponse } from "../../src/commands/response-actions.js";
 import { EMPTY_GENERATION_STATE } from "../../src/dom/generation-state.js";
 import {
@@ -390,6 +390,25 @@ describe("extractMessagesFromHtml", () => {
     expect(result.data?.complete).toBe(false);
     expect(result.warnings.join(" ")).toContain("Timed out after receiving partial assistant text.");
     expect(result.warnings.join(" ")).toContain("completion was not confirmed");
+  });
+
+  it("bounds waitAndRead waits so callers can continue polling the same thread", async () => {
+    const page = askWaitFallbackPage("Earlier question.", "Earlier answer.");
+
+    const result = await waitAndRead({ page }, {
+      timeoutMs: 120000,
+      maxWaitChunkMs: 5,
+      stableMs: 0,
+      pollMs: 1,
+      format: "normalized_text"
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+    expect(result.output_text).toBe("Earlier answer.");
+    expect(result.data?.complete).toBe(false);
+    expect(result.warnings.join(" ")).toContain("bounded 5ms wait chunk");
+    expect(result.warnings.join(" ")).toContain("same thread");
   });
 
   it("waits for the send button to become ready before clicking", async () => {

--- a/plugins/codex-chatgpt-control/runtime/import-chatgpt-control.mjs
+++ b/plugins/codex-chatgpt-control/runtime/import-chatgpt-control.mjs
@@ -1,6 +1,18 @@
 import { pathToFileURL } from "node:url";
 
+function installNoiseFilter() {
+  if (globalThis.__codexChatGPTControlNoiseFilterInstalled) return;
+  globalThis.__codexChatGPTControlNoiseFilterInstalled = true;
+  const originalWarn = console.warn.bind(console);
+  console.warn = (...args) => {
+    const text = args.map((arg) => String(arg)).join(" ");
+    if (text.includes("[Statsig]") && text.includes("making requests too frequently")) return;
+    originalWarn(...args);
+  };
+}
+
 export async function importChatGPTControl({ cacheBust = true } = {}) {
+  installNoiseFilter();
   const runtimeUrl = new URL("./node/codex-chatgpt-control.bundle.mjs", import.meta.url);
   const href = cacheBust
     ? `${runtimeUrl.href}?t=${Date.now()}`

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
@@ -6832,7 +6832,8 @@ async function askMessage(env, args) {
   return withCommandOutputText(resultOk(data, await contextFromPage(page), warnings));
 }
 async function waitAndRead(env, args = {}) {
-  const wait = await waitForMessage(env, args);
+  const waitArgs = waitAndReadWaitArgs(args);
+  const wait = await waitForMessage(env, waitArgs);
   if (!wait.ok && wait.status !== "partial") {
     return forwardFailure(wait);
   }
@@ -6863,12 +6864,32 @@ async function waitAndRead(env, args = {}) {
       data,
       warnings: [
         ...warnings,
+        ...waitAndReadChunkWarnings(args, waitArgs),
         "Assistant response was read after partial wait, but completion was not confirmed."
       ],
       context: read.context
     });
   }
   return withCommandOutputText(resultOk(data, read.context, warnings));
+}
+function waitAndReadWaitArgs(args = {}) {
+  const waitArgs = { ...args };
+  const requested = finitePositiveNumber(args.timeoutMs) ?? 45e3;
+  const chunk = finitePositiveNumber(args.maxWaitChunkMs) ?? 45e3;
+  waitArgs.timeoutMs = Math.min(requested, chunk);
+  return waitArgs;
+}
+function waitAndReadChunkWarnings(args = {}, waitArgs = {}) {
+  const requested = finitePositiveNumber(args.timeoutMs);
+  if (requested !== void 0 && waitArgs.timeoutMs !== void 0 && waitArgs.timeoutMs < requested) {
+    return [`waitAndRead used a bounded ${waitArgs.timeoutMs}ms wait chunk; call waitAndRead again on the same thread to continue without resubmitting.`];
+  }
+  return [];
+}
+function finitePositiveNumber(value) {
+  if (value === void 0) return void 0;
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? Math.max(1, numberValue) : void 0;
 }
 async function ensurePage3(env) {
   if (env.page !== void 0) {

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
@@ -5465,7 +5465,8 @@ async function askMessage(env, args) {
   return withCommandOutputText(resultOk(data, await contextFromPage(page), warnings));
 }
 async function waitAndRead(env, args = {}) {
-  const wait = await waitForMessage(env, args);
+  const waitArgs = waitAndReadWaitArgs(args);
+  const wait = await waitForMessage(env, waitArgs);
   if (!wait.ok && wait.status !== "partial") {
     return forwardFailure(wait);
   }
@@ -5496,12 +5497,32 @@ async function waitAndRead(env, args = {}) {
       data,
       warnings: [
         ...warnings,
+        ...waitAndReadChunkWarnings(args, waitArgs),
         "Assistant response was read after partial wait, but completion was not confirmed."
       ],
       context: read.context
     });
   }
   return withCommandOutputText(resultOk(data, read.context, warnings));
+}
+function waitAndReadWaitArgs(args = {}) {
+  const waitArgs = { ...args };
+  const requested = finitePositiveNumber(args.timeoutMs) ?? 45e3;
+  const chunk = finitePositiveNumber(args.maxWaitChunkMs) ?? 45e3;
+  waitArgs.timeoutMs = Math.min(requested, chunk);
+  return waitArgs;
+}
+function waitAndReadChunkWarnings(args = {}, waitArgs = {}) {
+  const requested = finitePositiveNumber(args.timeoutMs);
+  if (requested !== void 0 && waitArgs.timeoutMs !== void 0 && waitArgs.timeoutMs < requested) {
+    return [`waitAndRead used a bounded ${waitArgs.timeoutMs}ms wait chunk; call waitAndRead again on the same thread to continue without resubmitting.`];
+  }
+  return [];
+}
+function finitePositiveNumber(value) {
+  if (value === void 0) return void 0;
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? Math.max(1, numberValue) : void 0;
 }
 async function ensurePage2(env) {
   if (env.page !== void 0) {

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
@@ -5410,7 +5410,8 @@ async function askMessage(env, args) {
   return withCommandOutputText(resultOk(data, await contextFromPage(page), warnings));
 }
 async function waitAndRead(env, args = {}) {
-  const wait = await waitForMessage(env, args);
+  const waitArgs = waitAndReadWaitArgs(args);
+  const wait = await waitForMessage(env, waitArgs);
   if (!wait.ok && wait.status !== "partial") {
     return forwardFailure(wait);
   }
@@ -5441,12 +5442,32 @@ async function waitAndRead(env, args = {}) {
       data,
       warnings: [
         ...warnings,
+        ...waitAndReadChunkWarnings(args, waitArgs),
         "Assistant response was read after partial wait, but completion was not confirmed."
       ],
       context: read.context
     });
   }
   return withCommandOutputText(resultOk(data, read.context, warnings));
+}
+function waitAndReadWaitArgs(args = {}) {
+  const waitArgs = { ...args };
+  const requested = finitePositiveNumber(args.timeoutMs) ?? 45e3;
+  const chunk = finitePositiveNumber(args.maxWaitChunkMs) ?? 45e3;
+  waitArgs.timeoutMs = Math.min(requested, chunk);
+  return waitArgs;
+}
+function waitAndReadChunkWarnings(args = {}, waitArgs = {}) {
+  const requested = finitePositiveNumber(args.timeoutMs);
+  if (requested !== void 0 && waitArgs.timeoutMs !== void 0 && waitArgs.timeoutMs < requested) {
+    return [`waitAndRead used a bounded ${waitArgs.timeoutMs}ms wait chunk; call waitAndRead again on the same thread to continue without resubmitting.`];
+  }
+  return [];
+}
+function finitePositiveNumber(value) {
+  if (value === void 0) return void 0;
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? Math.max(1, numberValue) : void 0;
 }
 async function ensurePage2(env) {
   if (env.page !== void 0) {

--- a/plugins/codex-chatgpt-control/skills/chatgpt-pro-consult/SKILL.md
+++ b/plugins/codex-chatgpt-control/skills/chatgpt-pro-consult/SKILL.md
@@ -50,6 +50,7 @@ Do not import from an older manually installed skill runtime; the plugin-bundled
 ```js
 const TOOL_CALL_SAFE_WAIT = {
   timeoutMs: 90_000,
+  maxWaitChunkMs: 45_000,
   stableMs: 2_000,
   pollMs: 750,
   mode: "deep_research"

--- a/scripts/build-plugin-runtime.mjs
+++ b/scripts/build-plugin-runtime.mjs
@@ -130,7 +130,19 @@ async function main() {
     path.join(root, "plugins/codex-chatgpt-control/runtime/import-chatgpt-control.mjs"),
     `import { pathToFileURL } from "node:url";
 
+function installNoiseFilter() {
+  if (globalThis.__codexChatGPTControlNoiseFilterInstalled) return;
+  globalThis.__codexChatGPTControlNoiseFilterInstalled = true;
+  const originalWarn = console.warn.bind(console);
+  console.warn = (...args) => {
+    const text = args.map((arg) => String(arg)).join(" ");
+    if (text.includes("[Statsig]") && text.includes("making requests too frequently")) return;
+    originalWarn(...args);
+  };
+}
+
 export async function importChatGPTControl({ cacheBust = true } = {}) {
+  installNoiseFilter();
   const runtimeUrl = new URL("./node/codex-chatgpt-control.bundle.mjs", import.meta.url);
   const href = cacheBust
     ? \`\${runtimeUrl.href}?t=\${Date.now()}\`


### PR DESCRIPTION
## Summary

- bound `messages.waitAndRead` waits into resumable chunks so long ChatGPT responses return partial output before host tool timeouts
- add `maxWaitChunkMs` to the typed wait-and-read surface and Pro consult example
- filter repeated Statsig rate-limit warnings from the plugin runtime loader

## Why

Long Pro/deep-research responses can keep generating past the host execution window. Previously a single `waitAndRead` call could run until the caller process timed out, losing the JS kernel state and making the submitted thread harder to resume. The new default keeps each wait chunk bounded while preserving the existing partial response contract.

## Validation

- `npm --prefix packages/node test -- tests/unit/messages.test.ts`
- `npm --prefix packages/node run build`
- `npm --prefix packages/node run contract:validate`
- `npm --prefix packages/node run docs:drift`
- `npm --prefix packages/node run parity:fixtures`
- `npm --prefix packages/node run parity:suite`
- `npm run plugin:check`
- `npm run plugin:validate`
