### PR TITLE
Refresh GitHub Actions release tooling

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -24,8 +24,8 @@ jobs:
       run:
         working-directory: packages/node
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: packages/node
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm
@@ -45,8 +45,8 @@ jobs:
       run:
         working-directory: packages/python
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm
@@ -56,7 +56,7 @@ jobs:
         run: |
           npm ci
           npm run bundle:backend
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,11 @@ jobs:
     name: release preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
-          package-manager-cache: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -58,12 +57,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false
       - run: npm --prefix packages/node ci
       - run: npm run release:check-version
       - run: npm run node:build
@@ -82,12 +80,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
-          package-manager-cache: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
## What changed

- upgrades actions/checkout and actions/setup-node to v7
- upgrades actions/setup-python to v6
- removes the obsolete package-manager-cache input

## Why

The successful v0.5.0-alpha.1 release reported Node 20 action-runtime deprecations and ignored setup-node inputs. These current official action majors remove those warnings and keep the next protected release path supported.

## Validation

- the corresponding private workflows passed all deterministic, backend, and Python parity lanes using the upgraded actions
- all public workflow files parse as YAML
- current official action releases were verified from their GitHub repositories
- generated public export matches private main