### PR TITLE
Expose status-only wait polling

### DIFF
--- a/packages/node/contracts/v1/fixtures/command-descriptors.json
+++ b/packages/node/contracts/v1/fixtures/command-descriptors.json
@@ -651,7 +651,13 @@
       "summary": "Compose, submit, optionally wait, and optionally read."
     },
     {
-      "args": {},
+      "args": {
+        "mode": "normal or deep_research",
+        "pollMs": "optional polling interval",
+        "responseContent": "include for current behavior, metadata to omit assistant text and return chars/hash only",
+        "stableMs": "optional stability window before completion",
+        "timeoutMs": "optional wait timeout"
+      },
       "blockers": [
         "browser_bridge_unavailable",
         "login_required",

--- a/packages/node/contracts/v1/fixtures/reports-create-redacted.json
+++ b/packages/node/contracts/v1/fixtures/reports-create-redacted.json
@@ -17,7 +17,7 @@
         "target": {
           "bytes": 335,
           "path": "/tmp/codex-chatgpt-control/reports/contract-fixtures/fixed-contract-report.json",
-          "sha256": "019c250aafc2ca9d5087acc223a0bacf7cae1538c9b0978239bda575a734d920"
+          "sha256": "e7c32e0911344d93330fd497a67985b7ee4adb5d78fb6b1fb18aed6133693ee1"
         }
       },
       "metaPath": "/tmp/codex-chatgpt-control/reports/contract-fixtures/fixed-contract-report.json.meta.json",

--- a/packages/node/references/backend-protocol.md
+++ b/packages/node/references/backend-protocol.md
@@ -67,7 +67,7 @@ Current protocol error codes are:
 
 Browser-control blockers are not protocol errors. They are normal command or runner results with `status: "blocked"`, `status: "partial"`, or `status: "needs_confirmation"` plus blocker/interruption details.
 
-`status: "partial"` is the required result for incomplete response capture. A partial result may still include `output_text` and `data.responseText`, but consumers must treat that text as incomplete until a later wait confirms completion. Common causes are wait timeout after partial assistant text, active generation controls such as `Stop answering`, stopped-generation markers such as `Stopped thinking`, or a read fallback after the wait step could not confirm completion. Intentional capture clipping uses `data.captureLimit` plus warnings; it is separate from ChatGPT generation length.
+`status: "partial"` is the required result for incomplete response capture. A partial result may still include `output_text` and `data.responseText`, but consumers must treat that text as incomplete until a later wait confirms completion. Common causes are wait timeout after partial assistant text, active generation controls such as `Stop answering`, stopped-generation markers such as `Stopped thinking`, or a read fallback after the wait step could not confirm completion. For status-only polling, `messages.wait` accepts `responseContent: "metadata"`; partial and completed wait results then omit assistant text and instead return compact metadata such as `data.responseChars` and `data.responseSha256`. Intentional capture clipping uses `data.captureLimit` plus warnings; it is separate from ChatGPT generation length.
 
 ## Streaming
 

--- a/packages/node/references/python-parity.md
+++ b/packages/node/references/python-parity.md
@@ -29,6 +29,8 @@ Wire fields stay TypeScript-compatible. Python exposes idiomatic aliases:
 
 Incomplete response capture is also shared contract behavior. Python must preserve `status == "partial"`, `output_text`, warnings, and any nested `data.captureLimit` dictionaries exactly as the TypeScript backend returns them. `partial` is not a protocol error: callers should inspect `data.complete` and run another wait/read on the same thread when they need final output.
 
+For long-answer polling, Python forwards `response_content="metadata"` to the shared wire field `responseContent: "metadata"` on `messages.wait`. The TypeScript backend then omits assistant text from wait results and returns compact metadata such as `data.responseChars` and `data.responseSha256`; Python must preserve those fields without trying to reconstruct omitted content.
+
 Generated-image behavior stays owned by the TypeScript runtime. Python exposes
 the same backend commands through `chatgpt.artifacts.list_latest(...)`,
 `chatgpt.artifacts.wait(...)`, and `chatgpt.artifacts.download_latest(...)`.

--- a/packages/node/references/troubleshooting.md
+++ b/packages/node/references/troubleshooting.md
@@ -115,12 +115,20 @@ Use `readLatest({ format: "markdown" })`, `copyLatest()`, or the default SDK `re
 
 ## Long Responses Return `partial`
 
-Long Pro, Thinking, Deep Research, or file-backed answers can take longer than the default wait window. Treat `status: "partial"` and `data.complete: false` as an incomplete capture even when `output_text` is non-empty. Re-run `messages.wait(...)` on the same thread with a larger timeout, then call `readLatest(...)` or `copyLatest(...)` only after completion is confirmed.
+Long Pro, Thinking, Deep Research, or file-backed answers can take longer than the default wait window. Treat `status: "partial"` and `data.complete: false` as an incomplete capture even when `output_text` is non-empty. For repeated polling, prefer `messages.wait({ responseContent: "metadata", ... })` so Codex receives compact status metadata instead of the same growing partial answer body. Re-run `messages.wait(...)` on the same thread until completion is confirmed, then call `readLatest(...)` or `copyLatest(...)` once.
 
 Recommended long-answer wait:
 
 ```ts
-wait: { timeoutMs: 600000, stableMs: 8000, pollMs: 1000 }
+await chatgpt.messages.wait({
+  timeoutMs: 45_000,
+  stableMs: 2_000,
+  pollMs: 1_000,
+  mode: "deep_research",
+  responseContent: "metadata"
+});
+
+const final = await chatgpt.messages.readLatest({ format: "markdown" });
 ```
 
 Active generation may appear as a visible or accessible-name control such as `Stop answering`, `Stop generating`, or `Stop streaming`. Stopped generation may appear as `Stopped thinking`. Treat all of those as incomplete states.

--- a/packages/node/src/commands/messages.ts
+++ b/packages/node/src/commands/messages.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readPageState, type PageState } from "../browser/page-state.js";
 import { resultError, resultOk } from "../errors.js";
 import { EMPTY_GENERATION_STATE, latestAssistantTurnHasResponseActions, readAssistantGenerationState, type AssistantGenerationState } from "../dom/generation-state.js";
@@ -391,17 +392,14 @@ export async function waitForMessage(
     };
 
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
+      const data = waitDataFromText(args, false, latestText, latestAssistantCount, Date.now() - started);
       return withCommandOutputText({
         ok: false,
         status: "partial",
-        data: {
-          complete: false,
-          responseText: latestText,
-          assistantTurnCount: latestAssistantCount,
-          elapsedMs: Date.now() - started
-        },
+        data,
         warnings: [
           ...waitWarnings,
+          ...responseContentWarnings(args, false),
           "ChatGPT generation appears to have been stopped or interrupted before completion.",
           ...snapshot.generation.signals.map(signal => `Generation state signal: ${signal}`)
         ],
@@ -410,10 +408,11 @@ export async function waitForMessage(
     }
 
     if (targetReached && isResponseComplete(snapshot)) {
+      const data = waitDataFromText(args, true, latestText, latestAssistantCount, Date.now() - started);
       return withCommandOutputText(resultOk(
-        { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
+        data,
         await contextFromPage(page),
-        [...waitWarnings]
+        [...waitWarnings, ...responseContentWarnings(args, true)]
       ));
     }
 
@@ -421,16 +420,12 @@ export async function waitForMessage(
   }
 
   if (lastTargetText.length > 0) {
+    const data = waitDataFromText(args, false, lastTargetText, latestAssistantCount, Date.now() - started);
     return withCommandOutputText({
       ok: false,
       status: "partial",
-      data: {
-        complete: false,
-        responseText: lastTargetText,
-        assistantTurnCount: latestAssistantCount,
-        elapsedMs: Date.now() - started
-      },
-      warnings: [...waitWarnings, "Timed out after receiving partial assistant text."],
+      data,
+      warnings: [...waitWarnings, ...responseContentWarnings(args, false), "Timed out after receiving partial assistant text."],
       context: await contextFromPage(page)
     } satisfies CommandResult<WaitData>);
   }
@@ -446,6 +441,39 @@ export async function waitForMessage(
     },
     context: await contextFromPage(page)
   };
+}
+
+function waitDataFromText(
+  args: WaitArgs,
+  complete: boolean,
+  responseText: string,
+  assistantTurnCount: number,
+  elapsedMs: number
+): WaitData {
+  const data: WaitData = {
+    complete,
+    assistantTurnCount,
+    elapsedMs
+  };
+
+  if (args.responseContent === "metadata") {
+    data.responseContent = "metadata";
+    data.responseChars = responseText.length;
+    data.responseSha256 = createHash("sha256").update(responseText).digest("hex");
+    return data;
+  }
+
+  data.responseText = responseText;
+  return data;
+}
+
+function responseContentWarnings(args: WaitArgs, complete: boolean): string[] {
+  if (args.responseContent !== "metadata") return [];
+  return [
+    complete
+      ? "Assistant response text was omitted because responseContent is metadata; call readLatest to capture the completed answer."
+      : "Partial assistant text was omitted because responseContent is metadata; call wait again on the same thread or readLatest after completion."
+  ];
 }
 
 async function pageStateFromProbe(

--- a/packages/node/src/commands/registry.ts
+++ b/packages/node/src/commands/registry.ts
@@ -249,6 +249,13 @@ function reportArgs(name: string): Record<string, string> {
 }
 
 function primitiveArgs(name: string): Record<string, string> {
+  if (name === "messages.wait") return {
+    timeoutMs: "optional wait timeout",
+    stableMs: "optional stability window before completion",
+    pollMs: "optional polling interval",
+    mode: "normal or deep_research",
+    responseContent: "include for current behavior, metadata to omit assistant text and return chars/hash only"
+  };
   if (name === "messages.readLatest") return { role: "assistant or user", format: "markdown, normalized_text, visible_text, html, blocks, or all" };
   if (name === "artifacts.listLatest") return { kind: "artifact kind; currently image", max: "maximum artifacts to return" };
   if (name === "artifacts.wait") return { kind: "artifact kind; currently image", afterArtifactCount: "baseline artifact count", requireDownload: "wait until a download affordance is visible" };

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -222,11 +222,15 @@ export type WaitArgs = {
   stableMs?: number;
   pollMs?: number;
   mode?: "normal" | "deep_research";
+  responseContent?: "include" | "metadata";
 };
 
 export type WaitData = {
   complete: boolean;
   responseText?: string;
+  responseChars?: number;
+  responseSha256?: string;
+  responseContent?: "include" | "metadata";
   assistantTurnCount: number;
   elapsedMs: number;
 };

--- a/packages/node/tests/unit/messages.test.ts
+++ b/packages/node/tests/unit/messages.test.ts
@@ -330,6 +330,65 @@ describe("extractMessagesFromHtml", () => {
     expect(result.status).toBe("partial");
   });
 
+  it("can return wait metadata without repeating assistant text", async () => {
+    const page = scriptedWaitPage([
+      {
+        totalCount: 2,
+        assistantCount: 1,
+        latestAssistantTurnIndex: 2,
+        latestAssistantText: "Partial text should stay out of the command result.",
+        hasStopControl: false,
+        stopButtonAria: "Stop answering",
+        hasResponseActions: true
+      }
+    ]);
+
+    const result = await waitForMessage({ page }, {
+      afterAssistantTurnCount: 0,
+      timeoutMs: 5,
+      stableMs: 0,
+      pollMs: 1,
+      responseContent: "metadata"
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("partial");
+    expect(result.output_text).toBeUndefined();
+    expect(result.data?.responseText).toBeUndefined();
+    expect(result.data?.responseChars).toBe(51);
+    expect(result.data?.responseSha256).toHaveLength(64);
+    expect(result.warnings.join(" ")).toContain("Partial assistant text was omitted");
+  });
+
+  it("can report completion metadata without returning the final answer body", async () => {
+    const page = scriptedWaitPage([
+      {
+        totalCount: 2,
+        assistantCount: 1,
+        latestAssistantTurnIndex: 2,
+        latestAssistantText: "Final text should be read in a separate command.",
+        hasStopControl: false,
+        hasResponseActions: true
+      }
+    ]);
+
+    const result = await waitForMessage({ page }, {
+      afterAssistantTurnCount: 0,
+      timeoutMs: 100,
+      stableMs: 0,
+      pollMs: 1,
+      responseContent: "metadata"
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe("ok");
+    expect(result.output_text).toBeUndefined();
+    expect(result.data?.responseText).toBeUndefined();
+    expect(result.data?.responseChars).toBe(48);
+    expect(result.data?.responseSha256).toHaveLength(64);
+    expect(result.warnings.join(" ")).toContain("Assistant response text was omitted");
+  });
+
   it("bounds page-state blocker scans so partial text is not lost", async () => {
     const page = scriptedWaitPage([
       {

--- a/packages/python/tests/test_primitives.py
+++ b/packages/python/tests/test_primitives.py
@@ -32,7 +32,7 @@ class PrimitiveFacadeTests(unittest.TestCase):
             (lambda: chatgpt.messages.compose(text="hi"), "messages.compose", {"text": "hi"}),
             (lambda: chatgpt.messages.submit(text="hi"), "messages.submit", {"text": "hi"}),
             (lambda: chatgpt.messages.ask(text="hi"), "messages.ask", {"text": "hi"}),
-            (lambda: chatgpt.messages.wait(timeout_ms=100), "messages.wait", {"timeoutMs": 100}),
+            (lambda: chatgpt.messages.wait(timeout_ms=100, response_content="metadata"), "messages.wait", {"timeoutMs": 100, "responseContent": "metadata"}),
             (lambda: chatgpt.messages.read_latest(format="markdown"), "messages.readLatest", {"format": "markdown"}),
             (lambda: chatgpt.messages.wait_and_read(format="markdown"), "messages.waitAndRead", {"format": "markdown"}),
             (lambda: chatgpt.artifacts.list_latest(kind="image"), "artifacts.listLatest", {"kind": "image"}),

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
@@ -6135,6 +6135,9 @@ function isNodeError2(error) {
   return error instanceof Error && "code" in error;
 }
 
+// src/commands/messages.ts
+import { createHash as createHash2 } from "node:crypto";
+
 // src/dom/generation-state.ts
 var EMPTY_GENERATION_STATE = {
   active: false,
@@ -6607,17 +6610,14 @@ async function waitForMessage(env, args = {}) {
       hasResponseActions: await responseActionsFromProbe(responseActionsProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings)
     };
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
+      const data = waitDataFromText(args, false, latestText, latestAssistantCount, Date.now() - started);
       return withCommandOutputText({
         ok: false,
         status: "partial",
-        data: {
-          complete: false,
-          responseText: latestText,
-          assistantTurnCount: latestAssistantCount,
-          elapsedMs: Date.now() - started
-        },
+        data,
         warnings: [
           ...waitWarnings,
+          ...responseContentWarnings(args, false),
           "ChatGPT generation appears to have been stopped or interrupted before completion.",
           ...snapshot.generation.signals.map((signal) => `Generation state signal: ${signal}`)
         ],
@@ -6625,25 +6625,22 @@ async function waitForMessage(env, args = {}) {
       });
     }
     if (targetReached && isResponseComplete(snapshot)) {
+      const data = waitDataFromText(args, true, latestText, latestAssistantCount, Date.now() - started);
       return withCommandOutputText(resultOk(
-        { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
+        data,
         await contextFromPage(page),
-        [...waitWarnings]
+        [...waitWarnings, ...responseContentWarnings(args, true)]
       ));
     }
     await sleep2(page, pollMs);
   }
   if (lastTargetText.length > 0) {
+    const data = waitDataFromText(args, false, lastTargetText, latestAssistantCount, Date.now() - started);
     return withCommandOutputText({
       ok: false,
       status: "partial",
-      data: {
-        complete: false,
-        responseText: lastTargetText,
-        assistantTurnCount: latestAssistantCount,
-        elapsedMs: Date.now() - started
-      },
-      warnings: [...waitWarnings, "Timed out after receiving partial assistant text."],
+      data,
+      warnings: [...waitWarnings, ...responseContentWarnings(args, false), "Timed out after receiving partial assistant text."],
       context: await contextFromPage(page)
     });
   }
@@ -6658,6 +6655,27 @@ async function waitForMessage(env, args = {}) {
     },
     context: await contextFromPage(page)
   };
+}
+function waitDataFromText(args, complete, responseText, assistantTurnCount, elapsedMs) {
+  const data = {
+    complete,
+    assistantTurnCount,
+    elapsedMs
+  };
+  if (args.responseContent === "metadata") {
+    data.responseContent = "metadata";
+    data.responseChars = responseText.length;
+    data.responseSha256 = createHash2("sha256").update(responseText).digest("hex");
+    return data;
+  }
+  data.responseText = responseText;
+  return data;
+}
+function responseContentWarnings(args, complete) {
+  if (args.responseContent !== "metadata") return [];
+  return [
+    complete ? "Assistant response text was omitted because responseContent is metadata; call readLatest to capture the completed answer." : "Partial assistant text was omitted because responseContent is metadata; call wait again on the same thread or readLatest after completion."
+  ];
 }
 async function pageStateFromProbe(probe, warnings) {
   const result = await probe;
@@ -7747,7 +7765,7 @@ function isSafeControlStringKey(key) {
 }
 
 // src/safety/untrusted-output.ts
-import { createHash as createHash2, randomUUID } from "node:crypto";
+import { createHash as createHash3, randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { link, mkdir as mkdir3, readFile as readFile2, stat as stat5, unlink, writeFile as writeFile2 } from "node:fs/promises";
 import { dirname } from "node:path";
@@ -7820,10 +7838,10 @@ function normalizePromptForIntegrity(prompt) {
   return prompt.replace(/\r\n?/g, "\n").split("\n").map((line) => line.replace(/[ \t]+$/g, "")).filter((line) => line.trim().length > 0).join("\n");
 }
 function sha256Text(text) {
-  return createHash2("sha256").update(text).digest("hex");
+  return createHash3("sha256").update(text).digest("hex");
 }
 async function sha256File(path3) {
-  const hash = createHash2("sha256");
+  const hash = createHash3("sha256");
   let bytes = 0;
   await new Promise((resolve3, reject) => {
     const stream = createReadStream(path3);
@@ -8426,6 +8444,13 @@ function reportArgs(name) {
   return { result: "CommandResult to persist", destDir: "optional report directory" };
 }
 function primitiveArgs(name) {
+  if (name === "messages.wait") return {
+    timeoutMs: "optional wait timeout",
+    stableMs: "optional stability window before completion",
+    pollMs: "optional polling interval",
+    mode: "normal or deep_research",
+    responseContent: "include for current behavior, metadata to omit assistant text and return chars/hash only"
+  };
   if (name === "messages.readLatest") return { role: "assistant or user", format: "markdown, normalized_text, visible_text, html, blocks, or all" };
   if (name === "artifacts.listLatest") return { kind: "artifact kind; currently image", max: "maximum artifacts to return" };
   if (name === "artifacts.wait") return { kind: "artifact kind; currently image", afterArtifactCount: "baseline artifact count", requireDownload: "wait until a download affordance is visible" };

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
@@ -4768,6 +4768,9 @@ function filterResultsByQuery(results, query) {
   });
 }
 
+// src/commands/messages.ts
+import { createHash as createHash2 } from "node:crypto";
+
 // src/dom/generation-state.ts
 var EMPTY_GENERATION_STATE = {
   active: false,
@@ -5240,17 +5243,14 @@ async function waitForMessage(env, args = {}) {
       hasResponseActions: await responseActionsFromProbe(responseActionsProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings)
     };
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
+      const data = waitDataFromText(args, false, latestText, latestAssistantCount, Date.now() - started);
       return withCommandOutputText({
         ok: false,
         status: "partial",
-        data: {
-          complete: false,
-          responseText: latestText,
-          assistantTurnCount: latestAssistantCount,
-          elapsedMs: Date.now() - started
-        },
+        data,
         warnings: [
           ...waitWarnings,
+          ...responseContentWarnings(args, false),
           "ChatGPT generation appears to have been stopped or interrupted before completion.",
           ...snapshot.generation.signals.map((signal) => `Generation state signal: ${signal}`)
         ],
@@ -5258,25 +5258,22 @@ async function waitForMessage(env, args = {}) {
       });
     }
     if (targetReached && isResponseComplete(snapshot)) {
+      const data = waitDataFromText(args, true, latestText, latestAssistantCount, Date.now() - started);
       return withCommandOutputText(resultOk(
-        { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
+        data,
         await contextFromPage(page),
-        [...waitWarnings]
+        [...waitWarnings, ...responseContentWarnings(args, true)]
       ));
     }
     await sleep(page, pollMs);
   }
   if (lastTargetText.length > 0) {
+    const data = waitDataFromText(args, false, lastTargetText, latestAssistantCount, Date.now() - started);
     return withCommandOutputText({
       ok: false,
       status: "partial",
-      data: {
-        complete: false,
-        responseText: lastTargetText,
-        assistantTurnCount: latestAssistantCount,
-        elapsedMs: Date.now() - started
-      },
-      warnings: [...waitWarnings, "Timed out after receiving partial assistant text."],
+      data,
+      warnings: [...waitWarnings, ...responseContentWarnings(args, false), "Timed out after receiving partial assistant text."],
       context: await contextFromPage(page)
     });
   }
@@ -5291,6 +5288,27 @@ async function waitForMessage(env, args = {}) {
     },
     context: await contextFromPage(page)
   };
+}
+function waitDataFromText(args, complete, responseText, assistantTurnCount, elapsedMs) {
+  const data = {
+    complete,
+    assistantTurnCount,
+    elapsedMs
+  };
+  if (args.responseContent === "metadata") {
+    data.responseContent = "metadata";
+    data.responseChars = responseText.length;
+    data.responseSha256 = createHash2("sha256").update(responseText).digest("hex");
+    return data;
+  }
+  data.responseText = responseText;
+  return data;
+}
+function responseContentWarnings(args, complete) {
+  if (args.responseContent !== "metadata") return [];
+  return [
+    complete ? "Assistant response text was omitted because responseContent is metadata; call readLatest to capture the completed answer." : "Partial assistant text was omitted because responseContent is metadata; call wait again on the same thread or readLatest after completion."
+  ];
 }
 async function pageStateFromProbe(probe, warnings) {
   const result = await probe;
@@ -6129,7 +6147,7 @@ async function sleep2(page, ms2) {
 // src/commands/files.ts
 import { access, readFile as readFile2, stat as stat4 } from "node:fs/promises";
 import { constants } from "node:fs";
-import { createHash as createHash2 } from "node:crypto";
+import { createHash as createHash3 } from "node:crypto";
 import path2 from "node:path";
 
 // src/platform/local-paths.ts
@@ -6372,7 +6390,7 @@ async function fileMetadata(absolute, bytes, includeHash = false) {
     category
   };
   if (includeHash) {
-    metadata.sha256 = createHash2("sha256").update(await readFile2(absolute)).digest("hex");
+    metadata.sha256 = createHash3("sha256").update(await readFile2(absolute)).digest("hex");
   }
   return metadata;
 }
@@ -9177,6 +9195,13 @@ function reportArgs(name) {
   return { result: "CommandResult to persist", destDir: "optional report directory" };
 }
 function primitiveArgs(name) {
+  if (name === "messages.wait") return {
+    timeoutMs: "optional wait timeout",
+    stableMs: "optional stability window before completion",
+    pollMs: "optional polling interval",
+    mode: "normal or deep_research",
+    responseContent: "include for current behavior, metadata to omit assistant text and return chars/hash only"
+  };
   if (name === "messages.readLatest") return { role: "assistant or user", format: "markdown, normalized_text, visible_text, html, blocks, or all" };
   if (name === "artifacts.listLatest") return { kind: "artifact kind; currently image", max: "maximum artifacts to return" };
   if (name === "artifacts.wait") return { kind: "artifact kind; currently image", afterArtifactCount: "baseline artifact count", requireDownload: "wait until a download affordance is visible" };

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
@@ -4713,6 +4713,9 @@ function filterResultsByQuery(results, query) {
   });
 }
 
+// src/commands/messages.ts
+import { createHash as createHash2 } from "node:crypto";
+
 // src/dom/generation-state.ts
 var EMPTY_GENERATION_STATE = {
   active: false,
@@ -5185,17 +5188,14 @@ async function waitForMessage(env, args = {}) {
       hasResponseActions: await responseActionsFromProbe(responseActionsProbe(page, deadline, { timeoutMs: probeTimeoutMs }), waitWarnings)
     };
     if (targetReached && snapshot.generation.stopped && latestText.length > 0) {
+      const data = waitDataFromText(args, false, latestText, latestAssistantCount, Date.now() - started);
       return withCommandOutputText({
         ok: false,
         status: "partial",
-        data: {
-          complete: false,
-          responseText: latestText,
-          assistantTurnCount: latestAssistantCount,
-          elapsedMs: Date.now() - started
-        },
+        data,
         warnings: [
           ...waitWarnings,
+          ...responseContentWarnings(args, false),
           "ChatGPT generation appears to have been stopped or interrupted before completion.",
           ...snapshot.generation.signals.map((signal) => `Generation state signal: ${signal}`)
         ],
@@ -5203,25 +5203,22 @@ async function waitForMessage(env, args = {}) {
       });
     }
     if (targetReached && isResponseComplete(snapshot)) {
+      const data = waitDataFromText(args, true, latestText, latestAssistantCount, Date.now() - started);
       return withCommandOutputText(resultOk(
-        { complete: true, responseText: latestText, assistantTurnCount: latestAssistantCount, elapsedMs: Date.now() - started },
+        data,
         await contextFromPage(page),
-        [...waitWarnings]
+        [...waitWarnings, ...responseContentWarnings(args, true)]
       ));
     }
     await sleep(page, pollMs);
   }
   if (lastTargetText.length > 0) {
+    const data = waitDataFromText(args, false, lastTargetText, latestAssistantCount, Date.now() - started);
     return withCommandOutputText({
       ok: false,
       status: "partial",
-      data: {
-        complete: false,
-        responseText: lastTargetText,
-        assistantTurnCount: latestAssistantCount,
-        elapsedMs: Date.now() - started
-      },
-      warnings: [...waitWarnings, "Timed out after receiving partial assistant text."],
+      data,
+      warnings: [...waitWarnings, ...responseContentWarnings(args, false), "Timed out after receiving partial assistant text."],
       context: await contextFromPage(page)
     });
   }
@@ -5236,6 +5233,27 @@ async function waitForMessage(env, args = {}) {
     },
     context: await contextFromPage(page)
   };
+}
+function waitDataFromText(args, complete, responseText, assistantTurnCount, elapsedMs) {
+  const data = {
+    complete,
+    assistantTurnCount,
+    elapsedMs
+  };
+  if (args.responseContent === "metadata") {
+    data.responseContent = "metadata";
+    data.responseChars = responseText.length;
+    data.responseSha256 = createHash2("sha256").update(responseText).digest("hex");
+    return data;
+  }
+  data.responseText = responseText;
+  return data;
+}
+function responseContentWarnings(args, complete) {
+  if (args.responseContent !== "metadata") return [];
+  return [
+    complete ? "Assistant response text was omitted because responseContent is metadata; call readLatest to capture the completed answer." : "Partial assistant text was omitted because responseContent is metadata; call wait again on the same thread or readLatest after completion."
+  ];
 }
 async function pageStateFromProbe(probe, warnings) {
   const result = await probe;
@@ -6074,7 +6092,7 @@ async function sleep2(page, ms2) {
 // src/commands/files.ts
 import { access, readFile as readFile3, stat as stat4 } from "node:fs/promises";
 import { constants } from "node:fs";
-import { createHash as createHash2 } from "node:crypto";
+import { createHash as createHash3 } from "node:crypto";
 import path2 from "node:path";
 
 // src/platform/local-paths.ts
@@ -6328,7 +6346,7 @@ async function fileMetadata(absolute, bytes, includeHash = false) {
     category
   };
   if (includeHash) {
-    metadata.sha256 = createHash2("sha256").update(await readFile3(absolute)).digest("hex");
+    metadata.sha256 = createHash3("sha256").update(await readFile3(absolute)).digest("hex");
   }
   return metadata;
 }
@@ -9237,6 +9255,13 @@ function reportArgs(name) {
   return { result: "CommandResult to persist", destDir: "optional report directory" };
 }
 function primitiveArgs(name) {
+  if (name === "messages.wait") return {
+    timeoutMs: "optional wait timeout",
+    stableMs: "optional stability window before completion",
+    pollMs: "optional polling interval",
+    mode: "normal or deep_research",
+    responseContent: "include for current behavior, metadata to omit assistant text and return chars/hash only"
+  };
   if (name === "messages.readLatest") return { role: "assistant or user", format: "markdown, normalized_text, visible_text, html, blocks, or all" };
   if (name === "artifacts.listLatest") return { kind: "artifact kind; currently image", max: "maximum artifacts to return" };
   if (name === "artifacts.wait") return { kind: "artifact kind; currently image", afterArtifactCount: "baseline artifact count", requireDownload: "wait until a download affordance is visible" };

--- a/plugins/codex-chatgpt-control/skills/chatgpt-pro-consult/SKILL.md
+++ b/plugins/codex-chatgpt-control/skills/chatgpt-pro-consult/SKILL.md
@@ -17,7 +17,7 @@ This skill is a thin workflow over the `codex-chatgpt-control` plugin. Use the s
 - Prefer a fresh thread unless the user asked to continue a specific ChatGPT thread.
 - Return Markdown by default. Use redacted reports by default; raw prompt/response content is opt-in only.
 - Treat ChatGPT Pro output as another model's judgment, not verified truth. Verify current, legal, medical, financial, or high-stakes claims with primary sources.
-- Keep each Codex tool call bounded. Submit the prompt under Pro first, then poll/read in chunks.
+- Keep each Codex tool call bounded. Submit the prompt under Pro first, poll with compact metadata, then read once after completion.
 
 ## Runtime Loader
 
@@ -52,7 +52,8 @@ const TOOL_CALL_SAFE_WAIT = {
   timeoutMs: 90_000,
   stableMs: 2_000,
   pollMs: 750,
-  mode: "deep_research"
+  mode: "deep_research",
+  responseContent: "metadata"
 };
 
 const pro = chatgpt.agent({
@@ -86,22 +87,22 @@ if (!submitted.ok || modeStep?.ok === false) {
     interruptions: submitted.interruptions
   }, null, 2));
 } else {
-  const read = await chatgpt.messages.waitAndRead({
-    ...TOOL_CALL_SAFE_WAIT,
-    role: "assistant",
-    format: "markdown"
-  });
+  const wait = await chatgpt.messages.wait(TOOL_CALL_SAFE_WAIT);
 
-  if (!read.ok) {
+  if (!wait.ok) {
     console.log(JSON.stringify({
       status: "submitted_wait_pending",
-      message: "Prompt is already submitted. Do not resubmit; run messages.waitAndRead again against this same thread.",
+      message: "Prompt is already submitted. Do not resubmit; run messages.wait again against this same thread.",
       thread: submitted.state?.thread ?? submitted.data?.thread,
       modeStep,
-      read
+      wait
     }, null, 2));
   } else {
-    console.log(read.data?.responseText ?? "");
+    const read = await chatgpt.messages.readLatest({
+      role: "assistant",
+      format: "markdown"
+    });
+    console.log(read.ok ? read.data?.responseText ?? read.output_text ?? "" : JSON.stringify(read, null, 2));
   }
 }
 ```
@@ -125,7 +126,7 @@ const submitted = await chatgpt.runner.run(pro, {
 });
 ```
 
-Use the same submit-then-poll pattern as Quick Consult. File-backed Pro answers can run longer than one Codex tool call.
+Use the same submit-then-poll pattern as Quick Consult. File-backed Pro answers can run longer than one Codex tool call, so poll with `messages.wait({ responseContent: "metadata", ... })` and read the answer once after completion.
 
 ## Continue A Known Thread
 

--- a/plugins/codex-chatgpt-control/skills/codex-chatgpt-control/SKILL.md
+++ b/plugins/codex-chatgpt-control/skills/codex-chatgpt-control/SKILL.md
@@ -139,6 +139,8 @@ const latest = await chatgpt.messages.waitAndRead({
 
 Use `format: "normalized_text"` only for compact assertions, polling checks, or simple exact-string smoke tests.
 
+For long Pro, Thinking, Deep Research, or file-backed answers, poll with `chatgpt.messages.wait({ responseContent: "metadata", ... })` so repeated partial polls return status metadata instead of re-emitting the growing answer body. Call `readLatest({ format: "markdown" })` once the wait confirms completion.
+
 See `references/response-capture.md` for fidelity warnings and report handling.
 
 ## File Upload Permissions

--- a/plugins/codex-chatgpt-control/skills/codex-chatgpt-control/references/file-uploads.md
+++ b/plugins/codex-chatgpt-control/skills/codex-chatgpt-control/references/file-uploads.md
@@ -22,4 +22,4 @@ await chatgpt.askWithFiles({
 });
 ```
 
-For long file-backed answers, submit first and then poll/read in bounded chunks rather than keeping one tool call open indefinitely.
+For long file-backed answers, submit first, poll with compact metadata, and read once after completion rather than keeping one tool call open indefinitely.

--- a/skills/codex-chatgpt-control/SKILL.md
+++ b/skills/codex-chatgpt-control/SKILL.md
@@ -205,6 +205,8 @@ const latest = await chatgpt.messages.waitAndRead({
 
 Use `format: "normalized_text"` only for compact assertions, polling checks, or simple exact-string smoke tests.
 
+For long Pro, Thinking, Deep Research, or file-backed answers, poll with `chatgpt.messages.wait({ responseContent: "metadata", ... })` so repeated partial polls return status metadata instead of re-emitting the growing answer body. Call `readLatest({ format: "markdown" })` once the wait confirms completion.
+
 ## Python Client
 
 The Python package is a protocol client over the Node backend. Build the backend first:


### PR DESCRIPTION
## Summary
- expose opt-in `responseContent: "metadata"` on `messages.wait` for compact long-response polling
- update command descriptors, docs, Python forwarding coverage, and plugin skills
- refresh generated plugin runtime bundles from the private source export

## Validation
- `npm run node:build`
- `npm run node:test`
- `npm run python:compile`
- `npm run python:test`
- `npm run node:contracts`
- `npm run plugin:validate`
- `npm run node:bundle`
- `npm run plugin:check`
