### PR TITLE
ci: retire push/PR triggers to workflow_dispatch (local-builds quota policy)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,16 +1,7 @@
 name: codex-chatgpt-control
 
 on:
-  push:
-    paths:
-      - ".github/workflows/node.yml"
-      - "package.json"
-      - "packages/node/**"
-  pull_request:
-    paths:
-      - ".github/workflows/node.yml"
-      - "package.json"
-      - "packages/node/**"
+  workflow_dispatch:
 
 jobs:
   deterministic-gates:

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,8 +1,7 @@
 name: codex-chatgpt-control-parity
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   node-backend-contracts:


### PR DESCRIPTION
Fleet policy: the GitHub account has a 2,000-minute/month Actions quota with a \$0 stop-usage budget, so push/PR-triggered workflows are being retired to workflow_dispatch-only (manual runs remain possible). Reference: docs/LOCAL_IMAGE_BUILDS.md (trading-system repo policy doc).

Per-workflow decisions:

- `.github/workflows/node.yml` — **CONVERT**. push/PR path-scoped Node gates; not a documented keeper. Now `workflow_dispatch` only.
- `.github/workflows/parity.yml` — **CONVERT**. Unscoped push/PR parity CI (README badge source); not a documented keeper. Now `workflow_dispatch` only. Note: the README CI badge will no longer auto-refresh on push; it will reflect manual dispatch runs.
- `.github/workflows/release.yml` — **KEEP** (unchanged). Tag-push-only (`v*`) release publish via OIDC trusted publishing, explicitly documented in `docs/release-process.md` (registry trusted-publisher config is keyed to workflow filename `release.yml`, flow is push-tag → approve `release` environment). Runs only on version tags — near-zero quota cost.

This change is trigger-only: no jobs, steps, matrices, or permissions were modified. All three workflow files still parse as valid YAML. Recent run history (via `gh run list`): all workflows last ran 2026-07-17 and were green; release.yml's documented tag flow is the reason it is kept.

Do not merge without review.