### PR TITLE
Fix registry propagation release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: npm run release:verify-published
+      - run: npm run release:verify-published -- --timeout-ms 900000
 
   github-release:
     name: publish GitHub prerelease

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -157,10 +157,13 @@ the package upload itself reproducible and tokenless.
    `macos-latest`.
 7. Let the workflow publish npm and PyPI independently. If one registry publish
    succeeds and the other fails, rerun only the failed job.
-8. The workflow must then clean-install the exact published npm and PyPI
-   versions, import both SDKs, exercise the installed Node backend from Python,
-   and only then create the GitHub prerelease. Re-run the same verification
-   locally if diagnosing propagation:
+8. The workflow then waits up to 15 minutes for the exact npm and PyPI
+   versions to become publicly installable, clean-installs them, imports both
+   SDKs, exercises the installed Node backend from Python, and only then
+   creates the GitHub prerelease. Its wait log records npm, PyPI JSON, and PyPI
+   Simple-index state independently. If it exhausts that window, re-run only
+   the registry-install verification job; do not re-publish immutable package
+   versions. Re-run the same verification locally if diagnosing propagation:
 
    ```bash
    npm run release:verify-published

--- a/scripts/tests/verify-release-install.test.mjs
+++ b/scripts/tests/verify-release-install.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_TIMEOUT_MS,
+  observeRegistryVersions,
+  parseArgs
+} from "../verify-release-install.mjs";
+
+const versions = {
+  nodeVersion: "0.5.1-alpha.4",
+  pythonVersion: "0.5.1a4"
+};
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    }
+  };
+}
+
+test("uses a fifteen-minute default registry propagation window", () => {
+  assert.equal(DEFAULT_TIMEOUT_MS, 900_000);
+  assert.deepEqual(parseArgs(["--registry"]), {
+    mode: "registry",
+    timeoutMs: 900_000
+  });
+});
+
+test("records PyPI observations when npm has not propagated", async () => {
+  const requestedUrls = [];
+  const observation = await observeRegistryVersions(versions, {
+    npmLookup() {
+      throw new Error("npm registry E404");
+    },
+    async fetchImpl(url) {
+      requestedUrls.push(url);
+      if (url.includes("/pypi/")) {
+        return jsonResponse(200, { info: { version: versions.pythonVersion } });
+      }
+      return jsonResponse(200, {
+        files: [{
+          filename: "codex_chatgpt_control-" + versions.pythonVersion + "-py3-none-any.whl"
+        }]
+      });
+    }
+  });
+
+  assert.equal(observation.ready, false);
+  assert.match(observation.status, /npm=unavailable/);
+  assert.match(observation.status, /npmError="npm registry E404"/);
+  assert.match(observation.status, /pypi=0\.5\.1a4/);
+  assert.match(observation.status, /pypiJsonStatus=200/);
+  assert.match(observation.status, /pypiSimple=true/);
+  assert.match(observation.status, /pypiSimpleStatus=200/);
+  assert.deepEqual(requestedUrls, [
+    "https://pypi.org/pypi/codex-chatgpt-control/0.5.1a4/json",
+    "https://pypi.org/simple/codex-chatgpt-control/"
+  ]);
+});
+
+test("requires matching npm and both PyPI registry views", async () => {
+  const observation = await observeRegistryVersions(versions, {
+    npmLookup: () => versions.nodeVersion,
+    async fetchImpl(url) {
+      if (url.includes("/pypi/")) {
+        return jsonResponse(200, { info: { version: versions.pythonVersion } });
+      }
+      return jsonResponse(200, {
+        files: [{
+          filename: "codex_chatgpt_control-" + versions.pythonVersion + "-py3-none-any.whl"
+        }]
+      });
+    }
+  });
+
+  assert.equal(observation.ready, true);
+  assert.doesNotMatch(observation.status, /Error=/);
+});

--- a/scripts/verify-release-install.mjs
+++ b/scripts/verify-release-install.mjs
@@ -19,9 +19,9 @@ const NPM_REGISTRY = "https://registry.npmjs.org";
 const PYPI_INDEX = "https://pypi.org/simple";
 const REQUEST_SCHEMA = "chatgpt.browser_control.backend_request.v1";
 const RESPONSE_SCHEMA = "chatgpt.browser_control.backend_response.v1";
-const DEFAULT_TIMEOUT_MS = 180_000;
+export const DEFAULT_TIMEOUT_MS = 900_000;
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const options = { mode: undefined, timeoutMs: DEFAULT_TIMEOUT_MS };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -71,51 +71,98 @@ async function metadata() {
   return { nodeVersion: node.version, pythonVersion };
 }
 
+function messageFor(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function capture(check) {
+  try {
+    return { ok: true, value: await check() };
+  } catch (error) {
+    return { ok: false, error: messageFor(error) };
+  }
+}
+
+function npmRegistryVersion(versions) {
+  const npm = npmInvocation([
+    "view",
+    NPM_PACKAGE + "@" + versions.nodeVersion,
+    "version",
+    "--json",
+    "--registry=" + NPM_REGISTRY
+  ]);
+  return JSON.parse(run(npm.program, npm.args, { capture: true }));
+}
+
+async function pypiJsonVersion(versions, fetchImpl) {
+  const response = await fetchImpl(
+    "https://pypi.org/pypi/" + PYPI_PACKAGE + "/" + versions.pythonVersion + "/json",
+    { headers: { "User-Agent": "codex-chatgpt-control-release-verifier" } }
+  );
+  const pypi = response.ok ? await response.json() : undefined;
+  return { status: response.status, version: pypi?.info?.version };
+}
+
+async function pypiSimpleVersion(versions, fetchImpl) {
+  const response = await fetchImpl(PYPI_INDEX + "/" + PYPI_PACKAGE + "/", {
+    headers: {
+      Accept: "application/vnd.pypi.simple.v1+json",
+      "User-Agent": "codex-chatgpt-control-release-verifier"
+    }
+  });
+  const simple = response.ok ? await response.json() : undefined;
+  const hasVersion = Array.isArray(simple?.files) && simple.files.some(file =>
+    typeof file?.filename === "string" && (
+      file.filename.includes("-" + versions.pythonVersion + "-") ||
+      file.filename.includes("-" + versions.pythonVersion + ".")
+    )
+  );
+  return { hasVersion, status: response.status };
+}
+
+export async function observeRegistryVersions(
+  versions,
+  { fetchImpl = fetch, npmLookup = npmRegistryVersion } = {}
+) {
+  const [npm, pypiJson, pypiSimple] = await Promise.all([
+    capture(() => npmLookup(versions)),
+    capture(() => pypiJsonVersion(versions, fetchImpl)),
+    capture(() => pypiSimpleVersion(versions, fetchImpl))
+  ]);
+  const npmVersion = npm.ok ? npm.value : undefined;
+  const pypiJsonValue = pypiJson.ok ? pypiJson.value : undefined;
+  const pypiSimpleValue = pypiSimple.ok ? pypiSimple.value : undefined;
+  const status = [
+    "npm=" + String(npmVersion ?? "unavailable"),
+    "pypi=" + String(pypiJsonValue?.version ?? "unavailable"),
+    "pypiJsonStatus=" + String(pypiJsonValue?.status ?? "unavailable"),
+    "pypiSimple=" + String(pypiSimpleValue?.hasVersion ?? "unavailable"),
+    "pypiSimpleStatus=" + String(pypiSimpleValue?.status ?? "unavailable"),
+    ...(npm.ok ? [] : ["npmError=" + JSON.stringify(npm.error)]),
+    ...(pypiJson.ok ? [] : ["pypiJsonError=" + JSON.stringify(pypiJson.error)]),
+    ...(pypiSimple.ok ? [] : ["pypiSimpleError=" + JSON.stringify(pypiSimple.error)])
+  ].join(" ");
+  return {
+    ready: npmVersion === versions.nodeVersion &&
+      pypiJsonValue?.version === versions.pythonVersion &&
+      pypiSimpleValue?.hasVersion === true,
+    status
+  };
+}
+
 async function waitForRegistryVersions(versions, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   let last = "registry metadata not checked";
   while (Date.now() <= deadline) {
-    try {
-      const npm = npmInvocation([
-        "view",
-        `${NPM_PACKAGE}@${versions.nodeVersion}`,
-        "version",
-        "--json",
-        `--registry=${NPM_REGISTRY}`
-      ]);
-      const npmVersion = JSON.parse(run(npm.program, npm.args, { capture: true }));
-      const response = await fetch(`https://pypi.org/pypi/${PYPI_PACKAGE}/${versions.pythonVersion}/json`, {
-        headers: { "User-Agent": "codex-chatgpt-control-release-verifier" }
-      });
-      const pypi = response.ok ? await response.json() : undefined;
-      const pypiVersion = pypi?.info?.version;
-      const simpleResponse = await fetch(`${PYPI_INDEX}/${PYPI_PACKAGE}/`, {
-        headers: {
-          Accept: "application/vnd.pypi.simple.v1+json",
-          "User-Agent": "codex-chatgpt-control-release-verifier"
-        }
-      });
-      const simple = simpleResponse.ok ? await simpleResponse.json() : undefined;
-      const simpleHasVersion = Array.isArray(simple?.files) && simple.files.some(file =>
-        typeof file?.filename === "string" && (
-          file.filename.includes(`-${versions.pythonVersion}-`) ||
-          file.filename.includes(`-${versions.pythonVersion}.`)
-        )
-      );
-      if (npmVersion === versions.nodeVersion && pypiVersion === versions.pythonVersion && simpleHasVersion) return;
-      last = [
-        `npm=${String(npmVersion)}`,
-        `pypi=${String(pypiVersion)}`,
-        `pypiJsonStatus=${response.status}`,
-        `pypiSimple=${String(simpleHasVersion)}`,
-        `pypiSimpleStatus=${simpleResponse.status}`
-      ].join(" ");
-    } catch (error) {
-      last = error instanceof Error ? error.message : String(error);
+    const observation = await observeRegistryVersions(versions);
+    if (observation.ready) return;
+    if (observation.status !== last) {
+      console.log("Waiting for published registry versions: " + observation.status);
     }
+    last = observation.status;
     await new Promise(resolveDelay => setTimeout(resolveDelay, 5_000));
   }
-  throw new Error(`Timed out waiting for published registry versions: ${last}`);
+  throw new Error("Timed out waiting for published registry versions: " + last);
 }
 
 async function sourceSpecs(root) {
@@ -274,7 +321,9 @@ async function main() {
   }
 }
 
-main().catch(error => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(error => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- wait up to 15 minutes for public npm/PyPI propagation before registry-install verification fails
- preserve independent npm, PyPI JSON, and PyPI Simple-index observations in the wait log
- add regression coverage and document verification-only retry behavior

Generated from private main merge c3e6369.

## Validation
- npm run node:test (1,870 package tests plus 7 root script tests)
- npm run node:build
- npm run node:contracts
- npm run python:test (349 tests)
- npm run python:compile
- npm run python:pyright
- npm run python:ordinary-shell
- npm run plugin:validate && npm run node:bundle && npm run plugin:check
- npm run release:check-node-pack
- npm run release:smoke-source
- npm run release:verify-published -- --timeout-ms 60000
- node tools/public-export/export-public.mjs --check