### PR TITLE
test: skip privileged symlink cases on Windows

### DIFF
--- a/packages/node/tests/unit/backend-runtime-identity.test.ts
+++ b/packages/node/tests/unit/backend-runtime-identity.test.ts
@@ -24,7 +24,28 @@ describe("packaged backend runtime identity", () => {
     });
   });
 
-  it.skipIf(process.platform === "win32")("discovers plugin metadata and refuses to hash a symlinked entry", async () => {
+  it("discovers plugin metadata for a regular entry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "backend-plugin-identity-"));
+    const runtime = join(root, "runtime", "node");
+    await mkdir(join(root, ".codex-plugin"), { recursive: true });
+    await mkdir(runtime, { recursive: true });
+    await writeFile(join(root, ".codex-plugin", "plugin.json"), JSON.stringify({
+      name: "codex-chatgpt-control",
+      version: "0.5.1-alpha.3"
+    }));
+    const entry = join(runtime, "backend.mjs");
+    const bytes = "export {};\n";
+    await writeFile(entry, bytes);
+
+    const identity = await detectPackagedBackendIdentity(pathToFileURL(entry));
+    expect(identity).toEqual({
+      packageName: "codex-chatgpt-control",
+      packageVersion: "0.5.1-alpha.3",
+      buildDigest: `sha256:${createHash("sha256").update(bytes).digest("hex")}`
+    });
+  });
+
+  it.skipIf(process.platform === "win32")("refuses to hash a symlinked entry", async () => {
     const root = await mkdtemp(join(tmpdir(), "backend-plugin-identity-"));
     const runtime = join(root, "runtime", "node");
     await mkdir(join(root, ".codex-plugin"), { recursive: true });

--- a/packages/node/tests/unit/backend-runtime-identity.test.ts
+++ b/packages/node/tests/unit/backend-runtime-identity.test.ts
@@ -24,7 +24,7 @@ describe("packaged backend runtime identity", () => {
     });
   });
 
-  it("discovers plugin metadata and refuses to hash a symlinked entry", async () => {
+  it.skipIf(process.platform === "win32")("discovers plugin metadata and refuses to hash a symlinked entry", async () => {
     const root = await mkdtemp(join(tmpdir(), "backend-plugin-identity-"));
     const runtime = join(root, "runtime", "node");
     await mkdir(join(root, ".codex-plugin"), { recursive: true });

--- a/packages/node/tests/unit/operations-production-chatgpt-artifacts.test.ts
+++ b/packages/node/tests/unit/operations-production-chatgpt-artifacts.test.ts
@@ -916,20 +916,9 @@ describe("production ChatGPT artifact source", () => {
     expect(await readdir(parent)).toEqual(["browser-owned-source.bin"]);
   });
 
-  it.each([
-    ["symlink", async (parent: string) => {
-      const target = join(parent, "real-source.bin");
-      const link = join(parent, "linked-source.bin");
-      await writeFile(target, PAYLOAD);
-      await symlink(target, link);
-      return { path: link, remaining: ["linked-source.bin", "real-source.bin"] };
-    }],
-    ["non-file", async (parent: string) => {
-      const directory = join(parent, "source-directory");
-      await mkdir(directory);
-      return { path: directory, remaining: ["source-directory"] };
-    }]
-  ])("fails closed for a %s path and still cleans the provider temp directory", async (_label, setup) => {
+  const assertInvalidPathCleanup = async (
+    setup: (parent: string) => Promise<{ path: string; remaining: string[] }>
+  ) => {
     const parent = await root("path-invalid");
     const configured = await setup(parent);
     const observed = facts();
@@ -938,6 +927,24 @@ describe("production ChatGPT artifact source", () => {
     const acquired = await provider.acquireDownload(request({ sourceIdentityDigest: artifactIdentityDigest(observed) }));
     await expect(provider.materializeDownload(acquired)).rejects.toThrow("source is unavailable");
     expect((await readdir(parent)).sort()).toEqual(configured.remaining.sort());
+  };
+
+  it.skipIf(process.platform === "win32")("fails closed for a symlink path and still cleans the provider temp directory", async () => {
+    await assertInvalidPathCleanup(async parent => {
+      const target = join(parent, "real-source.bin");
+      const link = join(parent, "linked-source.bin");
+      await writeFile(target, PAYLOAD);
+      await symlink(target, link);
+      return { path: link, remaining: ["linked-source.bin", "real-source.bin"] };
+    });
+  });
+
+  it("fails closed for a non-file path and still cleans the provider temp directory", async () => {
+    await assertInvalidPathCleanup(async parent => {
+      const directory = join(parent, "source-directory");
+      await mkdir(directory);
+      return { path: directory, remaining: ["source-directory"] };
+    });
   });
 
   it("snapshots options and request fields before caller mutation", async () => {


### PR DESCRIPTION
## Summary

Make the Node test suite deterministic on ordinary Windows hosts where creating file symlinks can fail with `EPERM` unless Developer Mode or elevation is enabled.

- Skip only the two symlink-creation cases on Windows.
- Keep the non-file artifact-path case running on Windows.
- Refactor the artifact test slightly so the symlink and non-file cases can have independent platform conditions.
- Production behavior is unchanged.

## Reproduction

On Windows without symlink privileges, current `main` fails while setting up these tests before the production assertions are reached:

- `backend-runtime-identity.test.ts` — `discovers plugin metadata and refuses to hash a symlinked entry`
- `operations-production-chatgpt-artifacts.test.ts` — symlink variant of `fails closed for a %s path and still cleans the provider temp directory`

The OS returns `EPERM` from `symlink(...)`.

## Verification

On Windows:

- targeted suites: **29 passed, 2 skipped, 0 failed**
- full Node Vitest suite: **1,585 passed, 2 skipped, 0 failed** across **92/92 files**
- `npm run build`: passed

The two skips are exactly the privilege-dependent symlink cases.