### PR TITLE
test: stabilize backend IPC timeout cases on Windows

### DIFF
--- a/packages/node/tests/unit/backend-client.test.ts
+++ b/packages/node/tests/unit/backend-client.test.ts
@@ -919,6 +919,11 @@ describe("ChatGPT backend client", () => {
         ok: true,
         result: { id: "req_fast" }
       });
+      await new Promise(resolve => setTimeout(resolve, 350));
+      await expect(transport.request(backendRequest("req_slow"))).resolves.toMatchObject({
+        ok: true,
+        result: { id: "req_slow" }
+      });
     } finally {
       await transport.close();
     }
@@ -940,7 +945,7 @@ describe("ChatGPT backend client", () => {
       await new Promise(resolve => setTimeout(resolve, 200));
       await expect(transport.request(backendRequest("req_after_recycle"))).resolves.toMatchObject({
         ok: true,
-        result: { id: "req_after_recycle" }
+        result: { id: "req_after_recycle", healthCount: 1 }
       });
     } finally {
       await transport.close();
@@ -1805,6 +1810,7 @@ let legacyProbeCount = 0;
 let healthCount = 0;
 let healthInFlight = 0;
 let maxHealthInFlight = 0;
+let delayedTimeoutResponseSent = false;
 let overflowCompleted = false;
 let pendingOverflowHealth;
 const seenRequestIds = [];
@@ -1887,7 +1893,10 @@ const health = request => {
     process.stderr.write("secret-stderr-payload");
     return setTimeout(() => process.exit(0), 5);
   }
-  if (mode === "timeout" && request.requestId === "req_slow") return setTimeout(() => ok(request, result), 250);
+  if (mode === "timeout" && request.requestId === "req_slow" && !delayedTimeoutResponseSent) {
+    delayedTimeoutResponseSent = true;
+    return setTimeout(() => ok(request, result), 250);
+  }
   if (mode === "cancel" && request.requestId === "req_cancel") return setTimeout(() => ok(request, result), 45);
   if (mode === "overflow" && request.requestId === "req_after_overflow" && !overflowCompleted) {
     pendingOverflowHealth = { request, result };

--- a/packages/node/tests/unit/backend-client.test.ts
+++ b/packages/node/tests/unit/backend-client.test.ts
@@ -907,8 +907,8 @@ describe("ChatGPT backend client", () => {
   it("tombstones timed-out ids, discards late output, and keeps the route healthy", async () => {
     const transport = new StdioBackendTransport({
       command: [process.execPath, "-e", childScript("timeout")],
-      timeoutMs: 15,
-      handshakeTimeoutMs: 500
+      timeoutMs: 100,
+      handshakeTimeoutMs: 1_000
     });
     try {
       await expect(transport.request(backendRequest("req_slow"))).rejects.toMatchObject({
@@ -927,9 +927,9 @@ describe("ChatGPT backend client", () => {
   it("recycles after an unresolved tombstone grace while healthy routes settle first", async () => {
     const transport = new StdioBackendTransport({
       command: [process.execPath, "-e", childScript("no-terminal")],
-      timeoutMs: 15,
-      handshakeTimeoutMs: 500,
-      lateOutputGraceMs: 25
+      timeoutMs: 100,
+      handshakeTimeoutMs: 1_000,
+      lateOutputGraceMs: 150
     });
     try {
       await expect(transport.request(backendRequest("req_stuck"))).rejects.toMatchObject({ code: "backend_timeout" });
@@ -937,7 +937,7 @@ describe("ChatGPT backend client", () => {
         ok: true,
         result: { id: "req_healthy" }
       });
-      await new Promise(resolve => setTimeout(resolve, 40));
+      await new Promise(resolve => setTimeout(resolve, 200));
       await expect(transport.request(backendRequest("req_after_recycle"))).resolves.toMatchObject({
         ok: true,
         result: { id: "req_after_recycle" }
@@ -1887,7 +1887,7 @@ const health = request => {
     process.stderr.write("secret-stderr-payload");
     return setTimeout(() => process.exit(0), 5);
   }
-  if (mode === "timeout" && request.requestId === "req_slow") return setTimeout(() => ok(request, result), 45);
+  if (mode === "timeout" && request.requestId === "req_slow") return setTimeout(() => ok(request, result), 250);
   if (mode === "cancel" && request.requestId === "req_cancel") return setTimeout(() => ok(request, result), 45);
   if (mode === "overflow" && request.requestId === "req_after_overflow" && !overflowCompleted) {
     pendingOverflowHealth = { request, result };


### PR DESCRIPTION
## Summary

Increase the timing separation in two backend stdio transport tests so they exercise timeout/tombstone behavior instead of ordinary Windows child-process scheduling latency.

- Raise the per-request timeout from 15 ms to 100 ms in the two affected cases.
- Raise handshake timeout to 1 s.
- Extend the deliberately late backend response to 250 ms so it still lands well after the timeout.
- Scale the tombstone grace and post-grace wait consistently.
- Production transport behavior is unchanged; this only changes test timing.

## Reproduction

On current `main` under Windows, these tests can fail even in isolation because healthy follow-up IPC requests exceed the 15 ms wall-clock budget:

- `tombstones timed-out ids, discards late output, and keeps the route healthy`
- `recycles after an unresolved tombstone grace while healthy routes settle first`

That makes the tests conflate the intended timeout behavior with normal Node child-process/stdout scheduling overhead.

## Verification

On Windows:

- `npx vitest run tests/unit/backend-client.test.ts`: **65/65 passed**
- `npm run build`: passed

A full Windows suite on this branch alone still encounters the separate symlink-privilege setup issue addressed independently in PR #39.