### PR TITLE
Fix npm launcher resolution on Windows Node 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Public source repo for the unofficial visible ChatGPT Chat and Work control SDK.",
   "type": "module",
   "scripts": {
-    "node:test": "npm --prefix packages/node test",
+    "node:test": "node --test scripts/tests/*.test.mjs && npm --prefix packages/node test",
     "node:build": "npm --prefix packages/node run build",
     "node:bundle": "npm --prefix packages/node run bundle && npm --prefix packages/node run bundle:backend && npm --prefix packages/node run bundle:live-smoke && npm --prefix packages/node run bundle:release-canary",
     "node:contracts": "npm --prefix packages/node run contract:validate && npm --prefix packages/node run docs:drift && npm --prefix packages/node run parity:fixtures && npm --prefix packages/node run parity:suite",

--- a/scripts/build-plugin-runtime.mjs
+++ b/scripts/build-plugin-runtime.mjs
@@ -6,6 +6,8 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import { npmInvocation } from "./lib/npm-command.mjs";
+
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const PRIVATE_PACKAGE_REL = path.join("work", "chatgpt-" + "browser-control");
 const PRIVATE_BUNDLE_PREFIX = "chatgpt-" + "browser-control";
@@ -101,7 +103,8 @@ async function main() {
 
   if (!args.skipBuild) {
     for (const script of ["build", "bundle", "bundle:backend", "bundle:live-smoke", "bundle:release-canary"]) {
-      execFileSync("npm", ["run", script], { cwd: packageDir, stdio: "inherit" });
+      const npm = npmInvocation(["run", script]);
+      execFileSync(npm.program, npm.args, { cwd: packageDir, stdio: "inherit" });
     }
   }
 

--- a/scripts/check-node-pack.mjs
+++ b/scripts/check-node-pack.mjs
@@ -2,6 +2,8 @@
 import { execFileSync } from "node:child_process";
 import process from "node:process";
 
+import { npmInvocation } from "./lib/npm-command.mjs";
+
 const REQUIRED_FILES = [
   "package.json",
   "README.md",
@@ -26,7 +28,8 @@ const FORBIDDEN_PATTERNS = [
 ];
 
 function main() {
-  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+  const npm = npmInvocation(["pack", "--dry-run", "--json"]);
+  const output = execFileSync(npm.program, npm.args, {
     cwd: new URL("../packages/node", import.meta.url),
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]

--- a/scripts/check-release-names.mjs
+++ b/scripts/check-release-names.mjs
@@ -4,6 +4,8 @@ import { readFile } from "node:fs/promises";
 import https from "node:https";
 import { promisify } from "node:util";
 
+import { npmInvocation } from "./lib/npm-command.mjs";
+
 const execFileAsync = promisify(execFile);
 
 const npmPackage = "codex-chatgpt-control";
@@ -23,7 +25,8 @@ async function readPythonVersion() {
 
 async function npmView(spec) {
   try {
-    const { stdout } = await execFileAsync("npm", ["view", spec, "name", "version", "--json"], {
+    const npm = npmInvocation(["view", spec, "name", "version", "--json"]);
+    const { stdout } = await execFileAsync(npm.program, npm.args, {
       maxBuffer: 1024 * 1024
     });
     return { exists: true, data: JSON.parse(stdout) };

--- a/scripts/lib/npm-command.mjs
+++ b/scripts/lib/npm-command.mjs
@@ -1,0 +1,31 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import process from "node:process";
+
+/**
+ * Resolve npm without asking Node to execute a Windows .cmd shim directly.
+ * Node 24 rejects that spawn shape with EINVAL when shell execution is off.
+ */
+export function npmInvocation(args, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const execPath = options.execPath ?? process.execPath;
+  const pathExists = options.existsSync ?? existsSync;
+  const candidates = [
+    env.npm_execpath,
+    join(dirname(execPath), "node_modules", "npm", "bin", "npm-cli.js")
+  ];
+  const npmCli = candidates.find(candidate =>
+    typeof candidate === "string" && candidate.length > 0 && pathExists(candidate)
+  );
+
+  if (npmCli !== undefined) {
+    return { program: execPath, args: [npmCli, ...args] };
+  }
+  if (platform === "win32") {
+    throw new Error(
+      "Unable to locate npm-cli.js. Run this command through npm or set npm_execpath."
+    );
+  }
+  return { program: "npm", args: [...args] };
+}

--- a/scripts/lib/npm-command.mjs
+++ b/scripts/lib/npm-command.mjs
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { posix, win32 } from "node:path";
 import process from "node:process";
 
 /**
@@ -11,9 +11,10 @@ export function npmInvocation(args, options = {}) {
   const env = options.env ?? process.env;
   const execPath = options.execPath ?? process.execPath;
   const pathExists = options.existsSync ?? existsSync;
+  const pathApi = platform === "win32" ? win32 : posix;
   const candidates = [
     env.npm_execpath,
-    join(dirname(execPath), "node_modules", "npm", "bin", "npm-cli.js")
+    pathApi.join(pathApi.dirname(execPath), "node_modules", "npm", "bin", "npm-cli.js")
   ];
   const npmCli = candidates.find(candidate =>
     typeof candidate === "string" && candidate.length > 0 && pathExists(candidate)

--- a/scripts/run-python-gate.mjs
+++ b/scripts/run-python-gate.mjs
@@ -4,11 +4,12 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 
+import { npmInvocation } from "./lib/npm-command.mjs";
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const pythonRoot = join(repoRoot, "packages", "python");
 const nodeRoot = join(repoRoot, "packages", "node");
 const venvDir = join(pythonRoot, ".venv");
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const pythonCommand = process.env.PYTHON ?? (process.platform === "win32" ? "python.exe" : "python");
 const venvPython = process.platform === "win32"
   ? join(venvDir, "Scripts", "python.exe")
@@ -34,7 +35,8 @@ function ensureVenv() {
 }
 
 if (gate === "test") {
-  run(npmCommand, ["--prefix", nodeRoot, "run", "bundle:backend"]);
+  const npm = npmInvocation(["--prefix", nodeRoot, "run", "bundle:backend"]);
+  run(npm.program, npm.args);
   ensureVenv();
   run(venvPython, ["-m", "unittest", "discover", "-s", "tests"], { cwd: pythonRoot });
 } else if (gate === "compile") {
@@ -44,7 +46,8 @@ if (gate === "test") {
   ensureVenv();
   run(venvPython, ["-m", "pyright", "--pythonpath", venvPython, "src", "tests"], { cwd: pythonRoot });
 } else if (gate === "ordinary-shell") {
-  run(npmCommand, ["--prefix", nodeRoot, "run", "bundle:backend"]);
+  const npm = npmInvocation(["--prefix", nodeRoot, "run", "bundle:backend"]);
+  run(npm.program, npm.args);
   ensureVenv();
   run(venvPython, ["scripts/live_smoke.py", "--mode", "ordinary-shell"], { cwd: pythonRoot });
 } else {

--- a/scripts/tests/npm-command.test.mjs
+++ b/scripts/tests/npm-command.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { npmInvocation } from "../lib/npm-command.mjs";
+
+test("uses npm_execpath through the active Node executable", () => {
+  const invocation = npmInvocation(["pack", "--json"], {
+    platform: "win32",
+    env: { npm_execpath: "C:\\npm\\npm-cli.js" },
+    execPath: "C:\\node\\node.exe",
+    existsSync: candidate => candidate === "C:\\npm\\npm-cli.js"
+  });
+
+  assert.deepEqual(invocation, {
+    program: "C:\\node\\node.exe",
+    args: ["C:\\npm\\npm-cli.js", "pack", "--json"]
+  });
+});
+
+test("finds npm beside Node when npm_execpath is absent", () => {
+  const expectedCli = "C:\\node\\node_modules\\npm\\bin\\npm-cli.js";
+  const invocation = npmInvocation(["run", "build"], {
+    platform: "win32",
+    env: {},
+    execPath: "C:\\node\\node.exe",
+    existsSync: candidate => candidate === expectedCli
+  });
+
+  assert.deepEqual(invocation, {
+    program: "C:\\node\\node.exe",
+    args: [expectedCli, "run", "build"]
+  });
+});
+
+test("falls back to PATH npm on non-Windows platforms", () => {
+  assert.deepEqual(npmInvocation(["view", "example"], {
+    platform: "linux",
+    env: {},
+    execPath: "/usr/bin/node",
+    existsSync: () => false
+  }), {
+    program: "npm",
+    args: ["view", "example"]
+  });
+});
+
+test("fails clearly when Windows npm cannot be resolved safely", () => {
+  assert.throws(
+    () => npmInvocation([], {
+      platform: "win32",
+      env: {},
+      execPath: "C:\\node\\node.exe",
+      existsSync: () => false
+    }),
+    /Unable to locate npm-cli\.js/
+  );
+});

--- a/scripts/verify-release-install.mjs
+++ b/scripts/verify-release-install.mjs
@@ -7,6 +7,8 @@ import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import process from "node:process";
 
+import { npmInvocation } from "./lib/npm-command.mjs";
+
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const NODE_ROOT = join(REPO_ROOT, "packages", "node");
 const PYTHON_ROOT = join(REPO_ROOT, "packages", "python");
@@ -38,10 +40,6 @@ function parseArgs(argv) {
   }
   if (options.mode === undefined) throw new Error("Choose exactly one mode: --source or --registry");
   return options;
-}
-
-function command(name) {
-  return process.platform === "win32" ? `${name}.cmd` : name;
 }
 
 function run(program, args, options = {}) {
@@ -78,13 +76,14 @@ async function waitForRegistryVersions(versions, timeoutMs) {
   let last = "registry metadata not checked";
   while (Date.now() <= deadline) {
     try {
-      const npmVersion = JSON.parse(run(command("npm"), [
+      const npm = npmInvocation([
         "view",
         `${NPM_PACKAGE}@${versions.nodeVersion}`,
         "version",
         "--json",
         `--registry=${NPM_REGISTRY}`
-      ], { capture: true }));
+      ]);
+      const npmVersion = JSON.parse(run(npm.program, npm.args, { capture: true }));
       const response = await fetch(`https://pypi.org/pypi/${PYPI_PACKAGE}/${versions.pythonVersion}/json`, {
         headers: { "User-Agent": "codex-chatgpt-control-release-verifier" }
       });
@@ -123,7 +122,8 @@ async function sourceSpecs(root) {
   const nodeDist = join(root, "node-dist");
   const pythonDist = join(root, "python-dist");
   await Promise.all([mkdir(nodeDist, { recursive: true }), mkdir(pythonDist, { recursive: true })]);
-  const packed = JSON.parse(run(command("npm"), ["pack", "--json", "--pack-destination", nodeDist], {
+  const npm = npmInvocation(["pack", "--json", "--pack-destination", nodeDist]);
+  const packed = JSON.parse(run(npm.program, npm.args, {
     cwd: NODE_ROOT,
     capture: true
   }));
@@ -153,7 +153,8 @@ async function installAndVerify(root, specs, versions) {
   const npmInstallArgs = ["install", "--ignore-scripts", "--no-audit", "--no-fund"];
   if (specs.registry) npmInstallArgs.push(`--registry=${NPM_REGISTRY}`);
   npmInstallArgs.push(specs.nodeSpec);
-  run(command("npm"), npmInstallArgs, { cwd: nodeEnv });
+  const npm = npmInvocation(npmInstallArgs);
+  run(npm.program, npm.args, { cwd: nodeEnv });
 
   const installedNodeRoot = join(nodeEnv, "node_modules", NPM_PACKAGE);
   const installedNode = JSON.parse(await readFile(join(installedNodeRoot, "package.json"), "utf8"));


### PR DESCRIPTION
## Summary

- run npm release helpers through the active Node executable and `npm-cli.js` instead of directly spawning the Windows `.cmd` shim
- resolve simulated Windows paths with `node:path.win32`, so the cross-platform unit test behaves the same on Linux CI and Windows
- keep the existing PATH-based npm fallback on non-Windows hosts
- fail clearly on Windows when no safe npm CLI entrypoint can be found

## Verification

- `node --test scripts/tests/*.test.mjs` (4 tests)
- exercised locally on Windows Node 24
- the same platform-simulated path case now passes on Linux CI semantics
