### PR TITLE
Fix current release canary surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Hardens file attachment around a single composer-scoped input, fresh visible
   evidence, one shared timeout, approved chooser APIs, and localized upload and
   download labels; removes the page-script `DataTransfer` fallback.
+- Recognizes effort-only simplified Chat configuration during live release
+  qualification and follows asynchronously mounted, filename-scoped artifact
+  previews until their verified Download control is ready.
 - Enforces strict HTTPS ChatGPT origins before and after navigation, honors
   user-open tabs for explicit reuse, and scopes lifecycle, blocker, and mode
   evidence away from hidden or quoted content.

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Hardens uploads, explicit tab reuse, origin checks, localized selectors,
   blocker/mode visibility, and fixture generation against the validated PR
   review findings.
+- Qualifies effort-only simplified Chat profiles and waits for delayed scoped
+  artifact previews before selecting their exact Download control.
 - Adds behavioral stop contracts, expanded regression coverage, rebuilt plugin
   runtimes, portable release helpers, and patched transitive dependency locks.
 

--- a/packages/node/src/commands/files.ts
+++ b/packages/node/src/commands/files.ts
@@ -1367,17 +1367,13 @@ async function tryGeneratedFilePreviewDownload(
 
     await affordance.click({ timeoutMs: localGuardTimeout(timeoutMs, 10000) });
     const labelledPreview = requiredLocator(page, `section[aria-label="${escapeCssAttribute(selected.filename)}"]`);
-    const labelledPreviewCount = typeof labelledPreview.count === "function"
-      ? await locatorCountWithTimeout(
-          labelledPreview,
-          localGuardTimeout(timeoutMs, 2000),
-          "generated_file_labelled_preview_count_timeout"
-        )
-      : undefined;
     const workbookPreviews = requiredLocator(page, "section[data-testid^='popcorn-']");
     const workbookPreview = workbookPreviews.filter?.({ hasText: selected.filename }) ?? workbookPreviews;
-    const preview = labelledPreviewCount === 0 ? workbookPreview : labelledPreview;
-    const download = await waitForPreviewDownloadControl(page, preview, timeoutMs);
+    const download = await waitForPreviewDownloadControl(
+      page,
+      [labelledPreview, workbookPreview],
+      timeoutMs
+    );
     if (download === undefined) {
       throw new Error(`The artifact preview for ${selected.filename} did not expose a visible Download control.`);
     }
@@ -1524,16 +1520,18 @@ function filenameMatches(filename: string, pattern: string): boolean {
 
 async function waitForPreviewDownloadControl(
   page: RuntimeEnv["page"] & {},
-  preview: LocatorLike,
+  previews: LocatorLike[],
   timeoutMs: number
 ): Promise<LocatorLike | undefined> {
-  const deadline = Date.now() + Math.min(timeoutMs, 15000);
+  const deadline = Date.now() + Math.min(timeoutMs, 60000);
   while (Date.now() < deadline) {
-    for (const label of localeLabels.download) {
-      const control = preview.getByRole?.("button", { name: label, exact: true })
-        ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
-      if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2000), "artifact_preview_download_count_timeout") === 1) {
-        return control;
+    for (const preview of previews) {
+      for (const label of localeLabels.download) {
+        const control = preview.getByRole?.("button", { name: label, exact: true })
+          ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
+        if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2000), "artifact_preview_download_count_timeout") === 1) {
+          return control;
+        }
       }
     }
     if (typeof page.waitForTimeout === "function") {

--- a/packages/node/src/scripts/live-smoke/scenarios.ts
+++ b/packages/node/src/scripts/live-smoke/scenarios.ts
@@ -186,7 +186,7 @@ export const requiredScenarios: LiveSmokeScenario[] = [
         chatConfiguration.ok
         && chatConfiguration.data?.experience === "chat"
         && chatConfiguration.data.verified === true);
-      const chatDesired = activeSelection(chatConfiguration.data!, ["intelligence", "model", "modelVersion"]);
+      const chatDesired = chatActiveSelection(chatConfiguration.data!);
       requireLiveCommand("configuration.inspect.chat.active", chatConfiguration,
         Object.keys(chatDesired).length > 0);
 
@@ -1103,6 +1103,12 @@ function activeSelection(
     }
   }
   return selection;
+}
+
+export function chatActiveSelection(
+  inspection: ConfigurationInspectionData
+): ConfigurationSelection {
+  return activeSelection(inspection, ["intelligence", "model", "modelVersion", "effort"]);
 }
 
 function hasAxes(inspection: ConfigurationInspectionData, axes: ConfigurationAxis[]): boolean {

--- a/packages/node/tests/unit/files.test.ts
+++ b/packages/node/tests/unit/files.test.ts
@@ -1491,6 +1491,76 @@ describe("downloadLatestFile", () => {
     await expect(readFile(join(dest, "chatgpt-live-smoke.csv"), "utf8")).resolves.toBe("name,value\nsmoke,1\n");
   });
 
+  it("waits beyond the former 15-second cap for a generated-file preview control", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "chatgpt-control-delayed-preview-download-"));
+    const dest = join(dir, "out");
+    const browserDownload = join(dir, "chatgpt-live-smoke.csv");
+    await mkdir(dest);
+    await writeFile(browserDownload, "name,value\nsmoke,1\n");
+
+    let now = 0;
+    let previewOpen = false;
+    let downloadClicked = false;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const missing: LocatorLike = { count: async () => 0 };
+    const filenameButton: LocatorLike = {
+      count: async () => 1,
+      click: async () => {
+        previewOpen = true;
+      }
+    };
+    const previewDownload: LocatorLike = {
+      count: async () => previewOpen && now >= 16000 ? 1 : 0,
+      click: async () => {
+        downloadClicked = true;
+      }
+    };
+    const assistant: LocatorLike = {
+      getByRole: (_role, options) => options?.name === "chatgpt-live-smoke.csv" ? filenameButton : missing
+    };
+    const assistants: LocatorLike = {
+      count: async () => 1,
+      nth: () => assistant
+    };
+    const preview: LocatorLike = {
+      count: async () => previewOpen && now >= 3000 ? 1 : 0,
+      getByRole: (_role, options) => options?.name === "Download" ? previewDownload : missing
+    };
+    const page: PageLike = {
+      content: async () => [
+        "<main><div data-message-author-role='assistant'>",
+        "<button aria-label='chatgpt-live-smoke.csv'>chatgpt-live-smoke.csv</button>",
+        "</div></main>"
+      ].join(""),
+      locator: selector => {
+        if (selector === "[data-message-author-role='assistant']") return assistants;
+        if (selector === "section[aria-label=\"chatgpt-live-smoke.csv\"]") return preview;
+        return missing;
+      },
+      waitForEvent: async () => ({ path: async () => browserDownload }),
+      waitForTimeout: async timeoutMs => {
+        now += timeoutMs;
+      },
+      title: async () => "ChatGPT",
+      url: () => "https://chatgpt.com/c/mock"
+    };
+
+    try {
+      const result = await downloadLatestFile({ page }, {
+        destDir: dest,
+        filenamePattern: "^chatgpt-live-smoke\\.csv$",
+        timeoutMs: 20000
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.data?.suggestedFilename).toBe("chatgpt-live-smoke.csv");
+      expect(downloadClicked).toBe(true);
+      expect(now).toBeGreaterThanOrEqual(16000);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it("normalizes Chat's download-prefixed artifact control and uses the workbook preview", async () => {
     const dir = await mkdtemp(join(tmpdir(), "chatgpt-control-generated-workbook-download-"));
     const dest = join(dir, "out");

--- a/packages/node/tests/unit/live-smoke-harness.test.ts
+++ b/packages/node/tests/unit/live-smoke-harness.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { filterScenarios, requiredFailures, writeReport } from "../../src/scripts/live-smoke/harness.js";
-import { generatedFileAskCanProceed, optionalScenarios, requiredScenarios } from "../../src/scripts/live-smoke/scenarios.js";
+import {
+  chatActiveSelection,
+  generatedFileAskCanProceed,
+  optionalScenarios,
+  requiredScenarios
+} from "../../src/scripts/live-smoke/scenarios.js";
+import type { ConfigurationInspectionData } from "../../src/types.js";
 import type { LiveSmokeScenario } from "../../src/scripts/live-smoke/types.js";
 import type { LiveSmokeScenarioResult } from "../../src/scripts/live-smoke/types.js";
 
@@ -58,6 +64,20 @@ describe("live smoke harness", () => {
 
     expect(expansion?.required).toBe(true);
     expect(expansion?.enabled({ agent: {}, reportDir: "/tmp/reports", env: {} })).toBe(true);
+  });
+
+  it("accepts the current simplified Chat effort axis for release verification", () => {
+    const inspection = {
+      experience: "chat",
+      selectorProfile: "chat_simplified_v1",
+      availableAxes: ["effort"],
+      active: { effort: "High" },
+      options: {},
+      verified: true,
+      evidence: []
+    } as ConfigurationInspectionData;
+
+    expect(chatActiveSelection(inspection)).toEqual({ effort: "High" });
   });
 
   it("keeps configuration mutation opt-in and restoration-oriented", () => {

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-backend.mjs
@@ -6955,15 +6955,13 @@ async function tryGeneratedFilePreviewDownload(page, args) {
     }
     await affordance.click({ timeoutMs: localGuardTimeout(timeoutMs, 1e4) });
     const labelledPreview = requiredLocator(page, `section[aria-label="${escapeCssAttribute(selected.filename)}"]`);
-    const labelledPreviewCount = typeof labelledPreview.count === "function" ? await locatorCountWithTimeout(
-      labelledPreview,
-      localGuardTimeout(timeoutMs, 2e3),
-      "generated_file_labelled_preview_count_timeout"
-    ) : void 0;
     const workbookPreviews = requiredLocator(page, "section[data-testid^='popcorn-']");
     const workbookPreview = workbookPreviews.filter?.({ hasText: selected.filename }) ?? workbookPreviews;
-    const preview = labelledPreviewCount === 0 ? workbookPreview : labelledPreview;
-    const download = await waitForPreviewDownloadControl(page, preview, timeoutMs);
+    const download = await waitForPreviewDownloadControl(
+      page,
+      [labelledPreview, workbookPreview],
+      timeoutMs
+    );
     if (download === void 0) {
       throw new Error(`The artifact preview for ${selected.filename} did not expose a visible Download control.`);
     }
@@ -7082,13 +7080,15 @@ function filenameMatches(filename, pattern) {
     return filename.toLocaleLowerCase().includes(pattern.toLocaleLowerCase());
   }
 }
-async function waitForPreviewDownloadControl(page, preview, timeoutMs) {
-  const deadline = Date.now() + Math.min(timeoutMs, 15e3);
+async function waitForPreviewDownloadControl(page, previews, timeoutMs) {
+  const deadline = Date.now() + Math.min(timeoutMs, 6e4);
   while (Date.now() < deadline) {
-    for (const label of localeLabels.download) {
-      const control = preview.getByRole?.("button", { name: label, exact: true }) ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
-      if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2e3), "artifact_preview_download_count_timeout") === 1) {
-        return control;
+    for (const preview of previews) {
+      for (const label of localeLabels.download) {
+        const control = preview.getByRole?.("button", { name: label, exact: true }) ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
+        if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2e3), "artifact_preview_download_count_timeout") === 1) {
+          return control;
+        }
       }
     }
     if (typeof page.waitForTimeout === "function") {

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-live-smoke.bundle.mjs
@@ -11638,15 +11638,13 @@ async function tryGeneratedFilePreviewDownload(page, args) {
     }
     await affordance.click({ timeoutMs: localGuardTimeout(timeoutMs, 1e4) });
     const labelledPreview = requiredLocator(page, `section[aria-label="${escapeCssAttribute(selected.filename)}"]`);
-    const labelledPreviewCount = typeof labelledPreview.count === "function" ? await locatorCountWithTimeout(
-      labelledPreview,
-      localGuardTimeout(timeoutMs, 2e3),
-      "generated_file_labelled_preview_count_timeout"
-    ) : void 0;
     const workbookPreviews = requiredLocator(page, "section[data-testid^='popcorn-']");
     const workbookPreview = workbookPreviews.filter?.({ hasText: selected.filename }) ?? workbookPreviews;
-    const preview = labelledPreviewCount === 0 ? workbookPreview : labelledPreview;
-    const download = await waitForPreviewDownloadControl(page, preview, timeoutMs);
+    const download = await waitForPreviewDownloadControl(
+      page,
+      [labelledPreview, workbookPreview],
+      timeoutMs
+    );
     if (download === void 0) {
       throw new Error(`The artifact preview for ${selected.filename} did not expose a visible Download control.`);
     }
@@ -11765,13 +11763,15 @@ function filenameMatches(filename, pattern) {
     return filename.toLocaleLowerCase().includes(pattern.toLocaleLowerCase());
   }
 }
-async function waitForPreviewDownloadControl(page, preview, timeoutMs) {
-  const deadline = Date.now() + Math.min(timeoutMs, 15e3);
+async function waitForPreviewDownloadControl(page, previews, timeoutMs) {
+  const deadline = Date.now() + Math.min(timeoutMs, 6e4);
   while (Date.now() < deadline) {
-    for (const label of localeLabels.download) {
-      const control = preview.getByRole?.("button", { name: label, exact: true }) ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
-      if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2e3), "artifact_preview_download_count_timeout") === 1) {
-        return control;
+    for (const preview of previews) {
+      for (const label of localeLabels.download) {
+        const control = preview.getByRole?.("button", { name: label, exact: true }) ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
+        if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2e3), "artifact_preview_download_count_timeout") === 1) {
+          return control;
+        }
       }
     }
     if (typeof page.waitForTimeout === "function") {
@@ -15661,7 +15661,7 @@ var requiredScenarios = [
         chatConfiguration,
         chatConfiguration.ok && chatConfiguration.data?.experience === "chat" && chatConfiguration.data.verified === true
       );
-      const chatDesired = activeSelection(chatConfiguration.data, ["intelligence", "model", "modelVersion"]);
+      const chatDesired = chatActiveSelection(chatConfiguration.data);
       requireLiveCommand(
         "configuration.inspect.chat.active",
         chatConfiguration,
@@ -16485,6 +16485,9 @@ function activeSelection(inspection, axes) {
     }
   }
   return selection;
+}
+function chatActiveSelection(inspection) {
+  return activeSelection(inspection, ["intelligence", "model", "modelVersion", "effort"]);
 }
 function hasAxes(inspection, axes) {
   return axes.every((axis) => inspection.availableAxes.includes(axis));

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-release-canary.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control-release-canary.bundle.mjs
@@ -11985,15 +11985,13 @@ async function tryGeneratedFilePreviewDownload(page, args) {
     }
     await affordance.click({ timeoutMs: localGuardTimeout(timeoutMs, 1e4) });
     const labelledPreview = requiredLocator(page, `section[aria-label="${escapeCssAttribute(selected.filename)}"]`);
-    const labelledPreviewCount = typeof labelledPreview.count === "function" ? await locatorCountWithTimeout(
-      labelledPreview,
-      localGuardTimeout(timeoutMs, 2e3),
-      "generated_file_labelled_preview_count_timeout"
-    ) : void 0;
     const workbookPreviews = requiredLocator(page, "section[data-testid^='popcorn-']");
     const workbookPreview = workbookPreviews.filter?.({ hasText: selected.filename }) ?? workbookPreviews;
-    const preview = labelledPreviewCount === 0 ? workbookPreview : labelledPreview;
-    const download = await waitForPreviewDownloadControl(page, preview, timeoutMs);
+    const download = await waitForPreviewDownloadControl(
+      page,
+      [labelledPreview, workbookPreview],
+      timeoutMs
+    );
     if (download === void 0) {
       throw new Error(`The artifact preview for ${selected.filename} did not expose a visible Download control.`);
     }
@@ -12112,13 +12110,15 @@ function filenameMatches(filename, pattern) {
     return filename.toLocaleLowerCase().includes(pattern.toLocaleLowerCase());
   }
 }
-async function waitForPreviewDownloadControl(page, preview, timeoutMs) {
-  const deadline = Date.now() + Math.min(timeoutMs, 15e3);
+async function waitForPreviewDownloadControl(page, previews, timeoutMs) {
+  const deadline = Date.now() + Math.min(timeoutMs, 6e4);
   while (Date.now() < deadline) {
-    for (const label of localeLabels.download) {
-      const control = preview.getByRole?.("button", { name: label, exact: true }) ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
-      if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2e3), "artifact_preview_download_count_timeout") === 1) {
-        return control;
+    for (const preview of previews) {
+      for (const label of localeLabels.download) {
+        const control = preview.getByRole?.("button", { name: label, exact: true }) ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
+        if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2e3), "artifact_preview_download_count_timeout") === 1) {
+          return control;
+        }
       }
     }
     if (typeof page.waitForTimeout === "function") {
@@ -16008,7 +16008,7 @@ var requiredScenarios = [
         chatConfiguration,
         chatConfiguration.ok && chatConfiguration.data?.experience === "chat" && chatConfiguration.data.verified === true
       );
-      const chatDesired = activeSelection(chatConfiguration.data, ["intelligence", "model", "modelVersion"]);
+      const chatDesired = chatActiveSelection(chatConfiguration.data);
       requireLiveCommand(
         "configuration.inspect.chat.active",
         chatConfiguration,
@@ -16832,6 +16832,9 @@ function activeSelection(inspection, axes) {
     }
   }
   return selection;
+}
+function chatActiveSelection(inspection) {
+  return activeSelection(inspection, ["intelligence", "model", "modelVersion", "effort"]);
 }
 function hasAxes(inspection, axes) {
   return axes.every((axis) => inspection.availableAxes.includes(axis));

--- a/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
+++ b/plugins/codex-chatgpt-control/runtime/node/codex-chatgpt-control.bundle.mjs
@@ -11619,15 +11619,13 @@ async function tryGeneratedFilePreviewDownload(page, args) {
     }
     await affordance.click({ timeoutMs: localGuardTimeout(timeoutMs, 1e4) });
     const labelledPreview = requiredLocator(page, `section[aria-label="${escapeCssAttribute(selected.filename)}"]`);
-    const labelledPreviewCount = typeof labelledPreview.count === "function" ? await locatorCountWithTimeout(
-      labelledPreview,
-      localGuardTimeout(timeoutMs, 2e3),
-      "generated_file_labelled_preview_count_timeout"
-    ) : void 0;
     const workbookPreviews = requiredLocator(page, "section[data-testid^='popcorn-']");
     const workbookPreview = workbookPreviews.filter?.({ hasText: selected.filename }) ?? workbookPreviews;
-    const preview = labelledPreviewCount === 0 ? workbookPreview : labelledPreview;
-    const download = await waitForPreviewDownloadControl(page, preview, timeoutMs);
+    const download = await waitForPreviewDownloadControl(
+      page,
+      [labelledPreview, workbookPreview],
+      timeoutMs
+    );
     if (download === void 0) {
       throw new Error(`The artifact preview for ${selected.filename} did not expose a visible Download control.`);
     }
@@ -11746,13 +11744,15 @@ function filenameMatches(filename, pattern) {
     return filename.toLocaleLowerCase().includes(pattern.toLocaleLowerCase());
   }
 }
-async function waitForPreviewDownloadControl(page, preview, timeoutMs) {
-  const deadline = Date.now() + Math.min(timeoutMs, 15e3);
+async function waitForPreviewDownloadControl(page, previews, timeoutMs) {
+  const deadline = Date.now() + Math.min(timeoutMs, 6e4);
   while (Date.now() < deadline) {
-    for (const label of localeLabels.download) {
-      const control = preview.getByRole?.("button", { name: label, exact: true }) ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
-      if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2e3), "artifact_preview_download_count_timeout") === 1) {
-        return control;
+    for (const preview of previews) {
+      for (const label of localeLabels.download) {
+        const control = preview.getByRole?.("button", { name: label, exact: true }) ?? preview.locator?.(`button[aria-label="${escapeCssAttribute(label)}"]`);
+        if (await locatorCountWithTimeout(control, localGuardTimeout(timeoutMs, 2e3), "artifact_preview_download_count_timeout") === 1) {
+          return control;
+        }
       }
     }
     if (typeof page.waitForTimeout === "function") {


### PR DESCRIPTION
## What changed

- treats a verified effort-only simplified Chat profile as valid release-canary configuration
- dynamically follows both filename-labelled and workbook artifact previews while the current ChatGPT UI mounts them
- keeps Download selection filename-scoped, exact, unique, and bounded
- adds deterministic regressions for delayed preview mounting and delayed Download readiness
- refreshes all plugin runtime bundles and changelog notes

## Root cause

The post-merge `0.5.1-alpha.2` release canary found two live UI mismatches before any tag or registry write. Its Chat scenario omitted the current simplified effort axis, and artifact download chose one fallback preview locator during the first two seconds instead of reconsidering the correctly labelled preview when it appeared.

## Validation

- 555 Node tests across 48 files
- TypeScript build, backend conformance, 55 fixtures, docs/parity checks, all bundles, and zero npm vulnerabilities
- live Chat/Work expansion plus configuration mutation/restore pass
- exact generated CSV download passed with the repaired runtime

The tag and trusted-publishing workflow remain withheld until this PR merges and the complete canary passes from public `main`.
